### PR TITLE
feat: Setup wizard for GitHub integration

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -13,6 +13,10 @@
       "type": "build"
     },
     {
+      "name": "@octokit/rest",
+      "type": "build"
+    },
+    {
       "name": "@types/jest",
       "type": "build"
     },

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -93,6 +93,9 @@
           "exec": "esbuild src/lambdas/delete-runner/index.ts --bundle --platform=node --target=node14 --external:aws-sdk --outfile=lib/lambdas/delete-runner/index.js"
         },
         {
+          "exec": "esbuild src/lambdas/setup/index.ts --bundle --platform=node --target=node14 --external:aws-sdk --outfile=lib/lambdas/setup/index.js"
+        },
+        {
           "exec": "esbuild src/lambdas/status/index.ts --bundle --platform=node --target=node14 --external:aws-sdk --outfile=lib/lambdas/status/index.js"
         },
         {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -17,6 +17,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
     'esbuild', // for faster NodejsFunction bundling
     '@octokit/core',
     '@octokit/auth-app',
+    '@octokit/rest',
     'aws-sdk',
     '@aws-sdk/types',
   ],

--- a/API.md
+++ b/API.md
@@ -924,6 +924,7 @@ Any object.
 | <code><a href="#@cloudsnorkel/cdk-github-runners.Secrets.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.Secrets.property.github">github</a></code> | <code>aws-cdk-lib.aws_secretsmanager.Secret</code> | Authentication secret for GitHub containing either app details or personal authentication token. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.Secrets.property.githubPrivateKey">githubPrivateKey</a></code> | <code>aws-cdk-lib.aws_secretsmanager.Secret</code> | GitHub app private key. Not needed when using personal authentication tokens. |
+| <code><a href="#@cloudsnorkel/cdk-github-runners.Secrets.property.setup">setup</a></code> | <code>aws-cdk-lib.aws_secretsmanager.Secret</code> | Setup secret used to authenticate user for our setup wizard. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.Secrets.property.webhook">webhook</a></code> | <code>aws-cdk-lib.aws_secretsmanager.Secret</code> | Webhook secret used to confirm events are coming from GitHub and nowhere else. |
 
 ---
@@ -968,6 +969,20 @@ public readonly githubPrivateKey: Secret;
 GitHub app private key. Not needed when using personal authentication tokens.
 
 This secret is meant to be edited by the user after being created. It is separate than the main GitHub secret because inserting private keys into JSON is hard.
+
+---
+
+##### `setup`<sup>Required</sup> <a name="setup" id="@cloudsnorkel/cdk-github-runners.Secrets.property.setup"></a>
+
+```typescript
+public readonly setup: Secret;
+```
+
+- *Type:* aws-cdk-lib.aws_secretsmanager.Secret
+
+Setup secret used to authenticate user for our setup wizard.
+
+Should be empty after setup has been completed.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -10,22 +10,22 @@
 
 Use this CDK construct to create ephemeral [self-hosted GitHub runners][1] on-demand inside your AWS account.
 
-* Easy to configure GitHub integration
+* Easy to configure GitHub integration with a web-based interface
 * Customizable runners with decent defaults
-* Supports multiple runner configurations controlled by labels
+* Multiple runner configurations controlled by labels
 * Everything fully hosted in your account
 
 Self-hosted runners in AWS are useful when:
 
 * You need easy access to internal resources in your actions
 * You want to pre-install some software for your actions
-* You want to provide some basic AWS API access ([aws-actions/configure-aws-credentials][2] has more security controls)
+* You want to provide some basic AWS API access (but [aws-actions/configure-aws-credentials][2] has more security controls)
 
-Ephemeral runners are the [recommended way by GitHub][14] for auto-scaling, and they make sure all jobs run with a clean image. Runners are started on-demand. You don't pay unless a job is running.
+Ephemeral (or on-demand) runners are the [recommended way by GitHub][14] for auto-scaling, and they make sure all jobs run with a clean image. Runners are started on-demand. You don't pay unless a job is running.
 
 ## API
 
-Documentation of available constructs and their interface is available on [Constructs Hub][13] in all supported programming languages.
+The best way to browse API documentation is on [Constructs Hub][13]. It is available in all supported programming languages.
 
 ## Providers
 
@@ -72,7 +72,7 @@ You can also create your own provider by implementing `IRunnerProvider`.
 4. Deploy your stack
 5. Look for the status command output similar to `aws --region us-east-1 lambda invoke --function-name status-XYZ123 status.json`
 6. Execute the status command (you may need to specify `--profile` too) and open the resulting `status.json` file
-7. [Setup GitHub](SETUP_GITHUB.md) integration as an app or with personal access token
+7. Open the URL in `github.setup.url` from `status.json` or [manually setup GitHub](SETUP_GITHUB.md) integration as an app or with personal access token
 8. Run status command again to confirm `github.auth.status` and `github.webhook.status` are OK
 9. Trigger a GitHub action that has a `self-hosted` label with `runs-on: [self-hosted, linux, codebuild]` or similar
 10. If the action is not successful, see [troubleshooting](#Troubleshooting)

--- a/SETUP_GITHUB.md
+++ b/SETUP_GITHUB.md
@@ -1,8 +1,22 @@
 # Setup GitHub
 
-Integration with GitHub can be done using an [app](#app-authentication) or [personal access token](#personal-access-token). Using an app allows more fine-grained access control. Personal access tokens are easier to set up but belong to a user instead of an organization.
+Integration with GitHub can be done using an [app](#app-authentication) or [personal access token](#personal-access-token). Using an app allows more fine-grained access control. Using an app is easier with the setup wizard.
 
 ## App Authentication
+
+### Setup Wizard
+
+1. Open the URL in `github.setup.url` from `status.json`
+2. If you want to create an app for your personal repositories, click the Create button under New Personal App
+3. If you want to create an app for your organization:
+   1. Find the New Organization App section
+   2. Type in the organization name in organization slug (ORGANIZATION from https://github.com/ORGANIZATION/REPO)
+   3. Click the Create button
+4. Follow the instructions on GitHub
+5. When brought back to the setup wizard, click the install link
+6. Install the new app on your desired repositories
+
+### Manually
 
 1. Decide if you want to create a personal app or an organization app
     1. For a personal app use https://github.com/settings/apps/new
@@ -30,21 +44,44 @@ Integration with GitHub can be done using an [app](#app-authentication) or [pers
 
 ## Personal Access Token
 
-1. Create a new token
-    1. Go to https://github.com/settings/tokens/new
-    2. Choose your expiration date (you will need to replace the token if it expires)
-    3. Under scopes select `repo`
-    4. Copy the generated token
-2. Open the URL in `github.auth.secretUrl` from `status.json` and edit the secret value
-    1. If you're using a self-hosted GitHub instance, put its domain in `domain` (e.g. `github.mycompany.com`)
-    2. Put the generated token in `personalAuthToken`
-    3. Ignore all other values
-3. Create a webhook
-    1. For organizations go to https://github.com/organizations/MY_ORG/settings/hooks after replacing `MY_ORG` with your GitHub organization name
-    2. For enterprise go to https://github.com/enterprises/MY_ENTERPRISE/settings/hooks after replacing `MY_ENTERPRISE` with your GitHub enterprise name
-    3. Otherwise, you can create one per repository in your repository settings under Webhooks
-    4. Configure the webhook:
-        1. For Webhook URL use the value of `github.webhook.url` from `status.json`
-        2. Open the URL in `github.webhook.secretUrl` from `status.json`, retrieve the secret value, and use it for webhook secret
-        3. Make sure content type is set to JSON
-        4. Select individual jobs and select only Workflow jobs
+### Create Token
+
+1. Go to https://github.com/settings/tokens/new
+2. Choose your expiration date (you will need to replace the token if it expires)
+3. Under scopes select `repo`
+4. Copy the generated token
+
+### Set Token
+
+#### Setup Wizard
+
+1. Open the URL in `github.setup.url` from `status.json`
+2. Enter your personal access token under Using Personal Access Token
+3. Click the Set button
+
+#### Manually
+
+1. Open the URL in `github.auth.secretUrl` from `status.json` and edit the secret value
+2. If you're using a self-hosted GitHub instance, put its domain in `domain` (e.g. `github.mycompany.com`)
+3. Put the generated token in `personalAuthToken`
+4. Ignore all other values
+
+### Setup Webhook
+
+1. For organizations go to https://github.com/organizations/MY_ORG/settings/hooks after replacing `MY_ORG` with your GitHub organization name
+2. For enterprise go to https://github.com/enterprises/MY_ENTERPRISE/settings/hooks after replacing `MY_ENTERPRISE` with your GitHub enterprise name
+3. Otherwise, you can create one per repository in your repository settings under Webhooks
+4. Configure the webhook:
+    1. For Webhook URL use the value of `github.webhook.url` from `status.json`
+    2. Open the URL in `github.webhook.secretUrl` from `status.json`, retrieve the secret value, and use it for webhook secret
+    3. Make sure content type is set to JSON
+    4. Select individual jobs and select only Workflow jobs
+
+## Resetting Setup Wizard
+
+If the setup wizard tells you setup has already been completed or if `github.setup.status` is completed, or if `github.setup.url` is empty:
+
+1. Open the URL in `github.setup.secretUrl` from `status.json`
+2. Edit the secret
+3. Put a new random value in `token`
+4. Run status function again to get the new URL

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/types": "^3.78.0",
     "@octokit/auth-app": "^3.6.1",
     "@octokit/core": "^3.6.0",
+    "@octokit/rest": "^18.12.0",
     "@types/jest": "^27.5.2",
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",

--- a/src/lambdas/helpers.ts
+++ b/src/lambdas/helpers.ts
@@ -1,0 +1,30 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import * as AWS from 'aws-sdk';
+
+const sm = new AWS.SecretsManager();
+
+export async function getSecretValue(arn: string | undefined) {
+  if (!arn) {
+    throw new Error('Missing secret ARN');
+  }
+
+  const secret = await sm.getSecretValue({ SecretId: arn }).promise();
+
+  if (!secret.SecretString) {
+    throw new Error(`No SecretString in ${arn}`);
+  }
+
+  return secret.SecretString;
+}
+
+export async function getSecretJsonValue(arn: string | undefined) {
+  return JSON.parse(await getSecretValue(arn));
+}
+
+export async function updateSecretValue(arn: string | undefined, value: string) {
+  if (!arn) {
+    throw new Error('Missing secret ARN');
+  }
+
+  await sm.updateSecret({ SecretId: arn, SecretString: value }).promise();
+}

--- a/src/lambdas/setup/index.ts
+++ b/src/lambdas/setup/index.ts
@@ -14,19 +14,9 @@ function getHtml(manifest: string, token: string): string {
     <title>Setup GitHub Runners</title>
 <body>
 <h1>Setup GitHub Runners</h1>
+<p>You can choose between creating a new app that will provide authentication for specific repositories, or a personal access token that will provide access to all repositories available to you. Apps are easier to set up and provide more fine-grained access control.</p>
 <h2>Using App</h2>
-<form action="app" method="post">
-    <fieldset>
-        <legend>Existing App</legend>
-        <label for="pat">App Id:</label>
-        <input type="number" id="appid" name="appid"><br><br>
-        <label for="pk">Private key:</label>
-        <textarea id="pk" name="pk"></textarea><br><br>
-        <input type="submit" value="Set">
-    </fieldset>
-</form>
-
-<br>
+<p>Choose whether you want a personal app, an organization app, or an existing app created according to the instructions in <a href="https://github.com/CloudSnorkel/cdk-github-runners/blob/main/SETUP_GITHUB.md">SETUP_GITHUB.md</a>. The scope of the app should match the scope of the repositories you need to provide runners for.</p>
 <form action="https://github.com/settings/apps/new?state=${token}" method="post">
     <fieldset>
         <legend>New Personal App</legend>
@@ -46,17 +36,31 @@ function getHtml(manifest: string, token: string): string {
     </fieldset>
 </form>
 
+<br>
+<form action="app" method="post">
+    <fieldset>
+        <p>Existing apps must have <code>actions</code> and <code>administration</code> write permissions. Don't forget to set up the webhook and its secret as described in <a href="https://github.com/CloudSnorkel/cdk-github-runners/blob/main/SETUP_GITHUB.md">SETUP_GITHUB.md</a>.</p>
+        <legend>Existing App</legend>
+        <label for="pat">App Id:</label>
+        <input type="number" id="appid" name="appid"><br><br>
+        <label for="pk">Private key:</label>
+        <textarea id="pk" name="pk"></textarea><br><br>
+        <input type="submit" value="Set">
+    </fieldset>
+</form>
+
 <script>
- document.getElementById("manifest").value = JSON.stringify(${manifest});
- document.getElementById("manifestorg").value = JSON.stringify(${manifest});
+    document.getElementById("manifest").value = JSON.stringify(${manifest});
+    document.getElementById("manifestorg").value = JSON.stringify(${manifest});
 </script>
 
 <h2>Using Personal Access Token</h2>
+<p>The personal token must have the <code>repo</code> scope enable. Don't forget to also create a webhook as described in <a href="https://github.com/CloudSnorkel/cdk-github-runners/blob/main/SETUP_GITHUB.md">SETUP_GITHUB.md</a>.</p>
 <form action="pat?token=${token}" method="post">
     <fieldset>
-    <label for="pat">Token:</label>
-    <input type="password" id="pat" name="pat">
-    <input type="submit" value="Set">
+        <label for="pat">Token:</label>
+        <input type="password" id="pat" name="pat">
+        <input type="submit" value="Set">
     </fieldset>
 </form>
 </body>

--- a/src/lambdas/setup/index.ts
+++ b/src/lambdas/setup/index.ts
@@ -1,0 +1,225 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import * as crypto from 'crypto';
+import * as querystring from 'querystring';
+import { Octokit } from '@octokit/rest';
+import { getSecretJsonValue, updateSecretValue } from '../helpers';
+
+function getHtml(manifest: string, token: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <title>Setup GitHub Runners</title>
+<body>
+<h1>Setup GitHub Runners</h1>
+<h2>Using App</h2>
+<form action="app" method="post">
+    <fieldset>
+        <legend>Existing App</legend>
+        <label for="pat">App Id:</label>
+        <input type="number" id="appid" name="appid"><br><br>
+        <label for="pk">Private key:</label>
+        <textarea id="pk" name="pk"></textarea><br><br>
+        <input type="submit" value="Set">
+    </fieldset>
+</form>
+
+<br>
+<form action="https://github.com/settings/apps/new?state=${token}" method="post">
+    <fieldset>
+        <legend>New Personal App</legend>
+        <input type="hidden" name="manifest" id="manifest">
+        <input type="submit" value="Create">
+    </fieldset>
+</form>
+
+<br>
+<form action="https://github.com/organizations/ORGANIZATION/settings/apps/new?state=${token}" method="post">
+    <fieldset>
+        <legend>New Organization App</legend>
+        <label for="org">Organization slug:</label>
+        <input id="org" name="org" value="ORGANIZATION" onchange="this.form.action = \`https://github.com/organizations/\${this.value}/settings/apps/new?state=${token}\`"><br><br>
+        <input type="hidden" name="manifest" id="manifestorg">
+        <input type="submit" value="Create">
+    </fieldset>
+</form>
+
+<script>
+ document.getElementById("manifest").value = JSON.stringify(${manifest});
+ document.getElementById("manifestorg").value = JSON.stringify(${manifest});
+</script>
+
+<h2>Using Personal Access Token</h2>
+<form action="pat?token=${token}" method="post">
+    <fieldset>
+    <label for="pat">Token:</label>
+    <input type="password" id="pat" name="pat">
+    <input type="submit" value="Set">
+    </fieldset>
+</form>
+</body>
+</html>
+`;
+}
+
+function getManifest(baseUrl: string) {
+  return JSON.stringify({
+    url: 'https://github.com/CloudSnorkel/cdk-github-runners',
+    hook_attributes: {
+      url: process.env.WEBHOOK_URL,
+    },
+    redirect_url: `${baseUrl}/complete-new-app`,
+    public: false,
+    default_permissions: {
+      actions: 'write',
+      administration: 'write',
+    },
+    default_events: [
+      'workflow_job',
+    ],
+  });
+}
+
+async function handleRoot(event: any, setupToken: string) {
+  const setupBaseUrl = `https://${event.requestContext.domainName}`;
+
+  return {
+    statusCode: 200,
+    headers: {
+      'Content-Type': 'text/html',
+    },
+    body: getHtml(getManifest(setupBaseUrl), setupToken),
+  };
+}
+
+function decodeBody(event: any) {
+  let body = event.body;
+  if (event.isBase64Encoded) {
+    body = Buffer.from(body, 'base64').toString('utf-8');
+  }
+  return querystring.decode(body);
+}
+
+async function handlePat(event: any) {
+  const body = decodeBody(event);
+  if (!body.pat) {
+    return {
+      statusCode: 400,
+      headers: {
+        'Content-Type': 'text/html',
+      },
+      body: 'Invalid personal access token',
+    };
+  }
+
+  await updateSecretValue(process.env.GITHUB_SECRET_ARN, JSON.stringify({
+    domain: 'github.com',
+    appId: '',
+    personalAuthToken: body.pat,
+  }));
+  await updateSecretValue(process.env.SETUP_SECRET_ARN, JSON.stringify({ token: '' }));
+
+  return {
+    statusCode: 200,
+    headers: {
+      'Content-Type': 'text/html',
+    },
+    body: 'Personal access token set',
+  };
+}
+
+async function handleNewApp(event: any) {
+  const code = event.queryStringParameters.code;
+
+  if (!code) {
+    return {
+      statusCode: 400,
+      headers: {
+        'Content-Type': 'text/html',
+      },
+      body: 'Invalid code',
+    };
+  }
+
+  const newApp = await new Octokit().rest.apps.createFromManifest({ code });
+
+  await updateSecretValue(process.env.GITHUB_SECRET_ARN, JSON.stringify({
+    domain: 'github.com',
+    appId: newApp.data.id,
+    personalAuthToken: '',
+  }));
+  await updateSecretValue(process.env.GITHUB_PRIVATE_KEY_SECRET_ARN, newApp.data.pem);
+  await updateSecretValue(process.env.WEBHOOK_SECRET_ARN, JSON.stringify({
+    webhookSecret: newApp.data.webhook_secret,
+  }));
+  await updateSecretValue(process.env.SETUP_SECRET_ARN, JSON.stringify({ token: '' }));
+
+  return {
+    statusCode: 200,
+    headers: {
+      'Content-Type': 'text/html',
+    },
+    body: `New app set. <a href="${newApp.data.html_url}/installations/new">Install it</a> for your repositories.`,
+  };
+}
+
+exports.handler = async function (event: any) {
+  // confirm required environment variables
+  if (!process.env.WEBHOOK_URL) {
+    throw new Error('Missing environment variables');
+  }
+
+  const setupToken = (await getSecretJsonValue(process.env.SETUP_SECRET_ARN)).token;
+
+  // bail out if setup was already completed
+  if (!setupToken) {
+    return {
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'text/html',
+      },
+      body: 'Setup already complete. Put a new token in the setup secret if you want to redo it.',
+    };
+  }
+
+  if (!event.queryStringParameters) {
+    return {
+      statusCode: 403,
+      headers: {
+        'Content-Type': 'text/html',
+      },
+      body: 'Wrong setup token.',
+    };
+  }
+
+  // safely confirm url token matches our secret
+  const urlToken = event.queryStringParameters.token || event.queryStringParameters.state;
+  if (urlToken.length != setupToken.length || !crypto.timingSafeEqual(Buffer.from(urlToken, 'utf-8'), Buffer.from(setupToken, 'utf-8'))) {
+    return {
+      statusCode: 403,
+      headers: {
+        'Content-Type': 'text/html',
+      },
+      body: 'Wrong setup token.',
+    };
+  }
+
+  // handle requests
+  if (event.requestContext.http.path == '/') {
+    return handleRoot(event, setupToken);
+  } else if (event.requestContext.http.path == '/pat' && event.requestContext.http.method == 'POST') {
+    return handlePat(event);
+  } else if (event.requestContext.http.path == '/complete-new-app' && event.requestContext.http.method == 'GET') {
+    return handleNewApp(event);
+  } else {
+    return {
+      statusCode: 404,
+      headers: {
+        'Content-Type': 'text/html',
+      },
+      body: 'Not found',
+    };
+  }
+};

--- a/src/lambdas/webhook-handler/index.ts
+++ b/src/lambdas/webhook-handler/index.ts
@@ -1,9 +1,9 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import * as crypto from 'crypto';
 import * as AWS from 'aws-sdk';
+import { getSecretJsonValue } from '../helpers';
 
 const sf = new AWS.StepFunctions();
-const sm = new AWS.SecretsManager();
 
 // TODO use @octokit/webhooks?
 
@@ -35,15 +35,7 @@ exports.handler = async function (event: any) {
     throw new Error('Missing environment variables');
   }
 
-  const secret = await sm.getSecretValue({
-    SecretId: process.env.WEBHOOK_SECRET_ARN,
-  }).promise();
-
-  if (!secret.SecretString) {
-    throw new Error(`No SecretString in ${process.env.WEBHOOK_SECRET_ARN}`);
-  }
-
-  const webhookSecret = JSON.parse(secret.SecretString).webhookSecret;
+  const webhookSecret = (await getSecretJsonValue(process.env.WEBHOOK_SECRET_ARN)).webhookSecret;
 
   let body;
   try {

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -26,6 +26,11 @@ export class Secrets extends Construct {
    */
   readonly githubPrivateKey: secretsmanager.Secret;
 
+  /**
+   * Setup secret used to authenticate user for our setup wizard. Should be empty after setup has been completed.
+   */
+  readonly setup: secretsmanager.Secret;
+
   constructor(scope: Construct, id: string) {
     super(scope, id);
 
@@ -65,6 +70,21 @@ export class Secrets extends Construct {
       'GitHub Private Key',
       {
         secretStringValue: cdk.SecretValue.unsafePlainText('-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----'),
+      },
+    );
+
+    this.setup = new secretsmanager.Secret(
+      this,
+      'Setup',
+      {
+        generateSecretString: {
+          secretStringTemplate: JSON.stringify({
+            token: '',
+          }),
+          generateStringKey: 'token',
+          includeSpace: false,
+          excludePunctuation: true,
+        },
       },
     );
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -734,7 +734,7 @@
   dependencies:
     "@octokit/types" "^6.0.3"
 
-"@octokit/core@^3.6.0":
+"@octokit/core@^3.5.1", "@octokit/core@^3.6.0":
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.6.0.tgz#3376cb9f3008d9b3d110370d90e0a1fcd5fe6085"
   integrity sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==
@@ -786,6 +786,26 @@
   resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-11.2.0.tgz#b38d7fc3736d52a1e96b230c1ccd4a58a2f400a6"
   integrity sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA==
 
+"@octokit/plugin-paginate-rest@^2.16.8":
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz#32e9c7cab2a374421d3d0de239102287d791bce7"
+  integrity sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==
+  dependencies:
+    "@octokit/types" "^6.34.0"
+
+"@octokit/plugin-request-log@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz#5e50ed7083a613816b1e4a28aeec5fb7f1462e85"
+  integrity sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==
+
+"@octokit/plugin-rest-endpoint-methods@^5.12.0":
+  version "5.13.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz#8c46109021a3412233f6f50d28786f8e552427ba"
+  integrity sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==
+  dependencies:
+    "@octokit/types" "^6.34.0"
+    deprecation "^2.3.1"
+
 "@octokit/request-error@^2.0.5", "@octokit/request-error@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.1.0.tgz#9e150357831bfc788d13a4fd4b1913d60c74d677"
@@ -807,7 +827,17 @@
     node-fetch "^2.6.7"
     universal-user-agent "^6.0.0"
 
-"@octokit/types@^6.0.3", "@octokit/types@^6.10.0", "@octokit/types@^6.12.2", "@octokit/types@^6.16.1":
+"@octokit/rest@^18.12.0":
+  version "18.12.0"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.12.0.tgz#f06bc4952fc87130308d810ca9d00e79f6988881"
+  integrity sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==
+  dependencies:
+    "@octokit/core" "^3.5.1"
+    "@octokit/plugin-paginate-rest" "^2.16.8"
+    "@octokit/plugin-request-log" "^1.0.4"
+    "@octokit/plugin-rest-endpoint-methods" "^5.12.0"
+
+"@octokit/types@^6.0.3", "@octokit/types@^6.10.0", "@octokit/types@^6.12.2", "@octokit/types@^6.16.1", "@octokit/types@^6.34.0":
   version "6.34.0"
   resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.34.0.tgz#c6021333334d1ecfb5d370a8798162ddf1ae8218"
   integrity sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==


### PR DESCRIPTION
Provide an automated way to create GitHub app with manifests, or to set a personal token. This allows the user to easily install everything without manually editing secrets or copying around strings.

Closes #6