### PR TITLE
fix: Failure to update runner if image hasn't changed

### DIFF
--- a/API.md
+++ b/API.md
@@ -3162,7 +3162,6 @@ const runnerImage: RunnerImage = { ... }
 | <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerImage.property.imageRepository">imageRepository</a></code> | <code>aws-cdk-lib.aws_ecr.IRepository</code> | ECR repository containing the image. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerImage.property.imageTag">imageTag</a></code> | <code>string</code> | Static image tag where the image will be pushed. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerImage.property.os">os</a></code> | <code><a href="#@cloudsnorkel/cdk-github-runners.Os">Os</a></code> | OS type of the image. |
-| <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerImage.property.imageDigest">imageDigest</a></code> | <code>string</code> | Image digest for providers that need to know the digest like Lambda. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerImage.property.logGroup">logGroup</a></code> | <code>aws-cdk-lib.aws_logs.LogGroup</code> | Log group where image builds are logged. |
 
 ---
@@ -3212,22 +3211,6 @@ public readonly os: Os;
 - *Type:* <a href="#@cloudsnorkel/cdk-github-runners.Os">Os</a>
 
 OS type of the image.
-
----
-
-##### `imageDigest`<sup>Optional</sup> <a name="imageDigest" id="@cloudsnorkel/cdk-github-runners.RunnerImage.property.imageDigest"></a>
-
-```typescript
-public readonly imageDigest: string;
-```
-
-- *Type:* string
-
-Image digest for providers that need to know the digest like Lambda.
-
-If the digest is not specified, imageTag must always point to a new tag on update. If not, the build may try to use the old image.
-
-WARNING: the digest might change when the builder automatically rebuilds the image on a schedule. Do not expect for this digest to stay the same between deploys.
 
 ---
 

--- a/src/providers/common.ts
+++ b/src/providers/common.ts
@@ -100,15 +100,6 @@ export interface RunnerImage {
   readonly imageTag: string;
 
   /**
-   * Image digest for providers that need to know the digest like Lambda.
-   *
-   * If the digest is not specified, imageTag must always point to a new tag on update. If not, the build may try to use the old image.
-   *
-   * WARNING: the digest might change when the builder automatically rebuilds the image on a schedule. Do not expect for this digest to stay the same between deploys.
-   */
-  readonly imageDigest?: string;
-
-  /**
    * Architecture of the image.
    */
   readonly architecture: Architecture;

--- a/src/providers/image-builders/container.ts
+++ b/src/providers/image-builders/container.ts
@@ -669,7 +669,7 @@ export class ContainerImageBuilder extends Construct implements IImageBuilder {
         // we can't use image.attrName because it comes up with upper case
         cdk.Fn.split(':', cdk.Fn.split('/', image.attrImageUri, 2)[1], 2)[0],
       ),
-      imageTag: cdk.Fn.split(':', image.attrImageUri, 2)[1],
+      imageTag: 'latest',
       os: this.os,
       architecture: this.architecture,
       logGroup: log,

--- a/src/providers/lambda.ts
+++ b/src/providers/lambda.ts
@@ -301,10 +301,10 @@ export class LambdaRunner extends Construct implements IRunnerProvider {
           imageIds: [
             {
               imageTag: image.imageTag,
-            }
+            },
           ],
         },
-        physicalResourceId: cr.PhysicalResourceId.of(`ImageDigest`),
+        physicalResourceId: cr.PhysicalResourceId.of('ImageDigest'),
       },
       onUpdate: {
         service: 'ECR',
@@ -314,10 +314,10 @@ export class LambdaRunner extends Construct implements IRunnerProvider {
           imageIds: [
             {
               imageTag: image.imageTag,
-            }
+            },
           ],
         },
-        physicalResourceId: cr.PhysicalResourceId.of(`ImageDigest`),
+        physicalResourceId: cr.PhysicalResourceId.of('ImageDigest'),
       },
       onDelete: {
         // this will NOT be called thanks to RemovalPolicy.RETAIN below

--- a/src/providers/lambda.ts
+++ b/src/providers/lambda.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
 import * as cdk from 'aws-cdk-lib';
 import {
-  Annotations,
   aws_ec2 as ec2,
   aws_events as events,
   aws_events_targets as events_targets,
@@ -9,6 +8,7 @@ import {
   aws_lambda as lambda,
   aws_stepfunctions as stepfunctions,
   aws_stepfunctions_tasks as stepfunctions_tasks,
+  custom_resources as cr,
 } from 'aws-cdk-lib';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
@@ -164,16 +164,22 @@ export class LambdaRunner extends Construct implements IRunnerProvider {
       throw new Error(`Unable to find support Lambda architecture for ${image.os.name}/${image.architecture.name}`);
     }
 
-    let code;
-    if (image.imageDigest) {
-      code = lambda.DockerImageCode.fromEcr(image.imageRepository, { tagOrDigest: `sha256:${image.imageDigest}` });
-    } else {
-      if (image.imageTag == 'latest') {
-        Annotations.of(this).addWarning('imageTag is `latest` even though imageDigest is not specified! This means any updates to the image by the' +
-          'stack will be used.');
-      }
-      code = lambda.DockerImageCode.fromEcr(image.imageRepository, { tagOrDigest: image.imageTag });
-    }
+    // get image digest and make sure to get it every time the lambda function might be updated
+    // pass all variables that may change and cause a function update
+    // if we don't get the latest digest, the update may fail as a new image was already built outside the stack on a schedule
+    // we automatically delete old images, so we must always get the latest digest
+    const imageDigest = this.imageDigest(image, {
+      version: 1, // bump this for any non-user changes like description or defaults
+      label: this.label,
+      architecture: architecture.name,
+      vpc: this.vpc?.vpcId,
+      securityGroups: this.securityGroup?.securityGroupId,
+      vpcSubnets: props.subnetSelection?.subnets?.map(s => s.subnetId),
+      timeout: props.timeout?.toSeconds(),
+      memorySize: props.memorySize,
+      ephemeralStorageSize: props.ephemeralStorageSize?.toKibibytes(),
+      logRetention: props.logRetention?.toFixed(),
+    });
 
     this.function = new lambda.DockerImageFunction(
       this,
@@ -181,7 +187,7 @@ export class LambdaRunner extends Construct implements IRunnerProvider {
       {
         description: `GitHub Actions runner for "${this.label}" label`,
         // CDK requires "sha256:" literal prefix -- https://github.com/aws/aws-cdk/blob/ba91ca45ad759ab5db6da17a62333e2bc11e1075/packages/%40aws-cdk/aws-ecr/lib/repository.ts#L184
-        code,
+        code: lambda.DockerImageCode.fromEcr(image.imageRepository, { tagOrDigest: `sha256:${imageDigest}` }),
         architecture,
         vpc: this.vpc,
         securityGroups: this.securityGroup && [this.securityGroup],
@@ -281,5 +287,62 @@ export class LambdaRunner extends Construct implements IRunnerProvider {
 
     // the event never triggers without this - not sure why
     (rule.node.defaultChild as events.CfnRule).addDeletionOverride('Properties.EventPattern.resources');
+  }
+
+  private imageDigest(image: RunnerImage, variableSettings: any): string {
+    // describe ECR image to get its digest
+    // the physical id is random so the resource always runs and always gets the latest digest, even if a scheduled build replaced the stack image
+    const reader = new cr.AwsCustomResource(this, 'Image Digest Reader', {
+      onCreate: {
+        service: 'ECR',
+        action: 'describeImages',
+        parameters: {
+          repositoryName: image.imageRepository.repositoryName,
+          imageIds: [
+            {
+              imageTag: image.imageTag,
+            }
+          ],
+        },
+        physicalResourceId: cr.PhysicalResourceId.of(`ImageDigest`),
+      },
+      onUpdate: {
+        service: 'ECR',
+        action: 'describeImages',
+        parameters: {
+          repositoryName: image.imageRepository.repositoryName,
+          imageIds: [
+            {
+              imageTag: image.imageTag,
+            }
+          ],
+        },
+        physicalResourceId: cr.PhysicalResourceId.of(`ImageDigest`),
+      },
+      onDelete: {
+        // this will NOT be called thanks to RemovalPolicy.RETAIN below
+        // we only use this to force the custom resource to be called again and get a new digest
+        service: 'fake',
+        action: 'fake',
+        parameters: variableSettings,
+      },
+      policy: cr.AwsCustomResourcePolicy.fromSdkCalls({
+        resources: [image.imageRepository.repositoryArn],
+      }),
+      resourceType: 'Custom::EcrImageDigest',
+      installLatestAwsSdk: false, // no need and it takes 60 seconds
+      logRetention: RetentionDays.ONE_MONTH,
+    });
+
+    const res = reader.node.tryFindChild('Resource') as cdk.CustomResource | undefined;
+    if (res) {
+      // don't actually call the fake onDelete above
+      res.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN);
+    } else {
+      throw new Error('Resource not found in AwsCustomResource. Report this bug at https://github.com/CloudSnorkel/cdk-github-runners/issues.');
+    }
+
+    // return only the digest because CDK expects 'sha256:' literal above
+    return cdk.Fn.split(':', reader.getResponseField('imageDetails.0.imageDigest'), 2)[1];
   }
 }

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -105,6 +105,19 @@
         }
       }
     },
+    "864aa5eb2d6ca4e0d4d65c940bc9e4d5a29db1e4f3f3a098ddb56f76b2129ac4": {
+      "source": {
+        "path": "asset.864aa5eb2d6ca4e0d4d65c940bc9e4d5a29db1e4f3f3a098ddb56f76b2129ac4",
+        "packaging": "zip"
+      },
+      "destinations": {
+        "current_account-current_region": {
+          "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
+          "objectKey": "864aa5eb2d6ca4e0d4d65c940bc9e4d5a29db1e4f3f3a098ddb56f76b2129ac4.zip",
+          "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
+        }
+      }
+    },
     "35c99ca05f12b61868c715d657cd142b535de141a93e018fd30f8198753d147e": {
       "source": {
         "path": "asset.35c99ca05f12b61868c715d657cd142b535de141a93e018fd30f8198753d147e",
@@ -196,7 +209,7 @@
         }
       }
     },
-    "eec7ddf5ddef416beed0b559678e3fc361291c42a70d00a7942df957d8d5f6fb": {
+    "281fea18609a1af0cc35f88caf7c5208faeffc506b1c05c52d8c4ebcd9c00b72": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -204,7 +217,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "eec7ddf5ddef416beed0b559678e3fc361291c42a70d00a7942df957d8d5f6fb.json",
+          "objectKey": "281fea18609a1af0cc35f88caf7c5208faeffc506b1c05c52d8c4ebcd9c00b72.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -504,11 +504,15 @@
         {
          "Ref": "FargatebuilderRepository8F7BA13C"
         },
-        "\",\n      \"STACK_ID\": \"unspecified\",\n      \"REQUEST_ID\": \"unspecified\",\n      \"LOGICAL_RESOURCE_ID\": \"unspecified\",\n      \"RESPONSE_URL\": \"unspecified\",\n      \"RUNNER_VERSION\": \"latest\"\n    }\n  },\n  \"phases\": {\n    \"pre_build\": {\n      \"commands\": [\n        \"mkdir -p extra_certs\",\n        \"$(aws ecr get-login --no-include-email --region \\\"$AWS_DEFAULT_REGION\\\")\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"docker build . -t \\\"$REPO_URI\\\"  --build-arg RUNNER_VERSION=\\\"latest\\\"\",\n        \"docker push \\\"$REPO_URI\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"STATUS=\\\"SUCCESS\\\"\",\n        \"DIGEST=\\\"UNKNOWN\\\"\",\n        \"if [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ]; then STATUS=\\\"FAILED\\\"; else DIGEST=`docker inspect \\\"$REPO_URI\\\" | jq -r '.[0].RepoDigests[0] | split(\\\"@\\\")[1] | split(\\\":\\\")[1]'`; fi\",\n        \"cat <<EOF > /tmp/payload.json\\n{\\n  \\\"StackId\\\": \\\"$STACK_ID\\\",\\n  \\\"RequestId\\\": \\\"$REQUEST_ID\\\",\\n  \\\"LogicalResourceId\\\": \\\"$LOGICAL_RESOURCE_ID\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$REPO_ARN\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"See logs in ",
+        "\",\n      \"STACK_ID\": \"unspecified\",\n      \"REQUEST_ID\": \"unspecified\",\n      \"LOGICAL_RESOURCE_ID\": \"unspecified\",\n      \"RESPONSE_URL\": \"unspecified\",\n      \"RUNNER_VERSION\": \"latest\"\n    }\n  },\n  \"phases\": {\n    \"pre_build\": {\n      \"commands\": [\n        \"mkdir -p extra_certs\",\n        \"$(aws ecr get-login --no-include-email --region \\\"$AWS_DEFAULT_REGION\\\")\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"docker build . -t \\\"$REPO_URI\\\"  --build-arg RUNNER_VERSION=\\\"latest\\\"\",\n        \"docker push \\\"$REPO_URI\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"STATUS=\\\"SUCCESS\\\"\",\n        \"if [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ]; then STATUS=\\\"FAILED\\\"; fi\",\n        \"cat <<EOF > /tmp/payload.json\\n{\\n  \\\"StackId\\\": \\\"$STACK_ID\\\",\\n  \\\"RequestId\\\": \\\"$REQUEST_ID\\\",\\n  \\\"LogicalResourceId\\\": \\\"$LOGICAL_RESOURCE_ID\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$REPO_ARN\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"See logs in ",
         {
          "Ref": "FargatebuilderLogs2F794091"
         },
-        "/$CODEBUILD_LOG_PATH (deploy again with 'cdk deploy -R' or logRemovalPolicy=RemovalPolicy.RETAIN if they are already deleted)\\\",\\n  \\\"Data\\\": {\\\"Digest\\\": \\\"$DIGEST\\\"}\\n}\\nEOF\",\n        \"if [ \\\"$RESPONSE_URL\\\" != \\\"unspecified\\\" ]; then jq . /tmp/payload.json; curl -fsSL -X PUT -H \\\"Content-Type:\\\" -d \\\"@/tmp/payload.json\\\" \\\"$RESPONSE_URL\\\"; fi\"\n      ]\n    }\n  }\n}"
+        "/$CODEBUILD_LOG_PATH (deploy again with 'cdk deploy -R' or logRemovalPolicy=RemovalPolicy.RETAIN if they are already deleted)\\\",\\n  \\\"Data\\\": {\\\"Name\\\": \\\"",
+        {
+         "Ref": "FargatebuilderRepository8F7BA13C"
+        },
+        "\\\"}\\n}\\nEOF\",\n        \"if [ \\\"$RESPONSE_URL\\\" != \\\"unspecified\\\" ]; then jq . /tmp/payload.json; curl -fsSL -X PUT -H \\\"Content-Type:\\\" -d \\\"@/tmp/payload.json\\\" \\\"$RESPONSE_URL\\\"; fi\"\n      ]\n    }\n  }\n}"
        ]
       ]
      },
@@ -638,7 +642,7 @@
     "ProjectName": {
      "Ref": "FargatebuilderCodeBuild4F182743"
     },
-    "BuildHash": "cc3d04f6622c3d43e149767a42d3265f"
+    "BuildHash": "84e62f8c69563bae535b19891eb2d8d9"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
@@ -996,11 +1000,15 @@
         {
          "Ref": "FargatebuilderarmRepository77DCC132"
         },
-        "\",\n      \"STACK_ID\": \"unspecified\",\n      \"REQUEST_ID\": \"unspecified\",\n      \"LOGICAL_RESOURCE_ID\": \"unspecified\",\n      \"RESPONSE_URL\": \"unspecified\",\n      \"RUNNER_VERSION\": \"latest\"\n    }\n  },\n  \"phases\": {\n    \"pre_build\": {\n      \"commands\": [\n        \"mkdir -p extra_certs\",\n        \"$(aws ecr get-login --no-include-email --region \\\"$AWS_DEFAULT_REGION\\\")\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"docker build . -t \\\"$REPO_URI\\\"  --build-arg RUNNER_VERSION=\\\"latest\\\"\",\n        \"docker push \\\"$REPO_URI\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"STATUS=\\\"SUCCESS\\\"\",\n        \"DIGEST=\\\"UNKNOWN\\\"\",\n        \"if [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ]; then STATUS=\\\"FAILED\\\"; else DIGEST=`docker inspect \\\"$REPO_URI\\\" | jq -r '.[0].RepoDigests[0] | split(\\\"@\\\")[1] | split(\\\":\\\")[1]'`; fi\",\n        \"cat <<EOF > /tmp/payload.json\\n{\\n  \\\"StackId\\\": \\\"$STACK_ID\\\",\\n  \\\"RequestId\\\": \\\"$REQUEST_ID\\\",\\n  \\\"LogicalResourceId\\\": \\\"$LOGICAL_RESOURCE_ID\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$REPO_ARN\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"See logs in ",
+        "\",\n      \"STACK_ID\": \"unspecified\",\n      \"REQUEST_ID\": \"unspecified\",\n      \"LOGICAL_RESOURCE_ID\": \"unspecified\",\n      \"RESPONSE_URL\": \"unspecified\",\n      \"RUNNER_VERSION\": \"latest\"\n    }\n  },\n  \"phases\": {\n    \"pre_build\": {\n      \"commands\": [\n        \"mkdir -p extra_certs\",\n        \"$(aws ecr get-login --no-include-email --region \\\"$AWS_DEFAULT_REGION\\\")\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"docker build . -t \\\"$REPO_URI\\\"  --build-arg RUNNER_VERSION=\\\"latest\\\"\",\n        \"docker push \\\"$REPO_URI\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"STATUS=\\\"SUCCESS\\\"\",\n        \"if [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ]; then STATUS=\\\"FAILED\\\"; fi\",\n        \"cat <<EOF > /tmp/payload.json\\n{\\n  \\\"StackId\\\": \\\"$STACK_ID\\\",\\n  \\\"RequestId\\\": \\\"$REQUEST_ID\\\",\\n  \\\"LogicalResourceId\\\": \\\"$LOGICAL_RESOURCE_ID\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$REPO_ARN\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"See logs in ",
         {
          "Ref": "FargatebuilderarmLogs63D60F4D"
         },
-        "/$CODEBUILD_LOG_PATH (deploy again with 'cdk deploy -R' or logRemovalPolicy=RemovalPolicy.RETAIN if they are already deleted)\\\",\\n  \\\"Data\\\": {\\\"Digest\\\": \\\"$DIGEST\\\"}\\n}\\nEOF\",\n        \"if [ \\\"$RESPONSE_URL\\\" != \\\"unspecified\\\" ]; then jq . /tmp/payload.json; curl -fsSL -X PUT -H \\\"Content-Type:\\\" -d \\\"@/tmp/payload.json\\\" \\\"$RESPONSE_URL\\\"; fi\"\n      ]\n    }\n  }\n}"
+        "/$CODEBUILD_LOG_PATH (deploy again with 'cdk deploy -R' or logRemovalPolicy=RemovalPolicy.RETAIN if they are already deleted)\\\",\\n  \\\"Data\\\": {\\\"Name\\\": \\\"",
+        {
+         "Ref": "FargatebuilderarmRepository77DCC132"
+        },
+        "\\\"}\\n}\\nEOF\",\n        \"if [ \\\"$RESPONSE_URL\\\" != \\\"unspecified\\\" ]; then jq . /tmp/payload.json; curl -fsSL -X PUT -H \\\"Content-Type:\\\" -d \\\"@/tmp/payload.json\\\" \\\"$RESPONSE_URL\\\"; fi\"\n      ]\n    }\n  }\n}"
        ]
       ]
      },
@@ -1130,7 +1138,7 @@
     "ProjectName": {
      "Ref": "FargatebuilderarmCodeBuild0D30679A"
     },
-    "BuildHash": "7991c693107c4ccdce5ed3d7bfff9926"
+    "BuildHash": "2d3997ab554ef29cf77733b310a789cc"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
@@ -1488,11 +1496,15 @@
         {
          "Ref": "LambdaImageBuilderx64Repository57F632F1"
         },
-        "\",\n      \"STACK_ID\": \"unspecified\",\n      \"REQUEST_ID\": \"unspecified\",\n      \"LOGICAL_RESOURCE_ID\": \"unspecified\",\n      \"RESPONSE_URL\": \"unspecified\",\n      \"RUNNER_VERSION\": \"latest\"\n    }\n  },\n  \"phases\": {\n    \"pre_build\": {\n      \"commands\": [\n        \"mkdir -p extra_certs\",\n        \"$(aws ecr get-login --no-include-email --region \\\"$AWS_DEFAULT_REGION\\\")\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"docker build . -t \\\"$REPO_URI\\\"  --build-arg RUNNER_VERSION=\\\"latest\\\"\",\n        \"docker push \\\"$REPO_URI\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"STATUS=\\\"SUCCESS\\\"\",\n        \"DIGEST=\\\"UNKNOWN\\\"\",\n        \"if [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ]; then STATUS=\\\"FAILED\\\"; else DIGEST=`docker inspect \\\"$REPO_URI\\\" | jq -r '.[0].RepoDigests[0] | split(\\\"@\\\")[1] | split(\\\":\\\")[1]'`; fi\",\n        \"cat <<EOF > /tmp/payload.json\\n{\\n  \\\"StackId\\\": \\\"$STACK_ID\\\",\\n  \\\"RequestId\\\": \\\"$REQUEST_ID\\\",\\n  \\\"LogicalResourceId\\\": \\\"$LOGICAL_RESOURCE_ID\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$REPO_ARN\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"See logs in ",
+        "\",\n      \"STACK_ID\": \"unspecified\",\n      \"REQUEST_ID\": \"unspecified\",\n      \"LOGICAL_RESOURCE_ID\": \"unspecified\",\n      \"RESPONSE_URL\": \"unspecified\",\n      \"RUNNER_VERSION\": \"latest\"\n    }\n  },\n  \"phases\": {\n    \"pre_build\": {\n      \"commands\": [\n        \"mkdir -p extra_certs\",\n        \"$(aws ecr get-login --no-include-email --region \\\"$AWS_DEFAULT_REGION\\\")\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"docker build . -t \\\"$REPO_URI\\\"  --build-arg RUNNER_VERSION=\\\"latest\\\"\",\n        \"docker push \\\"$REPO_URI\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"STATUS=\\\"SUCCESS\\\"\",\n        \"if [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ]; then STATUS=\\\"FAILED\\\"; fi\",\n        \"cat <<EOF > /tmp/payload.json\\n{\\n  \\\"StackId\\\": \\\"$STACK_ID\\\",\\n  \\\"RequestId\\\": \\\"$REQUEST_ID\\\",\\n  \\\"LogicalResourceId\\\": \\\"$LOGICAL_RESOURCE_ID\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$REPO_ARN\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"See logs in ",
         {
          "Ref": "LambdaImageBuilderx64Logs1C003BB4"
         },
-        "/$CODEBUILD_LOG_PATH (deploy again with 'cdk deploy -R' or logRemovalPolicy=RemovalPolicy.RETAIN if they are already deleted)\\\",\\n  \\\"Data\\\": {\\\"Digest\\\": \\\"$DIGEST\\\"}\\n}\\nEOF\",\n        \"if [ \\\"$RESPONSE_URL\\\" != \\\"unspecified\\\" ]; then jq . /tmp/payload.json; curl -fsSL -X PUT -H \\\"Content-Type:\\\" -d \\\"@/tmp/payload.json\\\" \\\"$RESPONSE_URL\\\"; fi\"\n      ]\n    }\n  }\n}"
+        "/$CODEBUILD_LOG_PATH (deploy again with 'cdk deploy -R' or logRemovalPolicy=RemovalPolicy.RETAIN if they are already deleted)\\\",\\n  \\\"Data\\\": {\\\"Name\\\": \\\"",
+        {
+         "Ref": "LambdaImageBuilderx64Repository57F632F1"
+        },
+        "\\\"}\\n}\\nEOF\",\n        \"if [ \\\"$RESPONSE_URL\\\" != \\\"unspecified\\\" ]; then jq . /tmp/payload.json; curl -fsSL -X PUT -H \\\"Content-Type:\\\" -d \\\"@/tmp/payload.json\\\" \\\"$RESPONSE_URL\\\"; fi\"\n      ]\n    }\n  }\n}"
        ]
       ]
      },
@@ -1622,7 +1634,7 @@
     "ProjectName": {
      "Ref": "LambdaImageBuilderx64CodeBuild67DE14C8"
     },
-    "BuildHash": "4d9954fe17e392795c604a410bc67863"
+    "BuildHash": "0cf05ec9f06e2ff23e2f94489f897b9d"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
@@ -1687,7 +1699,10 @@
       ],
       "repository-name": [
        {
-        "Ref": "LambdaImageBuilderx64Repository57F632F1"
+        "Fn::GetAtt": [
+         "LambdaImageBuilderx64Builder42F384AF",
+         "Name"
+        ]
        }
       ],
       "image-tag": [
@@ -1753,7 +1768,10 @@
          },
          "/",
          {
-          "Ref": "LambdaImageBuilderx64Repository57F632F1"
+          "Fn::GetAtt": [
+           "LambdaImageBuilderx64Builder42F384AF",
+           "Name"
+          ]
          },
          "\",\"repositoryTag\":\"latest\",\"stackName\":\"github-runners-test\"}"
         ]
@@ -2847,11 +2865,15 @@
         {
          "Ref": "CodeBuildImageBuilderRepository9DE3B6F0"
         },
-        "\",\n      \"STACK_ID\": \"unspecified\",\n      \"REQUEST_ID\": \"unspecified\",\n      \"LOGICAL_RESOURCE_ID\": \"unspecified\",\n      \"RESPONSE_URL\": \"unspecified\",\n      \"RUNNER_VERSION\": \"latest\"\n    }\n  },\n  \"phases\": {\n    \"pre_build\": {\n      \"commands\": [\n        \"mkdir -p extra_certs\",\n        \"$(aws ecr get-login --no-include-email --region \\\"$AWS_DEFAULT_REGION\\\")\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"docker build . -t \\\"$REPO_URI\\\"  --build-arg RUNNER_VERSION=\\\"latest\\\"\",\n        \"docker push \\\"$REPO_URI\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"STATUS=\\\"SUCCESS\\\"\",\n        \"DIGEST=\\\"UNKNOWN\\\"\",\n        \"if [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ]; then STATUS=\\\"FAILED\\\"; else DIGEST=`docker inspect \\\"$REPO_URI\\\" | jq -r '.[0].RepoDigests[0] | split(\\\"@\\\")[1] | split(\\\":\\\")[1]'`; fi\",\n        \"cat <<EOF > /tmp/payload.json\\n{\\n  \\\"StackId\\\": \\\"$STACK_ID\\\",\\n  \\\"RequestId\\\": \\\"$REQUEST_ID\\\",\\n  \\\"LogicalResourceId\\\": \\\"$LOGICAL_RESOURCE_ID\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$REPO_ARN\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"See logs in ",
+        "\",\n      \"STACK_ID\": \"unspecified\",\n      \"REQUEST_ID\": \"unspecified\",\n      \"LOGICAL_RESOURCE_ID\": \"unspecified\",\n      \"RESPONSE_URL\": \"unspecified\",\n      \"RUNNER_VERSION\": \"latest\"\n    }\n  },\n  \"phases\": {\n    \"pre_build\": {\n      \"commands\": [\n        \"mkdir -p extra_certs\",\n        \"$(aws ecr get-login --no-include-email --region \\\"$AWS_DEFAULT_REGION\\\")\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"docker build . -t \\\"$REPO_URI\\\"  --build-arg RUNNER_VERSION=\\\"latest\\\"\",\n        \"docker push \\\"$REPO_URI\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"STATUS=\\\"SUCCESS\\\"\",\n        \"if [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ]; then STATUS=\\\"FAILED\\\"; fi\",\n        \"cat <<EOF > /tmp/payload.json\\n{\\n  \\\"StackId\\\": \\\"$STACK_ID\\\",\\n  \\\"RequestId\\\": \\\"$REQUEST_ID\\\",\\n  \\\"LogicalResourceId\\\": \\\"$LOGICAL_RESOURCE_ID\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$REPO_ARN\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"See logs in ",
         {
          "Ref": "CodeBuildImageBuilderLogsE4CADFCC"
         },
-        "/$CODEBUILD_LOG_PATH (deploy again with 'cdk deploy -R' or logRemovalPolicy=RemovalPolicy.RETAIN if they are already deleted)\\\",\\n  \\\"Data\\\": {\\\"Digest\\\": \\\"$DIGEST\\\"}\\n}\\nEOF\",\n        \"if [ \\\"$RESPONSE_URL\\\" != \\\"unspecified\\\" ]; then jq . /tmp/payload.json; curl -fsSL -X PUT -H \\\"Content-Type:\\\" -d \\\"@/tmp/payload.json\\\" \\\"$RESPONSE_URL\\\"; fi\"\n      ]\n    }\n  }\n}"
+        "/$CODEBUILD_LOG_PATH (deploy again with 'cdk deploy -R' or logRemovalPolicy=RemovalPolicy.RETAIN if they are already deleted)\\\",\\n  \\\"Data\\\": {\\\"Name\\\": \\\"",
+        {
+         "Ref": "CodeBuildImageBuilderRepository9DE3B6F0"
+        },
+        "\\\"}\\n}\\nEOF\",\n        \"if [ \\\"$RESPONSE_URL\\\" != \\\"unspecified\\\" ]; then jq . /tmp/payload.json; curl -fsSL -X PUT -H \\\"Content-Type:\\\" -d \\\"@/tmp/payload.json\\\" \\\"$RESPONSE_URL\\\"; fi\"\n      ]\n    }\n  }\n}"
        ]
       ]
      },
@@ -2981,7 +3003,7 @@
     "ProjectName": {
      "Ref": "CodeBuildImageBuilderCodeBuild38ECAA44"
     },
-    "BuildHash": "2fed9af5f8a6b0e9fefaeb54869d7149"
+    "BuildHash": "103b2f743625d7f99a8c0f8bcc701ed3"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
@@ -3238,7 +3260,10 @@
         },
         "/",
         {
-         "Ref": "CodeBuildImageBuilderRepository9DE3B6F0"
+         "Fn::GetAtt": [
+          "CodeBuildImageBuilderB8638EC8",
+          "Name"
+         ]
         },
         ":latest"
        ]
@@ -3664,11 +3689,15 @@
         {
          "Ref": "CodeBuildImageBuilderarmRepositoryE967421B"
         },
-        "\",\n      \"STACK_ID\": \"unspecified\",\n      \"REQUEST_ID\": \"unspecified\",\n      \"LOGICAL_RESOURCE_ID\": \"unspecified\",\n      \"RESPONSE_URL\": \"unspecified\",\n      \"RUNNER_VERSION\": \"latest\"\n    }\n  },\n  \"phases\": {\n    \"pre_build\": {\n      \"commands\": [\n        \"mkdir -p extra_certs\",\n        \"$(aws ecr get-login --no-include-email --region \\\"$AWS_DEFAULT_REGION\\\")\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"docker build . -t \\\"$REPO_URI\\\"  --build-arg RUNNER_VERSION=\\\"latest\\\"\",\n        \"docker push \\\"$REPO_URI\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"STATUS=\\\"SUCCESS\\\"\",\n        \"DIGEST=\\\"UNKNOWN\\\"\",\n        \"if [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ]; then STATUS=\\\"FAILED\\\"; else DIGEST=`docker inspect \\\"$REPO_URI\\\" | jq -r '.[0].RepoDigests[0] | split(\\\"@\\\")[1] | split(\\\":\\\")[1]'`; fi\",\n        \"cat <<EOF > /tmp/payload.json\\n{\\n  \\\"StackId\\\": \\\"$STACK_ID\\\",\\n  \\\"RequestId\\\": \\\"$REQUEST_ID\\\",\\n  \\\"LogicalResourceId\\\": \\\"$LOGICAL_RESOURCE_ID\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$REPO_ARN\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"See logs in ",
+        "\",\n      \"STACK_ID\": \"unspecified\",\n      \"REQUEST_ID\": \"unspecified\",\n      \"LOGICAL_RESOURCE_ID\": \"unspecified\",\n      \"RESPONSE_URL\": \"unspecified\",\n      \"RUNNER_VERSION\": \"latest\"\n    }\n  },\n  \"phases\": {\n    \"pre_build\": {\n      \"commands\": [\n        \"mkdir -p extra_certs\",\n        \"$(aws ecr get-login --no-include-email --region \\\"$AWS_DEFAULT_REGION\\\")\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"docker build . -t \\\"$REPO_URI\\\"  --build-arg RUNNER_VERSION=\\\"latest\\\"\",\n        \"docker push \\\"$REPO_URI\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"STATUS=\\\"SUCCESS\\\"\",\n        \"if [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ]; then STATUS=\\\"FAILED\\\"; fi\",\n        \"cat <<EOF > /tmp/payload.json\\n{\\n  \\\"StackId\\\": \\\"$STACK_ID\\\",\\n  \\\"RequestId\\\": \\\"$REQUEST_ID\\\",\\n  \\\"LogicalResourceId\\\": \\\"$LOGICAL_RESOURCE_ID\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$REPO_ARN\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"See logs in ",
         {
          "Ref": "CodeBuildImageBuilderarmLogs5A60CB81"
         },
-        "/$CODEBUILD_LOG_PATH (deploy again with 'cdk deploy -R' or logRemovalPolicy=RemovalPolicy.RETAIN if they are already deleted)\\\",\\n  \\\"Data\\\": {\\\"Digest\\\": \\\"$DIGEST\\\"}\\n}\\nEOF\",\n        \"if [ \\\"$RESPONSE_URL\\\" != \\\"unspecified\\\" ]; then jq . /tmp/payload.json; curl -fsSL -X PUT -H \\\"Content-Type:\\\" -d \\\"@/tmp/payload.json\\\" \\\"$RESPONSE_URL\\\"; fi\"\n      ]\n    }\n  }\n}"
+        "/$CODEBUILD_LOG_PATH (deploy again with 'cdk deploy -R' or logRemovalPolicy=RemovalPolicy.RETAIN if they are already deleted)\\\",\\n  \\\"Data\\\": {\\\"Name\\\": \\\"",
+        {
+         "Ref": "CodeBuildImageBuilderarmRepositoryE967421B"
+        },
+        "\\\"}\\n}\\nEOF\",\n        \"if [ \\\"$RESPONSE_URL\\\" != \\\"unspecified\\\" ]; then jq . /tmp/payload.json; curl -fsSL -X PUT -H \\\"Content-Type:\\\" -d \\\"@/tmp/payload.json\\\" \\\"$RESPONSE_URL\\\"; fi\"\n      ]\n    }\n  }\n}"
        ]
       ]
      },
@@ -3798,7 +3827,7 @@
     "ProjectName": {
      "Ref": "CodeBuildImageBuilderarmCodeBuildBFF1CF57"
     },
-    "BuildHash": "21182c8b3705b184ce0f9aeeba9fefd7"
+    "BuildHash": "f6900d4af688c7e21926ac8d97b0cdf7"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
@@ -4055,7 +4084,10 @@
         },
         "/",
         {
-         "Ref": "CodeBuildImageBuilderarmRepositoryE967421B"
+         "Fn::GetAtt": [
+          "CodeBuildImageBuilderarmBuilder755EB37D",
+          "Name"
+         ]
         },
         ":latest"
        ]
@@ -4345,23 +4377,7 @@
           }
          ]
         },
-        ":",
-        {
-         "Fn::Select": [
-          1,
-          {
-           "Fn::Split": [
-            ":",
-            {
-             "Fn::GetAtt": [
-              "WindowsImageBuilderImage7065BB07",
-              "ImageUri"
-             ]
-            }
-           ]
-          }
-         ]
-        }
+        ":latest"
        ]
       ]
      },
@@ -4394,6 +4410,84 @@
     },
     "TimeoutInMinutes": 60
    }
+  },
+  "LambdaImageDigestReaderCustomResourcePolicyE8E146E6": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": "ecr:DescribeImages",
+       "Effect": "Allow",
+       "Resource": {
+        "Ref": "LambdaImageBuilderx64Builder42F384AF"
+       }
+      },
+      {
+       "Action": "fake:Fake",
+       "Effect": "Allow",
+       "Resource": {
+        "Ref": "LambdaImageBuilderx64Builder42F384AF"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "LambdaImageDigestReaderCustomResourcePolicyE8E146E6",
+    "Roles": [
+     {
+      "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2"
+     }
+    ]
+   }
+  },
+  "LambdaImageDigestReaderE0842577": {
+   "Type": "Custom::EcrImageDigest",
+   "Properties": {
+    "ServiceToken": {
+     "Fn::GetAtt": [
+      "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
+      "Arn"
+     ]
+    },
+    "Create": {
+     "Fn::Join": [
+      "",
+      [
+       "{\"service\":\"ECR\",\"action\":\"describeImages\",\"parameters\":{\"repositoryName\":\"",
+       {
+        "Fn::GetAtt": [
+         "LambdaImageBuilderx64Builder42F384AF",
+         "Name"
+        ]
+       },
+       "\",\"imageIds\":[{\"imageTag\":\"latest\"}]},\"physicalResourceId\":{\"id\":\"ImageDigest\"}}"
+      ]
+     ]
+    },
+    "Update": {
+     "Fn::Join": [
+      "",
+      [
+       "{\"service\":\"ECR\",\"action\":\"describeImages\",\"parameters\":{\"repositoryName\":\"",
+       {
+        "Fn::GetAtt": [
+         "LambdaImageBuilderx64Builder42F384AF",
+         "Name"
+        ]
+       },
+       "\",\"imageIds\":[{\"imageTag\":\"latest\"}]},\"physicalResourceId\":{\"id\":\"ImageDigest\"}}"
+      ]
+     ]
+    },
+    "Delete": "{\"service\":\"fake\",\"action\":\"fake\",\"parameters\":{\"version\":1,\"label\":\"lambda-x64\",\"architecture\":\"x86_64\"}}",
+    "InstallLatestAwsSdk": false
+   },
+   "DependsOn": [
+    "LambdaImageDigestReaderCustomResourcePolicyE8E146E6"
+   ],
+   "UpdateReplacePolicy": "Retain",
+   "DeletionPolicy": "Retain"
   },
   "LambdaFunctionServiceRoleB1826A50": {
    "Type": "AWS::IAM::Role",
@@ -4467,13 +4561,26 @@
         },
         "/",
         {
-         "Ref": "LambdaImageBuilderx64Repository57F632F1"
+         "Fn::GetAtt": [
+          "LambdaImageBuilderx64Builder42F384AF",
+          "Name"
+         ]
         },
         "@sha256:",
         {
-         "Fn::GetAtt": [
-          "LambdaImageBuilderx64Builder42F384AF",
-          "Digest"
+         "Fn::Select": [
+          1,
+          {
+           "Fn::Split": [
+            ":",
+            {
+             "Fn::GetAtt": [
+              "LambdaImageDigestReaderE0842577",
+              "imageDetails.0.imageDigest"
+             ]
+            }
+           ]
+          }
          ]
         }
        ]
@@ -4517,6 +4624,83 @@
        "/aws/lambda/",
        {
         "Ref": "LambdaFunction9233991D"
+       }
+      ]
+     ]
+    },
+    "RetentionInDays": 30
+   }
+  },
+  "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   }
+  },
+  "AWS679f53fac002430cb0da5b7982bd22872D164C4C": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "S3Bucket": {
+      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
+     },
+     "S3Key": "864aa5eb2d6ca4e0d4d65c940bc9e4d5a29db1e4f3f3a098ddb56f76b2129ac4.zip"
+    },
+    "Role": {
+     "Fn::GetAtt": [
+      "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
+      "Arn"
+     ]
+    },
+    "Handler": "index.handler",
+    "Runtime": "nodejs14.x",
+    "Timeout": 120
+   },
+   "DependsOn": [
+    "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2"
+   ]
+  },
+  "AWS679f53fac002430cb0da5b7982bd2287LogRetentionCE72797A": {
+   "Type": "Custom::LogRetention",
+   "Properties": {
+    "ServiceToken": {
+     "Fn::GetAtt": [
+      "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+      "Arn"
+     ]
+    },
+    "LogGroupName": {
+     "Fn::Join": [
+      "",
+      [
+       "/aws/lambda/",
+       {
+        "Ref": "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
        }
       ]
      ]
@@ -4975,11 +5159,15 @@
         {
          "Ref": "LambdaImageBuilderzRepository7C7AD146"
         },
-        "\",\n      \"STACK_ID\": \"unspecified\",\n      \"REQUEST_ID\": \"unspecified\",\n      \"LOGICAL_RESOURCE_ID\": \"unspecified\",\n      \"RESPONSE_URL\": \"unspecified\",\n      \"RUNNER_VERSION\": \"latest\"\n    }\n  },\n  \"phases\": {\n    \"pre_build\": {\n      \"commands\": [\n        \"mkdir -p extra_certs\",\n        \"$(aws ecr get-login --no-include-email --region \\\"$AWS_DEFAULT_REGION\\\")\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"docker build . -t \\\"$REPO_URI\\\"  --build-arg RUNNER_VERSION=\\\"latest\\\"\",\n        \"docker push \\\"$REPO_URI\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"STATUS=\\\"SUCCESS\\\"\",\n        \"DIGEST=\\\"UNKNOWN\\\"\",\n        \"if [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ]; then STATUS=\\\"FAILED\\\"; else DIGEST=`docker inspect \\\"$REPO_URI\\\" | jq -r '.[0].RepoDigests[0] | split(\\\"@\\\")[1] | split(\\\":\\\")[1]'`; fi\",\n        \"cat <<EOF > /tmp/payload.json\\n{\\n  \\\"StackId\\\": \\\"$STACK_ID\\\",\\n  \\\"RequestId\\\": \\\"$REQUEST_ID\\\",\\n  \\\"LogicalResourceId\\\": \\\"$LOGICAL_RESOURCE_ID\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$REPO_ARN\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"See logs in ",
+        "\",\n      \"STACK_ID\": \"unspecified\",\n      \"REQUEST_ID\": \"unspecified\",\n      \"LOGICAL_RESOURCE_ID\": \"unspecified\",\n      \"RESPONSE_URL\": \"unspecified\",\n      \"RUNNER_VERSION\": \"latest\"\n    }\n  },\n  \"phases\": {\n    \"pre_build\": {\n      \"commands\": [\n        \"mkdir -p extra_certs\",\n        \"$(aws ecr get-login --no-include-email --region \\\"$AWS_DEFAULT_REGION\\\")\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"docker build . -t \\\"$REPO_URI\\\"  --build-arg RUNNER_VERSION=\\\"latest\\\"\",\n        \"docker push \\\"$REPO_URI\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"STATUS=\\\"SUCCESS\\\"\",\n        \"if [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ]; then STATUS=\\\"FAILED\\\"; fi\",\n        \"cat <<EOF > /tmp/payload.json\\n{\\n  \\\"StackId\\\": \\\"$STACK_ID\\\",\\n  \\\"RequestId\\\": \\\"$REQUEST_ID\\\",\\n  \\\"LogicalResourceId\\\": \\\"$LOGICAL_RESOURCE_ID\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$REPO_ARN\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"See logs in ",
         {
          "Ref": "LambdaImageBuilderzLogsC9FB42C8"
         },
-        "/$CODEBUILD_LOG_PATH (deploy again with 'cdk deploy -R' or logRemovalPolicy=RemovalPolicy.RETAIN if they are already deleted)\\\",\\n  \\\"Data\\\": {\\\"Digest\\\": \\\"$DIGEST\\\"}\\n}\\nEOF\",\n        \"if [ \\\"$RESPONSE_URL\\\" != \\\"unspecified\\\" ]; then jq . /tmp/payload.json; curl -fsSL -X PUT -H \\\"Content-Type:\\\" -d \\\"@/tmp/payload.json\\\" \\\"$RESPONSE_URL\\\"; fi\"\n      ]\n    }\n  }\n}"
+        "/$CODEBUILD_LOG_PATH (deploy again with 'cdk deploy -R' or logRemovalPolicy=RemovalPolicy.RETAIN if they are already deleted)\\\",\\n  \\\"Data\\\": {\\\"Name\\\": \\\"",
+        {
+         "Ref": "LambdaImageBuilderzRepository7C7AD146"
+        },
+        "\\\"}\\n}\\nEOF\",\n        \"if [ \\\"$RESPONSE_URL\\\" != \\\"unspecified\\\" ]; then jq . /tmp/payload.json; curl -fsSL -X PUT -H \\\"Content-Type:\\\" -d \\\"@/tmp/payload.json\\\" \\\"$RESPONSE_URL\\\"; fi\"\n      ]\n    }\n  }\n}"
        ]
       ]
      },
@@ -5109,7 +5297,7 @@
     "ProjectName": {
      "Ref": "LambdaImageBuilderzCodeBuild73AB6718"
     },
-    "BuildHash": "8296fc682b519a37cfb8e52e2c70e58c"
+    "BuildHash": "ef5678072a3a16bbf63acea0043dacc1"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
@@ -5174,7 +5362,10 @@
       ],
       "repository-name": [
        {
-        "Ref": "LambdaImageBuilderzRepository7C7AD146"
+        "Fn::GetAtt": [
+         "LambdaImageBuilderzBuilder235DD147",
+         "Name"
+        ]
        }
       ],
       "image-tag": [
@@ -5240,7 +5431,10 @@
          },
          "/",
          {
-          "Ref": "LambdaImageBuilderzRepository7C7AD146"
+          "Fn::GetAtt": [
+           "LambdaImageBuilderzBuilder235DD147",
+           "Name"
+          ]
          },
          "\",\"repositoryTag\":\"latest\",\"stackName\":\"github-runners-test\"}"
         ]
@@ -5268,6 +5462,84 @@
      ]
     }
    }
+  },
+  "LambdaARMImageDigestReaderCustomResourcePolicy2980B36A": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": "ecr:DescribeImages",
+       "Effect": "Allow",
+       "Resource": {
+        "Ref": "LambdaImageBuilderzBuilder235DD147"
+       }
+      },
+      {
+       "Action": "fake:Fake",
+       "Effect": "Allow",
+       "Resource": {
+        "Ref": "LambdaImageBuilderzBuilder235DD147"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "LambdaARMImageDigestReaderCustomResourcePolicy2980B36A",
+    "Roles": [
+     {
+      "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2"
+     }
+    ]
+   }
+  },
+  "LambdaARMImageDigestReaderF3DD55C4": {
+   "Type": "Custom::EcrImageDigest",
+   "Properties": {
+    "ServiceToken": {
+     "Fn::GetAtt": [
+      "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
+      "Arn"
+     ]
+    },
+    "Create": {
+     "Fn::Join": [
+      "",
+      [
+       "{\"service\":\"ECR\",\"action\":\"describeImages\",\"parameters\":{\"repositoryName\":\"",
+       {
+        "Fn::GetAtt": [
+         "LambdaImageBuilderzBuilder235DD147",
+         "Name"
+        ]
+       },
+       "\",\"imageIds\":[{\"imageTag\":\"latest\"}]},\"physicalResourceId\":{\"id\":\"ImageDigest\"}}"
+      ]
+     ]
+    },
+    "Update": {
+     "Fn::Join": [
+      "",
+      [
+       "{\"service\":\"ECR\",\"action\":\"describeImages\",\"parameters\":{\"repositoryName\":\"",
+       {
+        "Fn::GetAtt": [
+         "LambdaImageBuilderzBuilder235DD147",
+         "Name"
+        ]
+       },
+       "\",\"imageIds\":[{\"imageTag\":\"latest\"}]},\"physicalResourceId\":{\"id\":\"ImageDigest\"}}"
+      ]
+     ]
+    },
+    "Delete": "{\"service\":\"fake\",\"action\":\"fake\",\"parameters\":{\"version\":1,\"label\":\"lambda-arm64\",\"architecture\":\"arm64\"}}",
+    "InstallLatestAwsSdk": false
+   },
+   "DependsOn": [
+    "LambdaARMImageDigestReaderCustomResourcePolicy2980B36A"
+   ],
+   "UpdateReplacePolicy": "Retain",
+   "DeletionPolicy": "Retain"
   },
   "LambdaARMFunctionServiceRole136069A0": {
    "Type": "AWS::IAM::Role",
@@ -5341,13 +5613,26 @@
         },
         "/",
         {
-         "Ref": "LambdaImageBuilderzRepository7C7AD146"
+         "Fn::GetAtt": [
+          "LambdaImageBuilderzBuilder235DD147",
+          "Name"
+         ]
         },
         "@sha256:",
         {
-         "Fn::GetAtt": [
-          "LambdaImageBuilderzBuilder235DD147",
-          "Digest"
+         "Fn::Select": [
+          1,
+          {
+           "Fn::Split": [
+            ":",
+            {
+             "Fn::GetAtt": [
+              "LambdaARMImageDigestReaderF3DD55C4",
+              "imageDetails.0.imageDigest"
+             ]
+            }
+           ]
+          }
          ]
         }
        ]
@@ -5479,7 +5764,10 @@
          },
          "/",
          {
-          "Ref": "FargatebuilderRepository8F7BA13C"
+          "Fn::GetAtt": [
+           "FargatebuilderBuilder0834CD0B",
+           "Name"
+          ]
          },
          ":latest"
         ]
@@ -5679,7 +5967,10 @@
          },
          "/",
          {
-          "Ref": "FargatebuilderRepository8F7BA13C"
+          "Fn::GetAtt": [
+           "FargatebuilderBuilder0834CD0B",
+           "Name"
+          ]
          },
          ":latest"
         ]
@@ -5879,7 +6170,10 @@
          },
          "/",
          {
-          "Ref": "FargatebuilderarmRepository77DCC132"
+          "Fn::GetAtt": [
+           "FargatebuilderarmBuilder48D1AF5A",
+           "Name"
+          ]
          },
          ":latest"
         ]
@@ -6079,7 +6373,10 @@
          },
          "/",
          {
-          "Ref": "FargatebuilderarmRepository77DCC132"
+          "Fn::GetAtt": [
+           "FargatebuilderarmBuilder48D1AF5A",
+           "Name"
+          ]
          },
          ":latest"
         ]
@@ -6284,23 +6581,7 @@
            }
           ]
          },
-         ":",
-         {
-          "Fn::Select": [
-           1,
-           {
-            "Fn::Split": [
-             ":",
-             {
-              "Fn::GetAtt": [
-               "WindowsImageBuilderImage7065BB07",
-               "ImageUri"
-              ]
-             }
-            ]
-           }
-          ]
-         }
+         ":latest"
         ]
        ]
       },
@@ -8609,7 +8890,10 @@
           },
           "/",
           {
-           "Ref": "CodeBuildImageBuilderRepository9DE3B6F0"
+           "Fn::GetAtt": [
+            "CodeBuildImageBuilderB8638EC8",
+            "Name"
+           ]
           }
          ]
         ]
@@ -8667,7 +8951,10 @@
           },
           "/",
           {
-           "Ref": "CodeBuildImageBuilderarmRepositoryE967421B"
+           "Fn::GetAtt": [
+            "CodeBuildImageBuilderarmBuilder755EB37D",
+            "Name"
+           ]
           }
          ]
         ]
@@ -8733,22 +9020,7 @@
          ]
         ]
        },
-       "imageTag": {
-        "Fn::Select": [
-         1,
-         {
-          "Fn::Split": [
-           ":",
-           {
-            "Fn::GetAtt": [
-             "WindowsImageBuilderImage7065BB07",
-             "ImageUri"
-            ]
-           }
-          ]
-         }
-        ]
-       },
+       "imageTag": "latest",
        "imageBuilderLogGroup": {
         "Ref": "WindowsImageBuilderLog0E03408E"
        }
@@ -8801,7 +9073,10 @@
           },
           "/",
           {
-           "Ref": "LambdaImageBuilderx64Repository57F632F1"
+           "Fn::GetAtt": [
+            "LambdaImageBuilderx64Builder42F384AF",
+            "Name"
+           ]
           }
          ]
         ]
@@ -8859,7 +9134,10 @@
           },
           "/",
           {
-           "Ref": "LambdaImageBuilderzRepository7C7AD146"
+           "Fn::GetAtt": [
+            "LambdaImageBuilderzBuilder235DD147",
+            "Name"
+           ]
           }
          ]
         ]
@@ -8940,7 +9218,10 @@
           },
           "/",
           {
-           "Ref": "FargatebuilderRepository8F7BA13C"
+           "Fn::GetAtt": [
+            "FargatebuilderBuilder0834CD0B",
+            "Name"
+           ]
           }
          ]
         ]
@@ -9021,7 +9302,10 @@
           },
           "/",
           {
-           "Ref": "FargatebuilderRepository8F7BA13C"
+           "Fn::GetAtt": [
+            "FargatebuilderBuilder0834CD0B",
+            "Name"
+           ]
           }
          ]
         ]
@@ -9102,7 +9386,10 @@
           },
           "/",
           {
-           "Ref": "FargatebuilderarmRepository77DCC132"
+           "Fn::GetAtt": [
+            "FargatebuilderarmBuilder48D1AF5A",
+            "Name"
+           ]
           }
          ]
         ]
@@ -9183,7 +9470,10 @@
           },
           "/",
           {
-           "Ref": "FargatebuilderarmRepository77DCC132"
+           "Fn::GetAtt": [
+            "FargatebuilderarmBuilder48D1AF5A",
+            "Name"
+           ]
           }
          ]
         ]
@@ -9272,22 +9562,7 @@
          ]
         ]
        },
-       "imageTag": {
-        "Fn::Select": [
-         1,
-         {
-          "Fn::Split": [
-           ":",
-           {
-            "Fn::GetAtt": [
-             "WindowsImageBuilderImage7065BB07",
-             "ImageUri"
-            ]
-           }
-          ]
-         }
-        ]
-       },
+       "imageTag": "latest",
        "imageBuilderLogGroup": {
         "Ref": "WindowsImageBuilderLog0E03408E"
        }

--- a/test/default.integ.snapshot/manifest.json
+++ b/test/default.integ.snapshot/manifest.json
@@ -23,7 +23,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/eec7ddf5ddef416beed0b559678e3fc361291c42a70d00a7942df957d8d5f6fb.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/281fea18609a1af0cc35f88caf7c5208faeffc506b1c05c52d8c4ebcd9c00b72.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [
@@ -681,6 +681,18 @@
             "data": "CodeBuildWindowsCodeBuildC39F35C1"
           }
         ],
+        "/github-runners-test/Lambda/Image Digest Reader/CustomResourcePolicy/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "LambdaImageDigestReaderCustomResourcePolicyE8E146E6"
+          }
+        ],
+        "/github-runners-test/Lambda/Image Digest Reader/Resource/Default": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "LambdaImageDigestReaderE0842577"
+          }
+        ],
         "/github-runners-test/Lambda/Function/ServiceRole/Resource": [
           {
             "type": "aws:cdk:logicalId",
@@ -697,6 +709,24 @@
           {
             "type": "aws:cdk:logicalId",
             "data": "LambdaFunctionLogRetentionB6D78D6D"
+          }
+        ],
+        "/github-runners-test/AWS679f53fac002430cb0da5b7982bd2287/ServiceRole/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2"
+          }
+        ],
+        "/github-runners-test/AWS679f53fac002430cb0da5b7982bd2287/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
+          }
+        ],
+        "/github-runners-test/AWS679f53fac002430cb0da5b7982bd2287/LogRetention/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "AWS679f53fac002430cb0da5b7982bd2287LogRetentionCE72797A"
           }
         ],
         "/github-runners-test/update-lambda-dcc036c8-876b-451e-a2c1-552f9e06e9e1/ServiceRole/Resource": [
@@ -793,6 +823,18 @@
           {
             "type": "aws:cdk:logicalId",
             "data": "LambdaImageBuilderzDependableImagePushruleAllowEventRulegithubrunnerstestupdatelambdadcc036c8876b451ea2c1552f9e06e9e17433A98ECD865F34"
+          }
+        ],
+        "/github-runners-test/LambdaARM/Image Digest Reader/CustomResourcePolicy/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "LambdaARMImageDigestReaderCustomResourcePolicy2980B36A"
+          }
+        ],
+        "/github-runners-test/LambdaARM/Image Digest Reader/Resource/Default": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "LambdaARMImageDigestReaderF3DD55C4"
           }
         ],
         "/github-runners-test/LambdaARM/Function/ServiceRole/Resource": [

--- a/test/default.integ.snapshot/tree.json
+++ b/test/default.integ.snapshot/tree.json
@@ -792,11 +792,15 @@
                                 {
                                   "Ref": "FargatebuilderRepository8F7BA13C"
                                 },
-                                "\",\n      \"STACK_ID\": \"unspecified\",\n      \"REQUEST_ID\": \"unspecified\",\n      \"LOGICAL_RESOURCE_ID\": \"unspecified\",\n      \"RESPONSE_URL\": \"unspecified\",\n      \"RUNNER_VERSION\": \"latest\"\n    }\n  },\n  \"phases\": {\n    \"pre_build\": {\n      \"commands\": [\n        \"mkdir -p extra_certs\",\n        \"$(aws ecr get-login --no-include-email --region \\\"$AWS_DEFAULT_REGION\\\")\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"docker build . -t \\\"$REPO_URI\\\"  --build-arg RUNNER_VERSION=\\\"latest\\\"\",\n        \"docker push \\\"$REPO_URI\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"STATUS=\\\"SUCCESS\\\"\",\n        \"DIGEST=\\\"UNKNOWN\\\"\",\n        \"if [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ]; then STATUS=\\\"FAILED\\\"; else DIGEST=`docker inspect \\\"$REPO_URI\\\" | jq -r '.[0].RepoDigests[0] | split(\\\"@\\\")[1] | split(\\\":\\\")[1]'`; fi\",\n        \"cat <<EOF > /tmp/payload.json\\n{\\n  \\\"StackId\\\": \\\"$STACK_ID\\\",\\n  \\\"RequestId\\\": \\\"$REQUEST_ID\\\",\\n  \\\"LogicalResourceId\\\": \\\"$LOGICAL_RESOURCE_ID\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$REPO_ARN\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"See logs in ",
+                                "\",\n      \"STACK_ID\": \"unspecified\",\n      \"REQUEST_ID\": \"unspecified\",\n      \"LOGICAL_RESOURCE_ID\": \"unspecified\",\n      \"RESPONSE_URL\": \"unspecified\",\n      \"RUNNER_VERSION\": \"latest\"\n    }\n  },\n  \"phases\": {\n    \"pre_build\": {\n      \"commands\": [\n        \"mkdir -p extra_certs\",\n        \"$(aws ecr get-login --no-include-email --region \\\"$AWS_DEFAULT_REGION\\\")\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"docker build . -t \\\"$REPO_URI\\\"  --build-arg RUNNER_VERSION=\\\"latest\\\"\",\n        \"docker push \\\"$REPO_URI\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"STATUS=\\\"SUCCESS\\\"\",\n        \"if [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ]; then STATUS=\\\"FAILED\\\"; fi\",\n        \"cat <<EOF > /tmp/payload.json\\n{\\n  \\\"StackId\\\": \\\"$STACK_ID\\\",\\n  \\\"RequestId\\\": \\\"$REQUEST_ID\\\",\\n  \\\"LogicalResourceId\\\": \\\"$LOGICAL_RESOURCE_ID\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$REPO_ARN\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"See logs in ",
                                 {
                                   "Ref": "FargatebuilderLogs2F794091"
                                 },
-                                "/$CODEBUILD_LOG_PATH (deploy again with 'cdk deploy -R' or logRemovalPolicy=RemovalPolicy.RETAIN if they are already deleted)\\\",\\n  \\\"Data\\\": {\\\"Digest\\\": \\\"$DIGEST\\\"}\\n}\\nEOF\",\n        \"if [ \\\"$RESPONSE_URL\\\" != \\\"unspecified\\\" ]; then jq . /tmp/payload.json; curl -fsSL -X PUT -H \\\"Content-Type:\\\" -d \\\"@/tmp/payload.json\\\" \\\"$RESPONSE_URL\\\"; fi\"\n      ]\n    }\n  }\n}"
+                                "/$CODEBUILD_LOG_PATH (deploy again with 'cdk deploy -R' or logRemovalPolicy=RemovalPolicy.RETAIN if they are already deleted)\\\",\\n  \\\"Data\\\": {\\\"Name\\\": \\\"",
+                                {
+                                  "Ref": "FargatebuilderRepository8F7BA13C"
+                                },
+                                "\\\"}\\n}\\nEOF\",\n        \"if [ \\\"$RESPONSE_URL\\\" != \\\"unspecified\\\" ]; then jq . /tmp/payload.json; curl -fsSL -X PUT -H \\\"Content-Type:\\\" -d \\\"@/tmp/payload.json\\\" \\\"$RESPONSE_URL\\\"; fi\"\n      ]\n    }\n  }\n}"
                               ]
                             ]
                           }
@@ -1473,11 +1477,15 @@
                                 {
                                   "Ref": "FargatebuilderarmRepository77DCC132"
                                 },
-                                "\",\n      \"STACK_ID\": \"unspecified\",\n      \"REQUEST_ID\": \"unspecified\",\n      \"LOGICAL_RESOURCE_ID\": \"unspecified\",\n      \"RESPONSE_URL\": \"unspecified\",\n      \"RUNNER_VERSION\": \"latest\"\n    }\n  },\n  \"phases\": {\n    \"pre_build\": {\n      \"commands\": [\n        \"mkdir -p extra_certs\",\n        \"$(aws ecr get-login --no-include-email --region \\\"$AWS_DEFAULT_REGION\\\")\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"docker build . -t \\\"$REPO_URI\\\"  --build-arg RUNNER_VERSION=\\\"latest\\\"\",\n        \"docker push \\\"$REPO_URI\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"STATUS=\\\"SUCCESS\\\"\",\n        \"DIGEST=\\\"UNKNOWN\\\"\",\n        \"if [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ]; then STATUS=\\\"FAILED\\\"; else DIGEST=`docker inspect \\\"$REPO_URI\\\" | jq -r '.[0].RepoDigests[0] | split(\\\"@\\\")[1] | split(\\\":\\\")[1]'`; fi\",\n        \"cat <<EOF > /tmp/payload.json\\n{\\n  \\\"StackId\\\": \\\"$STACK_ID\\\",\\n  \\\"RequestId\\\": \\\"$REQUEST_ID\\\",\\n  \\\"LogicalResourceId\\\": \\\"$LOGICAL_RESOURCE_ID\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$REPO_ARN\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"See logs in ",
+                                "\",\n      \"STACK_ID\": \"unspecified\",\n      \"REQUEST_ID\": \"unspecified\",\n      \"LOGICAL_RESOURCE_ID\": \"unspecified\",\n      \"RESPONSE_URL\": \"unspecified\",\n      \"RUNNER_VERSION\": \"latest\"\n    }\n  },\n  \"phases\": {\n    \"pre_build\": {\n      \"commands\": [\n        \"mkdir -p extra_certs\",\n        \"$(aws ecr get-login --no-include-email --region \\\"$AWS_DEFAULT_REGION\\\")\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"docker build . -t \\\"$REPO_URI\\\"  --build-arg RUNNER_VERSION=\\\"latest\\\"\",\n        \"docker push \\\"$REPO_URI\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"STATUS=\\\"SUCCESS\\\"\",\n        \"if [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ]; then STATUS=\\\"FAILED\\\"; fi\",\n        \"cat <<EOF > /tmp/payload.json\\n{\\n  \\\"StackId\\\": \\\"$STACK_ID\\\",\\n  \\\"RequestId\\\": \\\"$REQUEST_ID\\\",\\n  \\\"LogicalResourceId\\\": \\\"$LOGICAL_RESOURCE_ID\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$REPO_ARN\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"See logs in ",
                                 {
                                   "Ref": "FargatebuilderarmLogs63D60F4D"
                                 },
-                                "/$CODEBUILD_LOG_PATH (deploy again with 'cdk deploy -R' or logRemovalPolicy=RemovalPolicy.RETAIN if they are already deleted)\\\",\\n  \\\"Data\\\": {\\\"Digest\\\": \\\"$DIGEST\\\"}\\n}\\nEOF\",\n        \"if [ \\\"$RESPONSE_URL\\\" != \\\"unspecified\\\" ]; then jq . /tmp/payload.json; curl -fsSL -X PUT -H \\\"Content-Type:\\\" -d \\\"@/tmp/payload.json\\\" \\\"$RESPONSE_URL\\\"; fi\"\n      ]\n    }\n  }\n}"
+                                "/$CODEBUILD_LOG_PATH (deploy again with 'cdk deploy -R' or logRemovalPolicy=RemovalPolicy.RETAIN if they are already deleted)\\\",\\n  \\\"Data\\\": {\\\"Name\\\": \\\"",
+                                {
+                                  "Ref": "FargatebuilderarmRepository77DCC132"
+                                },
+                                "\\\"}\\n}\\nEOF\",\n        \"if [ \\\"$RESPONSE_URL\\\" != \\\"unspecified\\\" ]; then jq . /tmp/payload.json; curl -fsSL -X PUT -H \\\"Content-Type:\\\" -d \\\"@/tmp/payload.json\\\" \\\"$RESPONSE_URL\\\"; fi\"\n      ]\n    }\n  }\n}"
                               ]
                             ]
                           }
@@ -2154,11 +2162,15 @@
                                 {
                                   "Ref": "LambdaImageBuilderx64Repository57F632F1"
                                 },
-                                "\",\n      \"STACK_ID\": \"unspecified\",\n      \"REQUEST_ID\": \"unspecified\",\n      \"LOGICAL_RESOURCE_ID\": \"unspecified\",\n      \"RESPONSE_URL\": \"unspecified\",\n      \"RUNNER_VERSION\": \"latest\"\n    }\n  },\n  \"phases\": {\n    \"pre_build\": {\n      \"commands\": [\n        \"mkdir -p extra_certs\",\n        \"$(aws ecr get-login --no-include-email --region \\\"$AWS_DEFAULT_REGION\\\")\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"docker build . -t \\\"$REPO_URI\\\"  --build-arg RUNNER_VERSION=\\\"latest\\\"\",\n        \"docker push \\\"$REPO_URI\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"STATUS=\\\"SUCCESS\\\"\",\n        \"DIGEST=\\\"UNKNOWN\\\"\",\n        \"if [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ]; then STATUS=\\\"FAILED\\\"; else DIGEST=`docker inspect \\\"$REPO_URI\\\" | jq -r '.[0].RepoDigests[0] | split(\\\"@\\\")[1] | split(\\\":\\\")[1]'`; fi\",\n        \"cat <<EOF > /tmp/payload.json\\n{\\n  \\\"StackId\\\": \\\"$STACK_ID\\\",\\n  \\\"RequestId\\\": \\\"$REQUEST_ID\\\",\\n  \\\"LogicalResourceId\\\": \\\"$LOGICAL_RESOURCE_ID\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$REPO_ARN\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"See logs in ",
+                                "\",\n      \"STACK_ID\": \"unspecified\",\n      \"REQUEST_ID\": \"unspecified\",\n      \"LOGICAL_RESOURCE_ID\": \"unspecified\",\n      \"RESPONSE_URL\": \"unspecified\",\n      \"RUNNER_VERSION\": \"latest\"\n    }\n  },\n  \"phases\": {\n    \"pre_build\": {\n      \"commands\": [\n        \"mkdir -p extra_certs\",\n        \"$(aws ecr get-login --no-include-email --region \\\"$AWS_DEFAULT_REGION\\\")\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"docker build . -t \\\"$REPO_URI\\\"  --build-arg RUNNER_VERSION=\\\"latest\\\"\",\n        \"docker push \\\"$REPO_URI\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"STATUS=\\\"SUCCESS\\\"\",\n        \"if [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ]; then STATUS=\\\"FAILED\\\"; fi\",\n        \"cat <<EOF > /tmp/payload.json\\n{\\n  \\\"StackId\\\": \\\"$STACK_ID\\\",\\n  \\\"RequestId\\\": \\\"$REQUEST_ID\\\",\\n  \\\"LogicalResourceId\\\": \\\"$LOGICAL_RESOURCE_ID\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$REPO_ARN\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"See logs in ",
                                 {
                                   "Ref": "LambdaImageBuilderx64Logs1C003BB4"
                                 },
-                                "/$CODEBUILD_LOG_PATH (deploy again with 'cdk deploy -R' or logRemovalPolicy=RemovalPolicy.RETAIN if they are already deleted)\\\",\\n  \\\"Data\\\": {\\\"Digest\\\": \\\"$DIGEST\\\"}\\n}\\nEOF\",\n        \"if [ \\\"$RESPONSE_URL\\\" != \\\"unspecified\\\" ]; then jq . /tmp/payload.json; curl -fsSL -X PUT -H \\\"Content-Type:\\\" -d \\\"@/tmp/payload.json\\\" \\\"$RESPONSE_URL\\\"; fi\"\n      ]\n    }\n  }\n}"
+                                "/$CODEBUILD_LOG_PATH (deploy again with 'cdk deploy -R' or logRemovalPolicy=RemovalPolicy.RETAIN if they are already deleted)\\\",\\n  \\\"Data\\\": {\\\"Name\\\": \\\"",
+                                {
+                                  "Ref": "LambdaImageBuilderx64Repository57F632F1"
+                                },
+                                "\\\"}\\n}\\nEOF\",\n        \"if [ \\\"$RESPONSE_URL\\\" != \\\"unspecified\\\" ]; then jq . /tmp/payload.json; curl -fsSL -X PUT -H \\\"Content-Type:\\\" -d \\\"@/tmp/payload.json\\\" \\\"$RESPONSE_URL\\\"; fi\"\n      ]\n    }\n  }\n}"
                               ]
                             ]
                           }
@@ -2422,7 +2434,10 @@
                                 ],
                                 "repository-name": [
                                   {
-                                    "Ref": "LambdaImageBuilderx64Repository57F632F1"
+                                    "Fn::GetAtt": [
+                                      "LambdaImageBuilderx64Builder42F384AF",
+                                      "Name"
+                                    ]
                                   }
                                 ],
                                 "image-tag": [
@@ -2493,7 +2508,10 @@
                                       },
                                       "/",
                                       {
-                                        "Ref": "LambdaImageBuilderx64Repository57F632F1"
+                                        "Fn::GetAtt": [
+                                          "LambdaImageBuilderx64Builder42F384AF",
+                                          "Name"
+                                        ]
                                       },
                                       "\",\"repositoryTag\":\"latest\",\"stackName\":\"github-runners-test\"}"
                                     ]
@@ -3933,11 +3951,15 @@
                                 {
                                   "Ref": "CodeBuildImageBuilderRepository9DE3B6F0"
                                 },
-                                "\",\n      \"STACK_ID\": \"unspecified\",\n      \"REQUEST_ID\": \"unspecified\",\n      \"LOGICAL_RESOURCE_ID\": \"unspecified\",\n      \"RESPONSE_URL\": \"unspecified\",\n      \"RUNNER_VERSION\": \"latest\"\n    }\n  },\n  \"phases\": {\n    \"pre_build\": {\n      \"commands\": [\n        \"mkdir -p extra_certs\",\n        \"$(aws ecr get-login --no-include-email --region \\\"$AWS_DEFAULT_REGION\\\")\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"docker build . -t \\\"$REPO_URI\\\"  --build-arg RUNNER_VERSION=\\\"latest\\\"\",\n        \"docker push \\\"$REPO_URI\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"STATUS=\\\"SUCCESS\\\"\",\n        \"DIGEST=\\\"UNKNOWN\\\"\",\n        \"if [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ]; then STATUS=\\\"FAILED\\\"; else DIGEST=`docker inspect \\\"$REPO_URI\\\" | jq -r '.[0].RepoDigests[0] | split(\\\"@\\\")[1] | split(\\\":\\\")[1]'`; fi\",\n        \"cat <<EOF > /tmp/payload.json\\n{\\n  \\\"StackId\\\": \\\"$STACK_ID\\\",\\n  \\\"RequestId\\\": \\\"$REQUEST_ID\\\",\\n  \\\"LogicalResourceId\\\": \\\"$LOGICAL_RESOURCE_ID\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$REPO_ARN\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"See logs in ",
+                                "\",\n      \"STACK_ID\": \"unspecified\",\n      \"REQUEST_ID\": \"unspecified\",\n      \"LOGICAL_RESOURCE_ID\": \"unspecified\",\n      \"RESPONSE_URL\": \"unspecified\",\n      \"RUNNER_VERSION\": \"latest\"\n    }\n  },\n  \"phases\": {\n    \"pre_build\": {\n      \"commands\": [\n        \"mkdir -p extra_certs\",\n        \"$(aws ecr get-login --no-include-email --region \\\"$AWS_DEFAULT_REGION\\\")\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"docker build . -t \\\"$REPO_URI\\\"  --build-arg RUNNER_VERSION=\\\"latest\\\"\",\n        \"docker push \\\"$REPO_URI\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"STATUS=\\\"SUCCESS\\\"\",\n        \"if [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ]; then STATUS=\\\"FAILED\\\"; fi\",\n        \"cat <<EOF > /tmp/payload.json\\n{\\n  \\\"StackId\\\": \\\"$STACK_ID\\\",\\n  \\\"RequestId\\\": \\\"$REQUEST_ID\\\",\\n  \\\"LogicalResourceId\\\": \\\"$LOGICAL_RESOURCE_ID\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$REPO_ARN\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"See logs in ",
                                 {
                                   "Ref": "CodeBuildImageBuilderLogsE4CADFCC"
                                 },
-                                "/$CODEBUILD_LOG_PATH (deploy again with 'cdk deploy -R' or logRemovalPolicy=RemovalPolicy.RETAIN if they are already deleted)\\\",\\n  \\\"Data\\\": {\\\"Digest\\\": \\\"$DIGEST\\\"}\\n}\\nEOF\",\n        \"if [ \\\"$RESPONSE_URL\\\" != \\\"unspecified\\\" ]; then jq . /tmp/payload.json; curl -fsSL -X PUT -H \\\"Content-Type:\\\" -d \\\"@/tmp/payload.json\\\" \\\"$RESPONSE_URL\\\"; fi\"\n      ]\n    }\n  }\n}"
+                                "/$CODEBUILD_LOG_PATH (deploy again with 'cdk deploy -R' or logRemovalPolicy=RemovalPolicy.RETAIN if they are already deleted)\\\",\\n  \\\"Data\\\": {\\\"Name\\\": \\\"",
+                                {
+                                  "Ref": "CodeBuildImageBuilderRepository9DE3B6F0"
+                                },
+                                "\\\"}\\n}\\nEOF\",\n        \"if [ \\\"$RESPONSE_URL\\\" != \\\"unspecified\\\" ]; then jq . /tmp/payload.json; curl -fsSL -X PUT -H \\\"Content-Type:\\\" -d \\\"@/tmp/payload.json\\\" \\\"$RESPONSE_URL\\\"; fi\"\n      ]\n    }\n  }\n}"
                               ]
                             ]
                           }
@@ -4459,7 +4481,10 @@
                                 },
                                 "/",
                                 {
-                                  "Ref": "CodeBuildImageBuilderRepository9DE3B6F0"
+                                  "Fn::GetAtt": [
+                                    "CodeBuildImageBuilderB8638EC8",
+                                    "Name"
+                                  ]
                                 },
                                 ":latest"
                               ]
@@ -5089,11 +5114,15 @@
                                 {
                                   "Ref": "CodeBuildImageBuilderarmRepositoryE967421B"
                                 },
-                                "\",\n      \"STACK_ID\": \"unspecified\",\n      \"REQUEST_ID\": \"unspecified\",\n      \"LOGICAL_RESOURCE_ID\": \"unspecified\",\n      \"RESPONSE_URL\": \"unspecified\",\n      \"RUNNER_VERSION\": \"latest\"\n    }\n  },\n  \"phases\": {\n    \"pre_build\": {\n      \"commands\": [\n        \"mkdir -p extra_certs\",\n        \"$(aws ecr get-login --no-include-email --region \\\"$AWS_DEFAULT_REGION\\\")\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"docker build . -t \\\"$REPO_URI\\\"  --build-arg RUNNER_VERSION=\\\"latest\\\"\",\n        \"docker push \\\"$REPO_URI\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"STATUS=\\\"SUCCESS\\\"\",\n        \"DIGEST=\\\"UNKNOWN\\\"\",\n        \"if [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ]; then STATUS=\\\"FAILED\\\"; else DIGEST=`docker inspect \\\"$REPO_URI\\\" | jq -r '.[0].RepoDigests[0] | split(\\\"@\\\")[1] | split(\\\":\\\")[1]'`; fi\",\n        \"cat <<EOF > /tmp/payload.json\\n{\\n  \\\"StackId\\\": \\\"$STACK_ID\\\",\\n  \\\"RequestId\\\": \\\"$REQUEST_ID\\\",\\n  \\\"LogicalResourceId\\\": \\\"$LOGICAL_RESOURCE_ID\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$REPO_ARN\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"See logs in ",
+                                "\",\n      \"STACK_ID\": \"unspecified\",\n      \"REQUEST_ID\": \"unspecified\",\n      \"LOGICAL_RESOURCE_ID\": \"unspecified\",\n      \"RESPONSE_URL\": \"unspecified\",\n      \"RUNNER_VERSION\": \"latest\"\n    }\n  },\n  \"phases\": {\n    \"pre_build\": {\n      \"commands\": [\n        \"mkdir -p extra_certs\",\n        \"$(aws ecr get-login --no-include-email --region \\\"$AWS_DEFAULT_REGION\\\")\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"docker build . -t \\\"$REPO_URI\\\"  --build-arg RUNNER_VERSION=\\\"latest\\\"\",\n        \"docker push \\\"$REPO_URI\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"STATUS=\\\"SUCCESS\\\"\",\n        \"if [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ]; then STATUS=\\\"FAILED\\\"; fi\",\n        \"cat <<EOF > /tmp/payload.json\\n{\\n  \\\"StackId\\\": \\\"$STACK_ID\\\",\\n  \\\"RequestId\\\": \\\"$REQUEST_ID\\\",\\n  \\\"LogicalResourceId\\\": \\\"$LOGICAL_RESOURCE_ID\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$REPO_ARN\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"See logs in ",
                                 {
                                   "Ref": "CodeBuildImageBuilderarmLogs5A60CB81"
                                 },
-                                "/$CODEBUILD_LOG_PATH (deploy again with 'cdk deploy -R' or logRemovalPolicy=RemovalPolicy.RETAIN if they are already deleted)\\\",\\n  \\\"Data\\\": {\\\"Digest\\\": \\\"$DIGEST\\\"}\\n}\\nEOF\",\n        \"if [ \\\"$RESPONSE_URL\\\" != \\\"unspecified\\\" ]; then jq . /tmp/payload.json; curl -fsSL -X PUT -H \\\"Content-Type:\\\" -d \\\"@/tmp/payload.json\\\" \\\"$RESPONSE_URL\\\"; fi\"\n      ]\n    }\n  }\n}"
+                                "/$CODEBUILD_LOG_PATH (deploy again with 'cdk deploy -R' or logRemovalPolicy=RemovalPolicy.RETAIN if they are already deleted)\\\",\\n  \\\"Data\\\": {\\\"Name\\\": \\\"",
+                                {
+                                  "Ref": "CodeBuildImageBuilderarmRepositoryE967421B"
+                                },
+                                "\\\"}\\n}\\nEOF\",\n        \"if [ \\\"$RESPONSE_URL\\\" != \\\"unspecified\\\" ]; then jq . /tmp/payload.json; curl -fsSL -X PUT -H \\\"Content-Type:\\\" -d \\\"@/tmp/payload.json\\\" \\\"$RESPONSE_URL\\\"; fi\"\n      ]\n    }\n  }\n}"
                               ]
                             ]
                           }
@@ -5615,7 +5644,10 @@
                                 },
                                 "/",
                                 {
-                                  "Ref": "CodeBuildImageBuilderarmRepositoryE967421B"
+                                  "Fn::GetAtt": [
+                                    "CodeBuildImageBuilderarmBuilder755EB37D",
+                                    "Name"
+                                  ]
                                 },
                                 ":latest"
                               ]
@@ -5993,23 +6025,7 @@
                                     }
                                   ]
                                 },
-                                ":",
-                                {
-                                  "Fn::Select": [
-                                    1,
-                                    {
-                                      "Fn::Split": [
-                                        ":",
-                                        {
-                                          "Fn::GetAtt": [
-                                            "WindowsImageBuilderImage7065BB07",
-                                            "ImageUri"
-                                          ]
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
+                                ":latest"
                               ]
                             ]
                           },
@@ -6072,6 +6088,90 @@
             "id": "Lambda",
             "path": "github-runners-test/Lambda",
             "children": {
+              "Image Digest Reader": {
+                "id": "Image Digest Reader",
+                "path": "github-runners-test/Lambda/Image Digest Reader",
+                "children": {
+                  "Provider": {
+                    "id": "Provider",
+                    "path": "github-runners-test/Lambda/Image Digest Reader/Provider",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_lambda.SingletonFunction",
+                      "version": "2.29.0"
+                    }
+                  },
+                  "CustomResourcePolicy": {
+                    "id": "CustomResourcePolicy",
+                    "path": "github-runners-test/Lambda/Image Digest Reader/CustomResourcePolicy",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "github-runners-test/Lambda/Image Digest Reader/CustomResourcePolicy/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::IAM::Policy",
+                          "aws:cdk:cloudformation:props": {
+                            "policyDocument": {
+                              "Statement": [
+                                {
+                                  "Action": "ecr:DescribeImages",
+                                  "Effect": "Allow",
+                                  "Resource": {
+                                    "Ref": "LambdaImageBuilderx64Builder42F384AF"
+                                  }
+                                },
+                                {
+                                  "Action": "fake:Fake",
+                                  "Effect": "Allow",
+                                  "Resource": {
+                                    "Ref": "LambdaImageBuilderx64Builder42F384AF"
+                                  }
+                                }
+                              ],
+                              "Version": "2012-10-17"
+                            },
+                            "policyName": "LambdaImageDigestReaderCustomResourcePolicyE8E146E6",
+                            "roles": [
+                              {
+                                "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2"
+                              }
+                            ]
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
+                          "version": "2.29.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_iam.Policy",
+                      "version": "2.29.0"
+                    }
+                  },
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "github-runners-test/Lambda/Image Digest Reader/Resource",
+                    "children": {
+                      "Default": {
+                        "id": "Default",
+                        "path": "github-runners-test/Lambda/Image Digest Reader/Resource/Default",
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.CfnResource",
+                          "version": "2.29.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.CustomResource",
+                      "version": "2.29.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.custom_resources.AwsCustomResource",
+                  "version": "2.29.0"
+                }
+              },
               "Function": {
                 "id": "Function",
                 "path": "github-runners-test/Lambda/Function",
@@ -6169,13 +6269,26 @@
                                 },
                                 "/",
                                 {
-                                  "Ref": "LambdaImageBuilderx64Repository57F632F1"
+                                  "Fn::GetAtt": [
+                                    "LambdaImageBuilderx64Builder42F384AF",
+                                    "Name"
+                                  ]
                                 },
                                 "@sha256:",
                                 {
-                                  "Fn::GetAtt": [
-                                    "LambdaImageBuilderx64Builder42F384AF",
-                                    "Digest"
+                                  "Fn::Select": [
+                                    1,
+                                    {
+                                      "Fn::Split": [
+                                        ":",
+                                        {
+                                          "Fn::GetAtt": [
+                                            "LambdaImageDigestReaderE0842577",
+                                            "imageDetails.0.imageDigest"
+                                          ]
+                                        }
+                                      ]
+                                    }
                                   ]
                                 }
                               ]
@@ -6249,6 +6362,145 @@
             "constructInfo": {
               "fqn": "constructs.Construct",
               "version": "10.0.5"
+            }
+          },
+          "AWS679f53fac002430cb0da5b7982bd2287": {
+            "id": "AWS679f53fac002430cb0da5b7982bd2287",
+            "path": "github-runners-test/AWS679f53fac002430cb0da5b7982bd2287",
+            "children": {
+              "ServiceRole": {
+                "id": "ServiceRole",
+                "path": "github-runners-test/AWS679f53fac002430cb0da5b7982bd2287/ServiceRole",
+                "children": {
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "github-runners-test/AWS679f53fac002430cb0da5b7982bd2287/ServiceRole/Resource",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::IAM::Role",
+                      "aws:cdk:cloudformation:props": {
+                        "assumeRolePolicyDocument": {
+                          "Statement": [
+                            {
+                              "Action": "sts:AssumeRole",
+                              "Effect": "Allow",
+                              "Principal": {
+                                "Service": "lambda.amazonaws.com"
+                              }
+                            }
+                          ],
+                          "Version": "2012-10-17"
+                        },
+                        "managedPolicyArns": [
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                "arn:",
+                                {
+                                  "Ref": "AWS::Partition"
+                                },
+                                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+                              ]
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_iam.CfnRole",
+                      "version": "2.29.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_iam.Role",
+                  "version": "2.29.0"
+                }
+              },
+              "Code": {
+                "id": "Code",
+                "path": "github-runners-test/AWS679f53fac002430cb0da5b7982bd2287/Code",
+                "children": {
+                  "Stage": {
+                    "id": "Stage",
+                    "path": "github-runners-test/AWS679f53fac002430cb0da5b7982bd2287/Code/Stage",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.AssetStaging",
+                      "version": "2.29.0"
+                    }
+                  },
+                  "AssetBucket": {
+                    "id": "AssetBucket",
+                    "path": "github-runners-test/AWS679f53fac002430cb0da5b7982bd2287/Code/AssetBucket",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_s3.BucketBase",
+                      "version": "2.29.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
+                  "version": "2.29.0"
+                }
+              },
+              "Resource": {
+                "id": "Resource",
+                "path": "github-runners-test/AWS679f53fac002430cb0da5b7982bd2287/Resource",
+                "attributes": {
+                  "aws:cdk:cloudformation:type": "AWS::Lambda::Function",
+                  "aws:cdk:cloudformation:props": {
+                    "code": {
+                      "s3Bucket": {
+                        "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
+                      },
+                      "s3Key": "864aa5eb2d6ca4e0d4d65c940bc9e4d5a29db1e4f3f3a098ddb56f76b2129ac4.zip"
+                    },
+                    "role": {
+                      "Fn::GetAtt": [
+                        "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
+                        "Arn"
+                      ]
+                    },
+                    "handler": "index.handler",
+                    "runtime": "nodejs14.x",
+                    "timeout": 120
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
+                  "version": "2.29.0"
+                }
+              },
+              "LogRetention": {
+                "id": "LogRetention",
+                "path": "github-runners-test/AWS679f53fac002430cb0da5b7982bd2287/LogRetention",
+                "children": {
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "github-runners-test/AWS679f53fac002430cb0da5b7982bd2287/LogRetention/Resource",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.CfnResource",
+                      "version": "2.29.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_logs.LogRetention",
+                  "version": "2.29.0"
+                }
+              },
+              "LogGroup": {
+                "id": "LogGroup",
+                "path": "github-runners-test/AWS679f53fac002430cb0da5b7982bd2287/LogGroup",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.Resource",
+                  "version": "2.29.0"
+                }
+              }
+            },
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.aws_lambda.Function",
+              "version": "2.29.0"
             }
           },
           "update-lambda-dcc036c8-876b-451e-a2c1-552f9e06e9e1": {
@@ -6898,11 +7150,15 @@
                                 {
                                   "Ref": "LambdaImageBuilderzRepository7C7AD146"
                                 },
-                                "\",\n      \"STACK_ID\": \"unspecified\",\n      \"REQUEST_ID\": \"unspecified\",\n      \"LOGICAL_RESOURCE_ID\": \"unspecified\",\n      \"RESPONSE_URL\": \"unspecified\",\n      \"RUNNER_VERSION\": \"latest\"\n    }\n  },\n  \"phases\": {\n    \"pre_build\": {\n      \"commands\": [\n        \"mkdir -p extra_certs\",\n        \"$(aws ecr get-login --no-include-email --region \\\"$AWS_DEFAULT_REGION\\\")\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"docker build . -t \\\"$REPO_URI\\\"  --build-arg RUNNER_VERSION=\\\"latest\\\"\",\n        \"docker push \\\"$REPO_URI\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"STATUS=\\\"SUCCESS\\\"\",\n        \"DIGEST=\\\"UNKNOWN\\\"\",\n        \"if [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ]; then STATUS=\\\"FAILED\\\"; else DIGEST=`docker inspect \\\"$REPO_URI\\\" | jq -r '.[0].RepoDigests[0] | split(\\\"@\\\")[1] | split(\\\":\\\")[1]'`; fi\",\n        \"cat <<EOF > /tmp/payload.json\\n{\\n  \\\"StackId\\\": \\\"$STACK_ID\\\",\\n  \\\"RequestId\\\": \\\"$REQUEST_ID\\\",\\n  \\\"LogicalResourceId\\\": \\\"$LOGICAL_RESOURCE_ID\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$REPO_ARN\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"See logs in ",
+                                "\",\n      \"STACK_ID\": \"unspecified\",\n      \"REQUEST_ID\": \"unspecified\",\n      \"LOGICAL_RESOURCE_ID\": \"unspecified\",\n      \"RESPONSE_URL\": \"unspecified\",\n      \"RUNNER_VERSION\": \"latest\"\n    }\n  },\n  \"phases\": {\n    \"pre_build\": {\n      \"commands\": [\n        \"mkdir -p extra_certs\",\n        \"$(aws ecr get-login --no-include-email --region \\\"$AWS_DEFAULT_REGION\\\")\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"docker build . -t \\\"$REPO_URI\\\"  --build-arg RUNNER_VERSION=\\\"latest\\\"\",\n        \"docker push \\\"$REPO_URI\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"STATUS=\\\"SUCCESS\\\"\",\n        \"if [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ]; then STATUS=\\\"FAILED\\\"; fi\",\n        \"cat <<EOF > /tmp/payload.json\\n{\\n  \\\"StackId\\\": \\\"$STACK_ID\\\",\\n  \\\"RequestId\\\": \\\"$REQUEST_ID\\\",\\n  \\\"LogicalResourceId\\\": \\\"$LOGICAL_RESOURCE_ID\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$REPO_ARN\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"See logs in ",
                                 {
                                   "Ref": "LambdaImageBuilderzLogsC9FB42C8"
                                 },
-                                "/$CODEBUILD_LOG_PATH (deploy again with 'cdk deploy -R' or logRemovalPolicy=RemovalPolicy.RETAIN if they are already deleted)\\\",\\n  \\\"Data\\\": {\\\"Digest\\\": \\\"$DIGEST\\\"}\\n}\\nEOF\",\n        \"if [ \\\"$RESPONSE_URL\\\" != \\\"unspecified\\\" ]; then jq . /tmp/payload.json; curl -fsSL -X PUT -H \\\"Content-Type:\\\" -d \\\"@/tmp/payload.json\\\" \\\"$RESPONSE_URL\\\"; fi\"\n      ]\n    }\n  }\n}"
+                                "/$CODEBUILD_LOG_PATH (deploy again with 'cdk deploy -R' or logRemovalPolicy=RemovalPolicy.RETAIN if they are already deleted)\\\",\\n  \\\"Data\\\": {\\\"Name\\\": \\\"",
+                                {
+                                  "Ref": "LambdaImageBuilderzRepository7C7AD146"
+                                },
+                                "\\\"}\\n}\\nEOF\",\n        \"if [ \\\"$RESPONSE_URL\\\" != \\\"unspecified\\\" ]; then jq . /tmp/payload.json; curl -fsSL -X PUT -H \\\"Content-Type:\\\" -d \\\"@/tmp/payload.json\\\" \\\"$RESPONSE_URL\\\"; fi\"\n      ]\n    }\n  }\n}"
                               ]
                             ]
                           }
@@ -7166,7 +7422,10 @@
                                 ],
                                 "repository-name": [
                                   {
-                                    "Ref": "LambdaImageBuilderzRepository7C7AD146"
+                                    "Fn::GetAtt": [
+                                      "LambdaImageBuilderzBuilder235DD147",
+                                      "Name"
+                                    ]
                                   }
                                 ],
                                 "image-tag": [
@@ -7237,7 +7496,10 @@
                                       },
                                       "/",
                                       {
-                                        "Ref": "LambdaImageBuilderzRepository7C7AD146"
+                                        "Fn::GetAtt": [
+                                          "LambdaImageBuilderzBuilder235DD147",
+                                          "Name"
+                                        ]
                                       },
                                       "\",\"repositoryTag\":\"latest\",\"stackName\":\"github-runners-test\"}"
                                     ]
@@ -7301,6 +7563,90 @@
             "id": "LambdaARM",
             "path": "github-runners-test/LambdaARM",
             "children": {
+              "Image Digest Reader": {
+                "id": "Image Digest Reader",
+                "path": "github-runners-test/LambdaARM/Image Digest Reader",
+                "children": {
+                  "Provider": {
+                    "id": "Provider",
+                    "path": "github-runners-test/LambdaARM/Image Digest Reader/Provider",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_lambda.SingletonFunction",
+                      "version": "2.29.0"
+                    }
+                  },
+                  "CustomResourcePolicy": {
+                    "id": "CustomResourcePolicy",
+                    "path": "github-runners-test/LambdaARM/Image Digest Reader/CustomResourcePolicy",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "github-runners-test/LambdaARM/Image Digest Reader/CustomResourcePolicy/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::IAM::Policy",
+                          "aws:cdk:cloudformation:props": {
+                            "policyDocument": {
+                              "Statement": [
+                                {
+                                  "Action": "ecr:DescribeImages",
+                                  "Effect": "Allow",
+                                  "Resource": {
+                                    "Ref": "LambdaImageBuilderzBuilder235DD147"
+                                  }
+                                },
+                                {
+                                  "Action": "fake:Fake",
+                                  "Effect": "Allow",
+                                  "Resource": {
+                                    "Ref": "LambdaImageBuilderzBuilder235DD147"
+                                  }
+                                }
+                              ],
+                              "Version": "2012-10-17"
+                            },
+                            "policyName": "LambdaARMImageDigestReaderCustomResourcePolicy2980B36A",
+                            "roles": [
+                              {
+                                "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2"
+                              }
+                            ]
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
+                          "version": "2.29.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_iam.Policy",
+                      "version": "2.29.0"
+                    }
+                  },
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "github-runners-test/LambdaARM/Image Digest Reader/Resource",
+                    "children": {
+                      "Default": {
+                        "id": "Default",
+                        "path": "github-runners-test/LambdaARM/Image Digest Reader/Resource/Default",
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.CfnResource",
+                          "version": "2.29.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.CustomResource",
+                      "version": "2.29.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.custom_resources.AwsCustomResource",
+                  "version": "2.29.0"
+                }
+              },
               "Function": {
                 "id": "Function",
                 "path": "github-runners-test/LambdaARM/Function",
@@ -7398,13 +7744,26 @@
                                 },
                                 "/",
                                 {
-                                  "Ref": "LambdaImageBuilderzRepository7C7AD146"
+                                  "Fn::GetAtt": [
+                                    "LambdaImageBuilderzBuilder235DD147",
+                                    "Name"
+                                  ]
                                 },
                                 "@sha256:",
                                 {
-                                  "Fn::GetAtt": [
-                                    "LambdaImageBuilderzBuilder235DD147",
-                                    "Digest"
+                                  "Fn::Select": [
+                                    1,
+                                    {
+                                      "Fn::Split": [
+                                        ":",
+                                        {
+                                          "Fn::GetAtt": [
+                                            "LambdaARMImageDigestReaderF3DD55C4",
+                                            "imageDetails.0.imageDigest"
+                                          ]
+                                        }
+                                      ]
+                                    }
                                   ]
                                 }
                               ]
@@ -7608,7 +7967,10 @@
                                   },
                                   "/",
                                   {
-                                    "Ref": "FargatebuilderRepository8F7BA13C"
+                                    "Fn::GetAtt": [
+                                      "FargatebuilderBuilder0834CD0B",
+                                      "Name"
+                                    ]
                                   },
                                   ":latest"
                                 ]
@@ -7940,7 +8302,10 @@
                                   },
                                   "/",
                                   {
-                                    "Ref": "FargatebuilderRepository8F7BA13C"
+                                    "Fn::GetAtt": [
+                                      "FargatebuilderBuilder0834CD0B",
+                                      "Name"
+                                    ]
                                   },
                                   ":latest"
                                 ]
@@ -8272,7 +8637,10 @@
                                   },
                                   "/",
                                   {
-                                    "Ref": "FargatebuilderarmRepository77DCC132"
+                                    "Fn::GetAtt": [
+                                      "FargatebuilderarmBuilder48D1AF5A",
+                                      "Name"
+                                    ]
                                   },
                                   ":latest"
                                 ]
@@ -8604,7 +8972,10 @@
                                   },
                                   "/",
                                   {
-                                    "Ref": "FargatebuilderarmRepository77DCC132"
+                                    "Fn::GetAtt": [
+                                      "FargatebuilderarmBuilder48D1AF5A",
+                                      "Name"
+                                    ]
                                   },
                                   ":latest"
                                 ]
@@ -8941,23 +9312,7 @@
                                       }
                                     ]
                                   },
-                                  ":",
-                                  {
-                                    "Fn::Select": [
-                                      1,
-                                      {
-                                        "Fn::Split": [
-                                          ":",
-                                          {
-                                            "Fn::GetAtt": [
-                                              "WindowsImageBuilderImage7065BB07",
-                                              "ImageUri"
-                                            ]
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
+                                  ":latest"
                                 ]
                               ]
                             },


### PR DESCRIPTION
This affected Lambda runners and Windows runners.
We create images as part of the stack, but we also update them on a schedule and delete the old ones. That means any stack update that touches just the runner and not the image will fail. It will fail because the Lambda function or CodeBuild project will be updated, but the stack will still try to update it with the old image as it's not aware of the new image. This code forces the stack to always get the latest image digest for Lambda, even if the image wasn't created by the stack. On the Windows side, we just tell it to use the 'latest' tag, so we don't have to worry about this issue. That means it's now just a Lambda runner problem and can be confined in the Lambda runner code. Lambda is the only runner provider that needs a digest instead of a tag.

BREAKING CHANGE: RunnerImage.imageDigest was removed