### PR TITLE
fix: All but first Lambda provider broke on rebuild interval

### DIFF
--- a/src/lambdas/update-lambda/index.ts
+++ b/src/lambdas/update-lambda/index.ts
@@ -12,7 +12,7 @@ interface Input {
 }
 
 export async function handler(event: Input) {
-  console.log(event);
+  console.log(JSON.stringify(event));
 
   const stacks = await cfn.describeStacks({
     StackName: event.stackName,

--- a/src/providers/lambda.ts
+++ b/src/providers/lambda.ts
@@ -236,10 +236,6 @@ export class LambdaRunner extends Construct implements IRunnerProvider {
       timeout: cdk.Duration.seconds(30),
       initialPolicy: [
         new iam.PolicyStatement({
-          actions: ['lambda:UpdateFunctionCode'],
-          resources: [this.function.functionArn],
-        }),
-        new iam.PolicyStatement({
           actions: ['cloudformation:DescribeStacks'],
           resources: [stack.formatArn({
             service: 'cloudformation',
@@ -249,6 +245,11 @@ export class LambdaRunner extends Construct implements IRunnerProvider {
         }),
       ],
     });
+
+    updater.addToRolePolicy(new iam.PolicyStatement({
+      actions: ['lambda:UpdateFunctionCode'],
+      resources: [this.function.functionArn],
+    }));
 
     let lambdaTarget = new events_targets.LambdaFunction(updater, {
       event: events.RuleTargetInput.fromObject({

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -105,15 +105,15 @@
         }
       }
     },
-    "69d02ba76fb89974a3d82ce4b3b404188be8c54589f2b9b359851ca87c5a2112": {
+    "35c99ca05f12b61868c715d657cd142b535de141a93e018fd30f8198753d147e": {
       "source": {
-        "path": "asset.69d02ba76fb89974a3d82ce4b3b404188be8c54589f2b9b359851ca87c5a2112",
+        "path": "asset.35c99ca05f12b61868c715d657cd142b535de141a93e018fd30f8198753d147e",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "69d02ba76fb89974a3d82ce4b3b404188be8c54589f2b9b359851ca87c5a2112.zip",
+          "objectKey": "35c99ca05f12b61868c715d657cd142b535de141a93e018fd30f8198753d147e.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -196,7 +196,7 @@
         }
       }
     },
-    "aa388e357f7475c7229425ec276f28481fb0da8ce1b50404789a8a0f0ff5379b": {
+    "1ba1bd4a09653bb58194a734bd256e8c4c9bc8f642ad138aa151baf3c584e6f4": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -204,7 +204,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "aa388e357f7475c7229425ec276f28481fb0da8ce1b50404789a8a0f0ff5379b.json",
+          "objectKey": "1ba1bd4a09653bb58194a734bd256e8c4c9bc8f642ad138aa151baf3c584e6f4.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -4763,16 +4763,6 @@
     "PolicyDocument": {
      "Statement": [
       {
-       "Action": "lambda:UpdateFunctionCode",
-       "Effect": "Allow",
-       "Resource": {
-        "Fn::GetAtt": [
-         "LambdaFunction9233991D",
-         "Arn"
-        ]
-       }
-      },
-      {
        "Action": "cloudformation:DescribeStacks",
        "Effect": "Allow",
        "Resource": {
@@ -4795,6 +4785,26 @@
          ]
         ]
        }
+      },
+      {
+       "Action": "lambda:UpdateFunctionCode",
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::GetAtt": [
+         "LambdaFunction9233991D",
+         "Arn"
+        ]
+       }
+      },
+      {
+       "Action": "lambda:UpdateFunctionCode",
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::GetAtt": [
+         "LambdaARMFunctionDD4B5FF7",
+         "Arn"
+        ]
+       }
       }
      ],
      "Version": "2012-10-17"
@@ -4814,7 +4824,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "69d02ba76fb89974a3d82ce4b3b404188be8c54589f2b9b359851ca87c5a2112.zip"
+     "S3Key": "35c99ca05f12b61868c715d657cd142b535de141a93e018fd30f8198753d147e.zip"
     },
     "Role": {
      "Fn::GetAtt": [

--- a/test/default.integ.snapshot/manifest.json
+++ b/test/default.integ.snapshot/manifest.json
@@ -23,7 +23,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/aa388e357f7475c7229425ec276f28481fb0da8ce1b50404789a8a0f0ff5379b.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/1ba1bd4a09653bb58194a734bd256e8c4c9bc8f642ad138aa151baf3c584e6f4.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/default.integ.snapshot/tree.json
+++ b/test/default.integ.snapshot/tree.json
@@ -6645,16 +6645,6 @@
                             "policyDocument": {
                               "Statement": [
                                 {
-                                  "Action": "lambda:UpdateFunctionCode",
-                                  "Effect": "Allow",
-                                  "Resource": {
-                                    "Fn::GetAtt": [
-                                      "LambdaFunction9233991D",
-                                      "Arn"
-                                    ]
-                                  }
-                                },
-                                {
                                   "Action": "cloudformation:DescribeStacks",
                                   "Effect": "Allow",
                                   "Resource": {
@@ -6675,6 +6665,26 @@
                                         },
                                         ":stack/github-runners-test/*"
                                       ]
+                                    ]
+                                  }
+                                },
+                                {
+                                  "Action": "lambda:UpdateFunctionCode",
+                                  "Effect": "Allow",
+                                  "Resource": {
+                                    "Fn::GetAtt": [
+                                      "LambdaFunction9233991D",
+                                      "Arn"
+                                    ]
+                                  }
+                                },
+                                {
+                                  "Action": "lambda:UpdateFunctionCode",
+                                  "Effect": "Allow",
+                                  "Resource": {
+                                    "Fn::GetAtt": [
+                                      "LambdaARMFunctionDD4B5FF7",
+                                      "Arn"
                                     ]
                                   }
                                 }
@@ -6742,7 +6752,7 @@
                       "s3Bucket": {
                         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                       },
-                      "s3Key": "69d02ba76fb89974a3d82ce4b3b404188be8c54589f2b9b359851ca87c5a2112.zip"
+                      "s3Key": "35c99ca05f12b61868c715d657cd142b535de141a93e018fd30f8198753d147e.zip"
                     },
                     "role": {
                       "Fn::GetAtt": [


### PR DESCRIPTION
The singleton Lambda only got permission to update the code for the first Lambda runner instead of all of them. This happened because we passed the inline policy to the singleton constructor which was only called once.