### PR TITLE
fix: Overlong agentName error from GitHub

### DIFF
--- a/src/lambdas/delete-runner/index.ts
+++ b/src/lambdas/delete-runner/index.ts
@@ -34,13 +34,13 @@ exports.handler = async function (event: any) {
   });
 
   // find runner id
-  const runnerId = await getRunnerId(octokit, event.owner, event.repo, event.runnerName);
+  const runnerId = await getRunnerId(octokit, event.owner, event.repo, event.runnerName.slice(0, 63));
   if (!runnerId) {
-    console.error(`Unable to find runner id for ${event.owner}/${event.repo}:${event.runnerName}`);
+    console.error(`Unable to find runner id for ${event.owner}/${event.repo}:${event.runnerName.slice(0, 63)}`);
     return;
   }
 
-  console.log(`Runner ${event.runnerName} has id #${runnerId}`);
+  console.log(`Runner ${event.runnerName.slice(0, 63)} has id #${runnerId}`);
 
   // delete runner (it usually gets deleted by ./run.sh, but it stopped prematurely if we're here)
   await octokit.request('DELETE /repos/{owner}/{repo}/actions/runners/{runnerId}', {

--- a/src/providers/docker-images/lambda/Dockerfile
+++ b/src/providers/docker-images/lambda/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/nodejs:14
+FROM public.ecr.aws/lambda/nodejs:14-x86_64
 
 WORKDIR /runner
 

--- a/src/providers/docker-images/lambda/runner.js
+++ b/src/providers/docker-images/lambda/runner.js
@@ -8,7 +8,7 @@ exports.handler = async (event, context) => {
         REPO: event.repo,
         GITHUB_DOMAIN: event.githubDomain,
         RUNNER_TOKEN: event.token,
-        RUNNER_NAME: event.runnerName,
+        RUNNER_NAME: event.runnerName.slice(0, 63),
         RUNNER_LABEL: event.label,
       },
     });


### PR DESCRIPTION
Ran into an issue where my org name + project name were 66 characters; GitHub errors if it's more than 64. This truncates that edge case at the cost of a couple bits of entropy from a UUID.