### PR TITLE
fix: Support building on Apple Silicon / Arm64 platforms

### DIFF
--- a/src/providers/docker-images/lambda/Dockerfile
+++ b/src/providers/docker-images/lambda/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/nodejs:14
+FROM public.ecr.aws/lambda/nodejs:14-x86_64
 
 WORKDIR /runner
 


### PR DESCRIPTION
This fixes busted deployments from M1 Macs. This was an exciting ten minutes to hunt down!