### PR TITLE
fix: Avoid --disableupdate for better compatibility

### DIFF
--- a/API.md
+++ b/API.md
@@ -2629,16 +2629,6 @@ Provider running an image to run inside CodeBuild with GitHub runner pre-configu
 
 A user named `runner` is expected to exist.
 
-The entry point should start GitHub runner. For example:
-
-```
-#!/bin/bash
-set -e -u -o pipefail
-
-/home/runner/config.sh --unattended --url "https://${GITHUB_DOMAIN}/${OWNER}/${REPO}" --token "${RUNNER_TOKEN}" --ephemeral --work _work --labels "${RUNNER_LABEL}" ${RUNNER_FLAGS} --name "${RUNNER_NAME}"
-/home/runner/run.sh
-```
-
 ---
 
 ##### `label`<sup>Optional</sup> <a name="label" id="@cloudsnorkel/cdk-github-runners.FargateRunnerProps.property.label"></a>

--- a/API.md
+++ b/API.md
@@ -2635,7 +2635,7 @@ The entry point should start GitHub runner. For example:
 #!/bin/bash
 set -e -u -o pipefail
 
-/home/runner/config.sh --unattended --url "https://${GITHUB_DOMAIN}/${OWNER}/${REPO}" --token "${RUNNER_TOKEN}" --ephemeral --work _work --labels "${RUNNER_LABEL}" --disableupdate --name "${RUNNER_NAME}"
+/home/runner/config.sh --unattended --url "https://${GITHUB_DOMAIN}/${OWNER}/${REPO}" --token "${RUNNER_TOKEN}" --ephemeral --work _work --labels "${RUNNER_LABEL}" ${RUNNER_FLAGS} --name "${RUNNER_NAME}"
 /home/runner/run.sh
 ```
 

--- a/src/providers/codebuild.ts
+++ b/src/providers/codebuild.ts
@@ -159,7 +159,8 @@ export class CodeBuildRunner extends Construct implements IRunnerProvider {
           commands: [
             'nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay2 &',
             'timeout 15 sh -c "until docker info; do echo .; sleep 1; done"',
-            'sudo -Hu runner /home/runner/config.sh --unattended --url "https://${GITHUB_DOMAIN}/${OWNER}/${REPO}" --token "${RUNNER_TOKEN}" --ephemeral --work _work --labels "${RUNNER_LABEL}" --disableupdate --name "${RUNNER_NAME}"',
+            'if [ "${RUNNER_VERSION}" = "latest" ]; then RUNNER_FLAGS=""; else RUNNER_FLAGS="--disableupdate"; fi',
+            'sudo -Hu runner /home/runner/config.sh --unattended --url "https://${GITHUB_DOMAIN}/${OWNER}/${REPO}" --token "${RUNNER_TOKEN}" --ephemeral --work _work --labels "${RUNNER_LABEL}" ${RUNNER_FLAGS} --name "${RUNNER_NAME}"',
           ],
         },
         build: {
@@ -178,7 +179,8 @@ export class CodeBuildRunner extends Construct implements IRunnerProvider {
     if (image.os.is(Os.WINDOWS)) {
       buildSpec.phases.install.commands = [
         'cd \\actions',
-        './config.cmd --unattended --url "https://${Env:GITHUB_DOMAIN}/${Env:OWNER}/${Env:REPO}" --token "${Env:RUNNER_TOKEN}" --ephemeral --work _work --labels "${Env:RUNNER_LABEL}" --disableupdate --name "${Env:RUNNER_NAME}"',
+        'if (${Env:RUNNER_VERSION} -eq "latest") { $RunnerFlags = "" } else { $RunnerFlags = "--disableupdate" }',
+        './config.cmd --unattended --url "https://${Env:GITHUB_DOMAIN}/${Env:OWNER}/${Env:REPO}" --token "${Env:RUNNER_TOKEN}" --ephemeral --work _work --labels "${Env:RUNNER_LABEL}" ${RunnerFlags} --name "${Env:RUNNER_NAME}"',
       ];
       buildSpec.phases.build.commands = [
         'cd \\actions',

--- a/src/providers/docker-images/codebuild/linux-arm64/Dockerfile
+++ b/src/providers/docker-images/codebuild/linux-arm64/Dockerfile
@@ -32,6 +32,7 @@ WORKDIR /home/runner
 
 # add runner without github's api which is rate limited
 ARG RUNNER_VERSION=latest
+ENV RUNNER_VERSION=${RUNNER_VERSION}
 RUN if [ "$RUNNER_VERSION" = "latest" ]; then RUNNER_VERSION=`curl  -w "%{redirect_url}" -fsS https://github.com/actions/runner/releases/latest | grep -oE "[^/v]+$"`; fi && \
     curl -fsSLO  "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-arm64-${RUNNER_VERSION}.tar.gz" && \
     tar xzf "actions-runner-linux-arm64-${RUNNER_VERSION}.tar.gz" && \

--- a/src/providers/docker-images/codebuild/linux-x64/Dockerfile
+++ b/src/providers/docker-images/codebuild/linux-x64/Dockerfile
@@ -32,6 +32,7 @@ WORKDIR /home/runner
 
 # add runner without github's api which is rate limited
 ARG RUNNER_VERSION=latest
+ENV RUNNER_VERSION=${RUNNER_VERSION}
 RUN if [ "${RUNNER_VERSION}" = "latest" ]; then RUNNER_VERSION=`curl  -w "%{redirect_url}" -fsS https://github.com/actions/runner/releases/latest | grep -oE "[^/v]+$"`; fi && \
     curl -fsSLO  "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" && \
     tar xzf "actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" && \

--- a/src/providers/docker-images/fargate/linux-arm64/Dockerfile
+++ b/src/providers/docker-images/fargate/linux-arm64/Dockerfile
@@ -32,6 +32,7 @@ WORKDIR /home/runner
 
 # add runner without github's api which is rate limited
 ARG RUNNER_VERSION=latest
+ENV RUNNER_VERSION=${RUNNER_VERSION}
 RUN if [ "${RUNNER_VERSION}" = "latest" ]; then RUNNER_VERSION=`curl  -w "%{redirect_url}" -fsS https://github.com/actions/runner/releases/latest | grep -oE "[^/v]+$"`; fi && \
     curl -fsSLO  "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-arm64-${RUNNER_VERSION}.tar.gz" && \
     tar xzf "actions-runner-linux-arm64-${RUNNER_VERSION}.tar.gz" && \

--- a/src/providers/docker-images/fargate/linux-x64/Dockerfile
+++ b/src/providers/docker-images/fargate/linux-x64/Dockerfile
@@ -32,6 +32,7 @@ WORKDIR /home/runner
 
 # add runner without github's api which is rate limited
 ARG RUNNER_VERSION=latest
+ENV RUNNER_VERSION=${RUNNER_VERSION}
 RUN if [ "${RUNNER_VERSION}" = "latest" ]; then RUNNER_VERSION=`curl  -w "%{redirect_url}" -fsS https://github.com/actions/runner/releases/latest | grep -oE "[^/v]+$"`; fi && \
     curl -fsSLO  "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" && \
     tar xzf "actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" && \

--- a/src/providers/docker-images/lambda/linux-arm64/Dockerfile
+++ b/src/providers/docker-images/lambda/linux-arm64/Dockerfile
@@ -23,6 +23,7 @@ RUN curl -fsSSL https://cli.github.com/packages/rpm/gh-cli.repo -o /etc/yum.repo
 
 # add runner without github's api which is rate limited
 ARG RUNNER_VERSION=latest
+ENV RUNNER_VERSION=${RUNNER_VERSION}
 RUN if [ "${RUNNER_VERSION}" = "latest" ]; then RUNNER_VERSION=`curl  -w "%{redirect_url}" -fsS https://github.com/actions/runner/releases/latest | grep -oE "[^/v]+$"`; fi && \
     curl -fsSLO  "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-arm64-${RUNNER_VERSION}.tar.gz" && \
     tar xzf "actions-runner-linux-arm64-${RUNNER_VERSION}.tar.gz" && \

--- a/src/providers/docker-images/lambda/linux-arm64/runner.sh
+++ b/src/providers/docker-images/lambda/linux-arm64/runner.sh
@@ -5,7 +5,8 @@ set -e -u -o pipefail
 cp -r /runner /tmp/
 cd /tmp/runner
 
-./config.sh --unattended --url "https://${GITHUB_DOMAIN}/${OWNER}/${REPO}" --token "${RUNNER_TOKEN}" --ephemeral --work _work --labels "${RUNNER_LABEL}" --name "${RUNNER_NAME}" --disableupdate
+if [ "${RUNNER_VERSION}" = "latest" ]; then RUNNER_FLAGS=""; else RUNNER_FLAGS="--disableupdate"; fi
+./config.sh --unattended --url "https://${GITHUB_DOMAIN}/${OWNER}/${REPO}" --token "${RUNNER_TOKEN}" --ephemeral --work _work --labels "${RUNNER_LABEL}" --name "${RUNNER_NAME}" ${RUNNER_FLAGS}
 echo Config done
 ./run.sh
 echo Run done

--- a/src/providers/docker-images/lambda/linux-x64/Dockerfile
+++ b/src/providers/docker-images/lambda/linux-x64/Dockerfile
@@ -23,6 +23,7 @@ RUN curl -fsSSL https://cli.github.com/packages/rpm/gh-cli.repo -o /etc/yum.repo
 
 # add runner without github's api which is rate limited
 ARG RUNNER_VERSION=latest
+ENV RUNNER_VERSION=${RUNNER_VERSION}
 RUN if [ "${RUNNER_VERSION}" = "latest" ]; then RUNNER_VERSION=`curl  -w "%{redirect_url}" -fsS https://github.com/actions/runner/releases/latest | grep -oE "[^/v]+$"`; fi && \
     curl -fsSLO "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" && \
     tar xzf "actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" && \

--- a/src/providers/docker-images/lambda/linux-x64/runner.sh
+++ b/src/providers/docker-images/lambda/linux-x64/runner.sh
@@ -5,7 +5,8 @@ set -e -u -o pipefail
 cp -r /runner /tmp/
 cd /tmp/runner
 
-./config.sh --unattended --url "https://${GITHUB_DOMAIN}/${OWNER}/${REPO}" --token "${RUNNER_TOKEN}" --ephemeral --work _work --labels "${RUNNER_LABEL}" --name "${RUNNER_NAME}" --disableupdate
+if [ "${RUNNER_VERSION}" = "latest" ]; then RUNNER_FLAGS=""; else RUNNER_FLAGS="--disableupdate"; fi
+./config.sh --unattended --url "https://${GITHUB_DOMAIN}/${OWNER}/${REPO}" --token "${RUNNER_TOKEN}" --ephemeral --work _work --labels "${RUNNER_LABEL}" --name "${RUNNER_NAME}" ${RUNNER_FLAGS}
 echo Config done
 ./run.sh
 echo Run done

--- a/src/providers/fargate.ts
+++ b/src/providers/fargate.ts
@@ -21,16 +21,6 @@ export interface FargateRunnerProps extends RunnerProviderProps {
   /**
    * Provider running an image to run inside CodeBuild with GitHub runner pre-configured. A user named `runner` is expected to exist.
    *
-   * The entry point should start GitHub runner. For example:
-   *
-   * ```
-   * #!/bin/bash
-   * set -e -u -o pipefail
-   *
-   * /home/runner/config.sh --unattended --url "https://${GITHUB_DOMAIN}/${OWNER}/${REPO}" --token "${RUNNER_TOKEN}" --ephemeral --work _work --labels "${RUNNER_LABEL}" ${RUNNER_FLAGS} --name "${RUNNER_NAME}"
-   * /home/runner/run.sh
-   * ```
-   *
    * @default image builder with `FargateRunner.LINUX_X64_DOCKERFILE_PATH` as Dockerfile
    */
   readonly imageBuilder?: IImageBuilder;

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -1,41 +1,41 @@
 {
   "version": "20.0.0",
   "files": {
-    "f21a107de9aaed0625532057c2f8259320d99d5185adcaece346941d88d04250": {
+    "ff33ef8c42c19a3b1919fad5b849b69b1979dcfaceb2eb58695b4f124e16a818": {
       "source": {
-        "path": "asset.f21a107de9aaed0625532057c2f8259320d99d5185adcaece346941d88d04250",
+        "path": "asset.ff33ef8c42c19a3b1919fad5b849b69b1979dcfaceb2eb58695b4f124e16a818",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "f21a107de9aaed0625532057c2f8259320d99d5185adcaece346941d88d04250.zip",
+          "objectKey": "ff33ef8c42c19a3b1919fad5b849b69b1979dcfaceb2eb58695b4f124e16a818.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "c7602b829f7a84e4b86e023a450c177a3e502b09bfabd905df981b666c626443": {
+    "0b985e7436349a499cd2e6551aa8c08f3a42276bfdaf949f98be4d3af2c33de3": {
       "source": {
-        "path": "asset.c7602b829f7a84e4b86e023a450c177a3e502b09bfabd905df981b666c626443",
+        "path": "asset.0b985e7436349a499cd2e6551aa8c08f3a42276bfdaf949f98be4d3af2c33de3",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "c7602b829f7a84e4b86e023a450c177a3e502b09bfabd905df981b666c626443.zip",
+          "objectKey": "0b985e7436349a499cd2e6551aa8c08f3a42276bfdaf949f98be4d3af2c33de3.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "7446727c79e655948a19c286c7344d79c1ab4a7b8906e31ab99cf2190c39ec8b": {
+    "719a3a6918de22e066f2368ac5b23e039f9611031fab1754dfda06eff0c0d6bb": {
       "source": {
-        "path": "asset.7446727c79e655948a19c286c7344d79c1ab4a7b8906e31ab99cf2190c39ec8b",
+        "path": "asset.719a3a6918de22e066f2368ac5b23e039f9611031fab1754dfda06eff0c0d6bb",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "7446727c79e655948a19c286c7344d79c1ab4a7b8906e31ab99cf2190c39ec8b.zip",
+          "objectKey": "719a3a6918de22e066f2368ac5b23e039f9611031fab1754dfda06eff0c0d6bb.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -66,15 +66,15 @@
         }
       }
     },
-    "c4b5dd5601c4f93574b8d50cf9c3535d4790187c10d927aee7b842afa7dd78c0": {
+    "5ddcf0270bec799efcd364faedadaa445365fef56d807626d8708ab83f24f7e2": {
       "source": {
-        "path": "asset.c4b5dd5601c4f93574b8d50cf9c3535d4790187c10d927aee7b842afa7dd78c0",
+        "path": "asset.5ddcf0270bec799efcd364faedadaa445365fef56d807626d8708ab83f24f7e2",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "c4b5dd5601c4f93574b8d50cf9c3535d4790187c10d927aee7b842afa7dd78c0.zip",
+          "objectKey": "5ddcf0270bec799efcd364faedadaa445365fef56d807626d8708ab83f24f7e2.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -92,15 +92,15 @@
         }
       }
     },
-    "a4439209261897e0fdef1079c134580fe74403f8f7f6254638ffa5ddc456e0a2": {
+    "b26ba58062e07311ed57d94ceb9332e828312745abd3718f2d296206e9ec05c2": {
       "source": {
-        "path": "asset.a4439209261897e0fdef1079c134580fe74403f8f7f6254638ffa5ddc456e0a2",
+        "path": "asset.b26ba58062e07311ed57d94ceb9332e828312745abd3718f2d296206e9ec05c2",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "a4439209261897e0fdef1079c134580fe74403f8f7f6254638ffa5ddc456e0a2.zip",
+          "objectKey": "b26ba58062e07311ed57d94ceb9332e828312745abd3718f2d296206e9ec05c2.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -131,15 +131,15 @@
         }
       }
     },
-    "d5545963484b1928f0ce61ce92cbf507d5c906258787f5d1c662525f5b02f03a": {
+    "fd74efb11a23e888bfdda26033271f933286246b5b17741e787125a962a76dcc": {
       "source": {
-        "path": "asset.d5545963484b1928f0ce61ce92cbf507d5c906258787f5d1c662525f5b02f03a",
+        "path": "asset.fd74efb11a23e888bfdda26033271f933286246b5b17741e787125a962a76dcc",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "d5545963484b1928f0ce61ce92cbf507d5c906258787f5d1c662525f5b02f03a.zip",
+          "objectKey": "fd74efb11a23e888bfdda26033271f933286246b5b17741e787125a962a76dcc.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -209,7 +209,7 @@
         }
       }
     },
-    "933df9d2e53b106de344ecd201740c9c8c3682c66dc00c26ca3d22a121b3235f": {
+    "12ae2d0e88d6fd5e2ccc66859915d800ddb920fd720aa427d2191cdaf6976404": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -217,7 +217,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "933df9d2e53b106de344ecd201740c9c8c3682c66dc00c26ca3d22a121b3235f.json",
+          "objectKey": "12ae2d0e88d6fd5e2ccc66859915d800ddb920fd720aa427d2191cdaf6976404.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -209,7 +209,7 @@
         }
       }
     },
-    "12ae2d0e88d6fd5e2ccc66859915d800ddb920fd720aa427d2191cdaf6976404": {
+    "48c35b5eff6568fca0f13cbdd1edbe25ec3ce4bf19ba9b1db3d0aecf408a40c0": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -217,7 +217,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "12ae2d0e88d6fd5e2ccc66859915d800ddb920fd720aa427d2191cdaf6976404.json",
+          "objectKey": "48c35b5eff6568fca0f13cbdd1edbe25ec3ce4bf19ba9b1db3d0aecf408a40c0.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -2184,7 +2184,8 @@
         ]
        }
       }
-     ]
+     ],
+     "dockerfileTemplate": "FROM {{{ imagebuilder:parentImage }}}\nENV RUNNER_VERSION=___RUNNER_VERSION___\n{{{ imagebuilder:environments }}}\n{{{ imagebuilder:components }}}"
     }
    },
    "UpdateReplacePolicy": "Retain",
@@ -2239,7 +2240,7 @@
     "Version": {
      "Ref": "WindowsImageBuilderContainerRecipeVersion13A2E3FD"
     },
-    "DockerfileTemplateData": "FROM {{{ imagebuilder:parentImage }}}\n{{{ imagebuilder:environments }}}\n{{{ imagebuilder:components }}}"
+    "DockerfileTemplateData": "FROM {{{ imagebuilder:parentImage }}}\nENV RUNNER_VERSION=latest\n{{{ imagebuilder:environments }}}\n{{{ imagebuilder:components }}}"
    }
   },
   "WindowsImageBuilderLog0E03408E": {
@@ -4392,7 +4393,7 @@
      ]
     },
     "Source": {
-     "BuildSpec": "{\n  \"version\": \"0.2\",\n  \"env\": {\n    \"variables\": {\n      \"RUNNER_TOKEN\": \"unspecified\",\n      \"RUNNER_NAME\": \"unspecified\",\n      \"RUNNER_LABEL\": \"unspecified\",\n      \"OWNER\": \"unspecified\",\n      \"REPO\": \"unspecified\",\n      \"GITHUB_DOMAIN\": \"github.com\"\n    }\n  },\n  \"phases\": {\n    \"install\": {\n      \"commands\": [\n        \"cd \\\\actions\",\n        \"if (${Env:RUNNER_VERSION} -eq \\\"latest\\\") { $RunnerFlags = \\\"\\\" } else  { $RunnerFlags = \\\"--disableupdate\\\" }\",\n        \"./config.cmd --unattended --url \\\"https://${Env:GITHUB_DOMAIN}/${Env:OWNER}/${Env:REPO}\\\" --token \\\"${Env:RUNNER_TOKEN}\\\" --ephemeral --work _work --labels \\\"${Env:RUNNER_LABEL}\\\" ${RunnerFlags} --name \\\"${Env:RUNNER_NAME}\\\"\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"cd \\\\actions\",\n        \"./run.cmd\"\n      ]\n    }\n  }\n}",
+     "BuildSpec": "{\n  \"version\": \"0.2\",\n  \"env\": {\n    \"variables\": {\n      \"RUNNER_TOKEN\": \"unspecified\",\n      \"RUNNER_NAME\": \"unspecified\",\n      \"RUNNER_LABEL\": \"unspecified\",\n      \"OWNER\": \"unspecified\",\n      \"REPO\": \"unspecified\",\n      \"GITHUB_DOMAIN\": \"github.com\"\n    }\n  },\n  \"phases\": {\n    \"install\": {\n      \"commands\": [\n        \"cd \\\\actions\",\n        \"if (${Env:RUNNER_VERSION} -eq \\\"latest\\\") { $RunnerFlags = \\\"\\\" } else { $RunnerFlags = \\\"--disableupdate\\\" }\",\n        \"./config.cmd --unattended --url \\\"https://${Env:GITHUB_DOMAIN}/${Env:OWNER}/${Env:REPO}\\\" --token \\\"${Env:RUNNER_TOKEN}\\\" --ephemeral --work _work --labels \\\"${Env:RUNNER_LABEL}\\\" ${RunnerFlags} --name \\\"${Env:RUNNER_NAME}\\\"\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"cd \\\\actions\",\n        \"./run.cmd\"\n      ]\n    }\n  }\n}",
      "Type": "NO_SOURCE"
     },
     "Cache": {

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -276,7 +276,7 @@
            {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
            },
-           "/f21a107de9aaed0625532057c2f8259320d99d5185adcaece346941d88d04250.zip"
+           "/ff33ef8c42c19a3b1919fad5b849b69b1979dcfaceb2eb58695b4f124e16a818.zip"
           ]
          ]
         }
@@ -523,7 +523,7 @@
         {
          "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
         },
-        "/f21a107de9aaed0625532057c2f8259320d99d5185adcaece346941d88d04250.zip"
+        "/ff33ef8c42c19a3b1919fad5b849b69b1979dcfaceb2eb58695b4f124e16a818.zip"
        ]
       ]
      },
@@ -642,7 +642,7 @@
     "ProjectName": {
      "Ref": "FargatebuilderCodeBuild4F182743"
     },
-    "BuildHash": "84e62f8c69563bae535b19891eb2d8d9"
+    "BuildHash": "8affc8f3de4718144ff0af63bd8dcf5f"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
@@ -772,7 +772,7 @@
            {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
            },
-           "/c7602b829f7a84e4b86e023a450c177a3e502b09bfabd905df981b666c626443.zip"
+           "/0b985e7436349a499cd2e6551aa8c08f3a42276bfdaf949f98be4d3af2c33de3.zip"
           ]
          ]
         }
@@ -1019,7 +1019,7 @@
         {
          "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
         },
-        "/c7602b829f7a84e4b86e023a450c177a3e502b09bfabd905df981b666c626443.zip"
+        "/0b985e7436349a499cd2e6551aa8c08f3a42276bfdaf949f98be4d3af2c33de3.zip"
        ]
       ]
      },
@@ -1138,7 +1138,7 @@
     "ProjectName": {
      "Ref": "FargatebuilderarmCodeBuild0D30679A"
     },
-    "BuildHash": "2d3997ab554ef29cf77733b310a789cc"
+    "BuildHash": "1171f8fa4f9411bb8697b12c1e9aef43"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
@@ -1268,7 +1268,7 @@
            {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
            },
-           "/7446727c79e655948a19c286c7344d79c1ab4a7b8906e31ab99cf2190c39ec8b.zip"
+           "/719a3a6918de22e066f2368ac5b23e039f9611031fab1754dfda06eff0c0d6bb.zip"
           ]
          ]
         }
@@ -1515,7 +1515,7 @@
         {
          "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
         },
-        "/7446727c79e655948a19c286c7344d79c1ab4a7b8906e31ab99cf2190c39ec8b.zip"
+        "/719a3a6918de22e066f2368ac5b23e039f9611031fab1754dfda06eff0c0d6bb.zip"
        ]
       ]
      },
@@ -1634,7 +1634,7 @@
     "ProjectName": {
      "Ref": "LambdaImageBuilderx64CodeBuild67DE14C8"
     },
-    "BuildHash": "eaa96ce15b72dc85f22384ecc97a4fe3"
+    "BuildHash": "e8d775eac5342969483f58e2360f7988"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
@@ -2637,7 +2637,7 @@
            {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
            },
-           "/c4b5dd5601c4f93574b8d50cf9c3535d4790187c10d927aee7b842afa7dd78c0.zip"
+           "/5ddcf0270bec799efcd364faedadaa445365fef56d807626d8708ab83f24f7e2.zip"
           ]
          ]
         }
@@ -2884,7 +2884,7 @@
         {
          "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
         },
-        "/c4b5dd5601c4f93574b8d50cf9c3535d4790187c10d927aee7b842afa7dd78c0.zip"
+        "/5ddcf0270bec799efcd364faedadaa445365fef56d807626d8708ab83f24f7e2.zip"
        ]
       ]
      },
@@ -3003,7 +3003,7 @@
     "ProjectName": {
      "Ref": "CodeBuildImageBuilderCodeBuild38ECAA44"
     },
-    "BuildHash": "0b4538e9f81f7be565dcc14e8d9262b6"
+    "BuildHash": "bcc37749b240f693243cc0c20ca90945"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
@@ -3280,7 +3280,7 @@
      ]
     },
     "Source": {
-     "BuildSpec": "{\n  \"version\": \"0.2\",\n  \"env\": {\n    \"variables\": {\n      \"RUNNER_TOKEN\": \"unspecified\",\n      \"RUNNER_NAME\": \"unspecified\",\n      \"RUNNER_LABEL\": \"unspecified\",\n      \"OWNER\": \"unspecified\",\n      \"REPO\": \"unspecified\",\n      \"GITHUB_DOMAIN\": \"github.com\"\n    }\n  },\n  \"phases\": {\n    \"install\": {\n      \"commands\": [\n        \"nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay2 &\",\n        \"timeout 15 sh -c \\\"until docker info; do echo .; sleep 1; done\\\"\",\n        \"sudo -Hu runner /home/runner/config.sh --unattended --url \\\"https://${GITHUB_DOMAIN}/${OWNER}/${REPO}\\\" --token \\\"${RUNNER_TOKEN}\\\" --ephemeral --work _work --labels \\\"${RUNNER_LABEL}\\\" --disableupdate --name \\\"${RUNNER_NAME}\\\"\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"sudo --preserve-env=AWS_CONTAINER_CREDENTIALS_RELATIVE_URI,AWS_DEFAULT_REGION,AWS_REGION -Hu runner /home/runner/run.sh\"\n      ]\n    }\n  }\n}",
+     "BuildSpec": "{\n  \"version\": \"0.2\",\n  \"env\": {\n    \"variables\": {\n      \"RUNNER_TOKEN\": \"unspecified\",\n      \"RUNNER_NAME\": \"unspecified\",\n      \"RUNNER_LABEL\": \"unspecified\",\n      \"OWNER\": \"unspecified\",\n      \"REPO\": \"unspecified\",\n      \"GITHUB_DOMAIN\": \"github.com\"\n    }\n  },\n  \"phases\": {\n    \"install\": {\n      \"commands\": [\n        \"nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay2 &\",\n        \"timeout 15 sh -c \\\"until docker info; do echo .; sleep 1; done\\\"\",\n        \"if [ \\\"${RUNNER_VERSION}\\\" = \\\"latest\\\" ]; then RUNNER_FLAGS=\\\"\\\"; else RUNNER_FLAGS=\\\"--disableupdate\\\"; fi\",\n        \"sudo -Hu runner /home/runner/config.sh --unattended --url \\\"https://${GITHUB_DOMAIN}/${OWNER}/${REPO}\\\" --token \\\"${RUNNER_TOKEN}\\\" --ephemeral --work _work --labels \\\"${RUNNER_LABEL}\\\" ${RUNNER_FLAGS} --name \\\"${RUNNER_NAME}\\\"\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"sudo --preserve-env=AWS_CONTAINER_CREDENTIALS_RELATIVE_URI,AWS_DEFAULT_REGION,AWS_REGION -Hu runner /home/runner/run.sh\"\n      ]\n    }\n  }\n}",
      "Type": "NO_SOURCE"
     },
     "Cache": {
@@ -3461,7 +3461,7 @@
            {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
            },
-           "/a4439209261897e0fdef1079c134580fe74403f8f7f6254638ffa5ddc456e0a2.zip"
+           "/b26ba58062e07311ed57d94ceb9332e828312745abd3718f2d296206e9ec05c2.zip"
           ]
          ]
         }
@@ -3708,7 +3708,7 @@
         {
          "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
         },
-        "/a4439209261897e0fdef1079c134580fe74403f8f7f6254638ffa5ddc456e0a2.zip"
+        "/b26ba58062e07311ed57d94ceb9332e828312745abd3718f2d296206e9ec05c2.zip"
        ]
       ]
      },
@@ -3827,7 +3827,7 @@
     "ProjectName": {
      "Ref": "CodeBuildImageBuilderarmCodeBuildBFF1CF57"
     },
-    "BuildHash": "47a14734b6c82106bf93065189b63919"
+    "BuildHash": "3d283b75287ed60448084cdac876d376"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
@@ -4104,7 +4104,7 @@
      ]
     },
     "Source": {
-     "BuildSpec": "{\n  \"version\": \"0.2\",\n  \"env\": {\n    \"variables\": {\n      \"RUNNER_TOKEN\": \"unspecified\",\n      \"RUNNER_NAME\": \"unspecified\",\n      \"RUNNER_LABEL\": \"unspecified\",\n      \"OWNER\": \"unspecified\",\n      \"REPO\": \"unspecified\",\n      \"GITHUB_DOMAIN\": \"github.com\"\n    }\n  },\n  \"phases\": {\n    \"install\": {\n      \"commands\": [\n        \"nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay2 &\",\n        \"timeout 15 sh -c \\\"until docker info; do echo .; sleep 1; done\\\"\",\n        \"sudo -Hu runner /home/runner/config.sh --unattended --url \\\"https://${GITHUB_DOMAIN}/${OWNER}/${REPO}\\\" --token \\\"${RUNNER_TOKEN}\\\" --ephemeral --work _work --labels \\\"${RUNNER_LABEL}\\\" --disableupdate --name \\\"${RUNNER_NAME}\\\"\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"sudo --preserve-env=AWS_CONTAINER_CREDENTIALS_RELATIVE_URI,AWS_DEFAULT_REGION,AWS_REGION -Hu runner /home/runner/run.sh\"\n      ]\n    }\n  }\n}",
+     "BuildSpec": "{\n  \"version\": \"0.2\",\n  \"env\": {\n    \"variables\": {\n      \"RUNNER_TOKEN\": \"unspecified\",\n      \"RUNNER_NAME\": \"unspecified\",\n      \"RUNNER_LABEL\": \"unspecified\",\n      \"OWNER\": \"unspecified\",\n      \"REPO\": \"unspecified\",\n      \"GITHUB_DOMAIN\": \"github.com\"\n    }\n  },\n  \"phases\": {\n    \"install\": {\n      \"commands\": [\n        \"nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay2 &\",\n        \"timeout 15 sh -c \\\"until docker info; do echo .; sleep 1; done\\\"\",\n        \"if [ \\\"${RUNNER_VERSION}\\\" = \\\"latest\\\" ]; then RUNNER_FLAGS=\\\"\\\"; else RUNNER_FLAGS=\\\"--disableupdate\\\"; fi\",\n        \"sudo -Hu runner /home/runner/config.sh --unattended --url \\\"https://${GITHUB_DOMAIN}/${OWNER}/${REPO}\\\" --token \\\"${RUNNER_TOKEN}\\\" --ephemeral --work _work --labels \\\"${RUNNER_LABEL}\\\" ${RUNNER_FLAGS} --name \\\"${RUNNER_NAME}\\\"\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"sudo --preserve-env=AWS_CONTAINER_CREDENTIALS_RELATIVE_URI,AWS_DEFAULT_REGION,AWS_REGION -Hu runner /home/runner/run.sh\"\n      ]\n    }\n  }\n}",
      "Type": "NO_SOURCE"
     },
     "Cache": {
@@ -4392,7 +4392,7 @@
      ]
     },
     "Source": {
-     "BuildSpec": "{\n  \"version\": \"0.2\",\n  \"env\": {\n    \"variables\": {\n      \"RUNNER_TOKEN\": \"unspecified\",\n      \"RUNNER_NAME\": \"unspecified\",\n      \"RUNNER_LABEL\": \"unspecified\",\n      \"OWNER\": \"unspecified\",\n      \"REPO\": \"unspecified\",\n      \"GITHUB_DOMAIN\": \"github.com\"\n    }\n  },\n  \"phases\": {\n    \"install\": {\n      \"commands\": [\n        \"cd \\\\actions\",\n        \"./config.cmd --unattended --url \\\"https://${Env:GITHUB_DOMAIN}/${Env:OWNER}/${Env:REPO}\\\" --token \\\"${Env:RUNNER_TOKEN}\\\" --ephemeral --work _work --labels \\\"${Env:RUNNER_LABEL}\\\" --disableupdate --name \\\"${Env:RUNNER_NAME}\\\"\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"cd \\\\actions\",\n        \"./run.cmd\"\n      ]\n    }\n  }\n}",
+     "BuildSpec": "{\n  \"version\": \"0.2\",\n  \"env\": {\n    \"variables\": {\n      \"RUNNER_TOKEN\": \"unspecified\",\n      \"RUNNER_NAME\": \"unspecified\",\n      \"RUNNER_LABEL\": \"unspecified\",\n      \"OWNER\": \"unspecified\",\n      \"REPO\": \"unspecified\",\n      \"GITHUB_DOMAIN\": \"github.com\"\n    }\n  },\n  \"phases\": {\n    \"install\": {\n      \"commands\": [\n        \"cd \\\\actions\",\n        \"if (${Env:RUNNER_VERSION} -eq \\\"latest\\\") { $RunnerFlags = \\\"\\\" } else  { $RunnerFlags = \\\"--disableupdate\\\" }\",\n        \"./config.cmd --unattended --url \\\"https://${Env:GITHUB_DOMAIN}/${Env:OWNER}/${Env:REPO}\\\" --token \\\"${Env:RUNNER_TOKEN}\\\" --ephemeral --work _work --labels \\\"${Env:RUNNER_LABEL}\\\" ${RunnerFlags} --name \\\"${Env:RUNNER_NAME}\\\"\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"cd \\\\actions\",\n        \"./run.cmd\"\n      ]\n    }\n  }\n}",
      "Type": "NO_SOURCE"
     },
     "Cache": {
@@ -4907,7 +4907,7 @@
            {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
            },
-           "/d5545963484b1928f0ce61ce92cbf507d5c906258787f5d1c662525f5b02f03a.zip"
+           "/fd74efb11a23e888bfdda26033271f933286246b5b17741e787125a962a76dcc.zip"
           ]
          ]
         }
@@ -5154,7 +5154,7 @@
         {
          "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
         },
-        "/d5545963484b1928f0ce61ce92cbf507d5c906258787f5d1c662525f5b02f03a.zip"
+        "/fd74efb11a23e888bfdda26033271f933286246b5b17741e787125a962a76dcc.zip"
        ]
       ]
      },
@@ -5273,7 +5273,7 @@
     "ProjectName": {
      "Ref": "LambdaImageBuilderzCodeBuild73AB6718"
     },
-    "BuildHash": "89d0e063b61fa8205d0feded9ad0a71a"
+    "BuildHash": "ebec5b5647daac71caebd61e9fb48bb5"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
@@ -5700,7 +5700,7 @@
       "Command": [
        "sh",
        "-c",
-       "./config.sh --unattended --url \"https://${GITHUB_DOMAIN}/${OWNER}/${REPO}\" --token \"${RUNNER_TOKEN}\" --ephemeral --work _work --labels \"${RUNNER_LABEL}\" --disableupdate --name \"${RUNNER_NAME}\" && ./run.sh"
+       "if [ \"${RUNNER_VERSION}\" = \"latest\" ]; then RUNNER_FLAGS=\"\"; else RUNNER_FLAGS=\"--disableupdate\"; fi && ./config.sh --unattended --url \"https://${GITHUB_DOMAIN}/${OWNER}/${REPO}\" --token \"${RUNNER_TOKEN}\" --ephemeral --work _work --labels \"${RUNNER_LABEL}\" ${RUNNER_FLAGS} --name \"${RUNNER_NAME}\" && ./run.sh"
       ],
       "Essential": true,
       "Image": {
@@ -5903,7 +5903,7 @@
       "Command": [
        "sh",
        "-c",
-       "./config.sh --unattended --url \"https://${GITHUB_DOMAIN}/${OWNER}/${REPO}\" --token \"${RUNNER_TOKEN}\" --ephemeral --work _work --labels \"${RUNNER_LABEL}\" --disableupdate --name \"${RUNNER_NAME}\" && ./run.sh"
+       "if [ \"${RUNNER_VERSION}\" = \"latest\" ]; then RUNNER_FLAGS=\"\"; else RUNNER_FLAGS=\"--disableupdate\"; fi && ./config.sh --unattended --url \"https://${GITHUB_DOMAIN}/${OWNER}/${REPO}\" --token \"${RUNNER_TOKEN}\" --ephemeral --work _work --labels \"${RUNNER_LABEL}\" ${RUNNER_FLAGS} --name \"${RUNNER_NAME}\" && ./run.sh"
       ],
       "Essential": true,
       "Image": {
@@ -6106,7 +6106,7 @@
       "Command": [
        "sh",
        "-c",
-       "./config.sh --unattended --url \"https://${GITHUB_DOMAIN}/${OWNER}/${REPO}\" --token \"${RUNNER_TOKEN}\" --ephemeral --work _work --labels \"${RUNNER_LABEL}\" --disableupdate --name \"${RUNNER_NAME}\" && ./run.sh"
+       "if [ \"${RUNNER_VERSION}\" = \"latest\" ]; then RUNNER_FLAGS=\"\"; else RUNNER_FLAGS=\"--disableupdate\"; fi && ./config.sh --unattended --url \"https://${GITHUB_DOMAIN}/${OWNER}/${REPO}\" --token \"${RUNNER_TOKEN}\" --ephemeral --work _work --labels \"${RUNNER_LABEL}\" ${RUNNER_FLAGS} --name \"${RUNNER_NAME}\" && ./run.sh"
       ],
       "Essential": true,
       "Image": {
@@ -6309,7 +6309,7 @@
       "Command": [
        "sh",
        "-c",
-       "./config.sh --unattended --url \"https://${GITHUB_DOMAIN}/${OWNER}/${REPO}\" --token \"${RUNNER_TOKEN}\" --ephemeral --work _work --labels \"${RUNNER_LABEL}\" --disableupdate --name \"${RUNNER_NAME}\" && ./run.sh"
+       "if [ \"${RUNNER_VERSION}\" = \"latest\" ]; then RUNNER_FLAGS=\"\"; else RUNNER_FLAGS=\"--disableupdate\"; fi && ./config.sh --unattended --url \"https://${GITHUB_DOMAIN}/${OWNER}/${REPO}\" --token \"${RUNNER_TOKEN}\" --ephemeral --work _work --labels \"${RUNNER_LABEL}\" ${RUNNER_FLAGS} --name \"${RUNNER_NAME}\" && ./run.sh"
       ],
       "Essential": true,
       "Image": {
@@ -6512,7 +6512,7 @@
       "Command": [
        "powershell",
        "-Command",
-       "cd \\actions ; ./config.cmd --unattended --url \"https://${Env:GITHUB_DOMAIN}/${Env:OWNER}/${Env:REPO}\" --token \"${Env:RUNNER_TOKEN}\" --ephemeral --work _work --labels \"${Env:RUNNER_LABEL}\" --disableupdate --name \"${Env:RUNNER_NAME}\" ; ./run.cmd"
+       "if (${Env:RUNNER_VERSION} -eq \"latest\") { $RunnerFlags = \"\" } else { $RunnerFlags = \"--disableupdate\" } ; cd \\actions ; ./config.cmd --unattended --url \"https://${Env:GITHUB_DOMAIN}/${Env:OWNER}/${Env:REPO}\" --token \"${Env:RUNNER_TOKEN}\" --ephemeral --work _work --labels \"${Env:RUNNER_LABEL}\" ${RunnerFlags} --name \"${Env:RUNNER_NAME}\" ; ./run.cmd"
       ],
       "Essential": true,
       "Image": {

--- a/test/default.integ.snapshot/manifest.json
+++ b/test/default.integ.snapshot/manifest.json
@@ -23,7 +23,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/933df9d2e53b106de344ecd201740c9c8c3682c66dc00c26ca3d22a121b3235f.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/12ae2d0e88d6fd5e2ccc66859915d800ddb920fd720aa427d2191cdaf6976404.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/default.integ.snapshot/manifest.json
+++ b/test/default.integ.snapshot/manifest.json
@@ -23,7 +23,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/12ae2d0e88d6fd5e2ccc66859915d800ddb920fd720aa427d2191cdaf6976404.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/48c35b5eff6568fca0f13cbdd1edbe25ec3ce4bf19ba9b1db3d0aecf408a40c0.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/default.integ.snapshot/tree.json
+++ b/test/default.integ.snapshot/tree.json
@@ -3010,7 +3010,7 @@
                         "version": {
                           "Ref": "WindowsImageBuilderContainerRecipeVersion13A2E3FD"
                         },
-                        "dockerfileTemplateData": "FROM {{{ imagebuilder:parentImage }}}\n{{{ imagebuilder:environments }}}\n{{{ imagebuilder:components }}}"
+                        "dockerfileTemplateData": "FROM {{{ imagebuilder:parentImage }}}\nENV RUNNER_VERSION=latest\n{{{ imagebuilder:environments }}}\n{{{ imagebuilder:components }}}"
                       }
                     },
                     "constructInfo": {
@@ -6041,7 +6041,7 @@
                         },
                         "source": {
                           "type": "NO_SOURCE",
-                          "buildSpec": "{\n  \"version\": \"0.2\",\n  \"env\": {\n    \"variables\": {\n      \"RUNNER_TOKEN\": \"unspecified\",\n      \"RUNNER_NAME\": \"unspecified\",\n      \"RUNNER_LABEL\": \"unspecified\",\n      \"OWNER\": \"unspecified\",\n      \"REPO\": \"unspecified\",\n      \"GITHUB_DOMAIN\": \"github.com\"\n    }\n  },\n  \"phases\": {\n    \"install\": {\n      \"commands\": [\n        \"cd \\\\actions\",\n        \"if (${Env:RUNNER_VERSION} -eq \\\"latest\\\") { $RunnerFlags = \\\"\\\" } else  { $RunnerFlags = \\\"--disableupdate\\\" }\",\n        \"./config.cmd --unattended --url \\\"https://${Env:GITHUB_DOMAIN}/${Env:OWNER}/${Env:REPO}\\\" --token \\\"${Env:RUNNER_TOKEN}\\\" --ephemeral --work _work --labels \\\"${Env:RUNNER_LABEL}\\\" ${RunnerFlags} --name \\\"${Env:RUNNER_NAME}\\\"\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"cd \\\\actions\",\n        \"./run.cmd\"\n      ]\n    }\n  }\n}"
+                          "buildSpec": "{\n  \"version\": \"0.2\",\n  \"env\": {\n    \"variables\": {\n      \"RUNNER_TOKEN\": \"unspecified\",\n      \"RUNNER_NAME\": \"unspecified\",\n      \"RUNNER_LABEL\": \"unspecified\",\n      \"OWNER\": \"unspecified\",\n      \"REPO\": \"unspecified\",\n      \"GITHUB_DOMAIN\": \"github.com\"\n    }\n  },\n  \"phases\": {\n    \"install\": {\n      \"commands\": [\n        \"cd \\\\actions\",\n        \"if (${Env:RUNNER_VERSION} -eq \\\"latest\\\") { $RunnerFlags = \\\"\\\" } else { $RunnerFlags = \\\"--disableupdate\\\" }\",\n        \"./config.cmd --unattended --url \\\"https://${Env:GITHUB_DOMAIN}/${Env:OWNER}/${Env:REPO}\\\" --token \\\"${Env:RUNNER_TOKEN}\\\" --ephemeral --work _work --labels \\\"${Env:RUNNER_LABEL}\\\" ${RunnerFlags} --name \\\"${Env:RUNNER_NAME}\\\"\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"cd \\\\actions\",\n        \"./run.cmd\"\n      ]\n    }\n  }\n}"
                         },
                         "cache": {
                           "type": "NO_CACHE"

--- a/test/default.integ.snapshot/tree.json
+++ b/test/default.integ.snapshot/tree.json
@@ -532,7 +532,7 @@
                                               {
                                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                               },
-                                              "/f21a107de9aaed0625532057c2f8259320d99d5185adcaece346941d88d04250.zip"
+                                              "/ff33ef8c42c19a3b1919fad5b849b69b1979dcfaceb2eb58695b4f124e16a818.zip"
                                             ]
                                           ]
                                         }
@@ -735,7 +735,7 @@
                                 {
                                   "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                 },
-                                "/f21a107de9aaed0625532057c2f8259320d99d5185adcaece346941d88d04250.zip"
+                                "/ff33ef8c42c19a3b1919fad5b849b69b1979dcfaceb2eb58695b4f124e16a818.zip"
                               ]
                             ]
                           },
@@ -1217,7 +1217,7 @@
                                               {
                                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                               },
-                                              "/c7602b829f7a84e4b86e023a450c177a3e502b09bfabd905df981b666c626443.zip"
+                                              "/0b985e7436349a499cd2e6551aa8c08f3a42276bfdaf949f98be4d3af2c33de3.zip"
                                             ]
                                           ]
                                         }
@@ -1420,7 +1420,7 @@
                                 {
                                   "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                 },
-                                "/c7602b829f7a84e4b86e023a450c177a3e502b09bfabd905df981b666c626443.zip"
+                                "/0b985e7436349a499cd2e6551aa8c08f3a42276bfdaf949f98be4d3af2c33de3.zip"
                               ]
                             ]
                           },
@@ -1902,7 +1902,7 @@
                                               {
                                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                               },
-                                              "/7446727c79e655948a19c286c7344d79c1ab4a7b8906e31ab99cf2190c39ec8b.zip"
+                                              "/719a3a6918de22e066f2368ac5b23e039f9611031fab1754dfda06eff0c0d6bb.zip"
                                             ]
                                           ]
                                         }
@@ -2105,7 +2105,7 @@
                                 {
                                   "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                 },
-                                "/7446727c79e655948a19c286c7344d79c1ab4a7b8906e31ab99cf2190c39ec8b.zip"
+                                "/719a3a6918de22e066f2368ac5b23e039f9611031fab1754dfda06eff0c0d6bb.zip"
                               ]
                             ]
                           },
@@ -3691,7 +3691,7 @@
                                               {
                                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                               },
-                                              "/c4b5dd5601c4f93574b8d50cf9c3535d4790187c10d927aee7b842afa7dd78c0.zip"
+                                              "/5ddcf0270bec799efcd364faedadaa445365fef56d807626d8708ab83f24f7e2.zip"
                                             ]
                                           ]
                                         }
@@ -3894,7 +3894,7 @@
                                 {
                                   "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                 },
-                                "/c4b5dd5601c4f93574b8d50cf9c3535d4790187c10d927aee7b842afa7dd78c0.zip"
+                                "/5ddcf0270bec799efcd364faedadaa445365fef56d807626d8708ab83f24f7e2.zip"
                               ]
                             ]
                           },
@@ -4502,7 +4502,7 @@
                         },
                         "source": {
                           "type": "NO_SOURCE",
-                          "buildSpec": "{\n  \"version\": \"0.2\",\n  \"env\": {\n    \"variables\": {\n      \"RUNNER_TOKEN\": \"unspecified\",\n      \"RUNNER_NAME\": \"unspecified\",\n      \"RUNNER_LABEL\": \"unspecified\",\n      \"OWNER\": \"unspecified\",\n      \"REPO\": \"unspecified\",\n      \"GITHUB_DOMAIN\": \"github.com\"\n    }\n  },\n  \"phases\": {\n    \"install\": {\n      \"commands\": [\n        \"nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay2 &\",\n        \"timeout 15 sh -c \\\"until docker info; do echo .; sleep 1; done\\\"\",\n        \"sudo -Hu runner /home/runner/config.sh --unattended --url \\\"https://${GITHUB_DOMAIN}/${OWNER}/${REPO}\\\" --token \\\"${RUNNER_TOKEN}\\\" --ephemeral --work _work --labels \\\"${RUNNER_LABEL}\\\" --disableupdate --name \\\"${RUNNER_NAME}\\\"\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"sudo --preserve-env=AWS_CONTAINER_CREDENTIALS_RELATIVE_URI,AWS_DEFAULT_REGION,AWS_REGION -Hu runner /home/runner/run.sh\"\n      ]\n    }\n  }\n}"
+                          "buildSpec": "{\n  \"version\": \"0.2\",\n  \"env\": {\n    \"variables\": {\n      \"RUNNER_TOKEN\": \"unspecified\",\n      \"RUNNER_NAME\": \"unspecified\",\n      \"RUNNER_LABEL\": \"unspecified\",\n      \"OWNER\": \"unspecified\",\n      \"REPO\": \"unspecified\",\n      \"GITHUB_DOMAIN\": \"github.com\"\n    }\n  },\n  \"phases\": {\n    \"install\": {\n      \"commands\": [\n        \"nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay2 &\",\n        \"timeout 15 sh -c \\\"until docker info; do echo .; sleep 1; done\\\"\",\n        \"if [ \\\"${RUNNER_VERSION}\\\" = \\\"latest\\\" ]; then RUNNER_FLAGS=\\\"\\\"; else RUNNER_FLAGS=\\\"--disableupdate\\\"; fi\",\n        \"sudo -Hu runner /home/runner/config.sh --unattended --url \\\"https://${GITHUB_DOMAIN}/${OWNER}/${REPO}\\\" --token \\\"${RUNNER_TOKEN}\\\" --ephemeral --work _work --labels \\\"${RUNNER_LABEL}\\\" ${RUNNER_FLAGS} --name \\\"${RUNNER_NAME}\\\"\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"sudo --preserve-env=AWS_CONTAINER_CREDENTIALS_RELATIVE_URI,AWS_DEFAULT_REGION,AWS_REGION -Hu runner /home/runner/run.sh\"\n      ]\n    }\n  }\n}"
                         },
                         "cache": {
                           "type": "NO_CACHE"
@@ -4854,7 +4854,7 @@
                                               {
                                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                               },
-                                              "/a4439209261897e0fdef1079c134580fe74403f8f7f6254638ffa5ddc456e0a2.zip"
+                                              "/b26ba58062e07311ed57d94ceb9332e828312745abd3718f2d296206e9ec05c2.zip"
                                             ]
                                           ]
                                         }
@@ -5057,7 +5057,7 @@
                                 {
                                   "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                 },
-                                "/a4439209261897e0fdef1079c134580fe74403f8f7f6254638ffa5ddc456e0a2.zip"
+                                "/b26ba58062e07311ed57d94ceb9332e828312745abd3718f2d296206e9ec05c2.zip"
                               ]
                             ]
                           },
@@ -5665,7 +5665,7 @@
                         },
                         "source": {
                           "type": "NO_SOURCE",
-                          "buildSpec": "{\n  \"version\": \"0.2\",\n  \"env\": {\n    \"variables\": {\n      \"RUNNER_TOKEN\": \"unspecified\",\n      \"RUNNER_NAME\": \"unspecified\",\n      \"RUNNER_LABEL\": \"unspecified\",\n      \"OWNER\": \"unspecified\",\n      \"REPO\": \"unspecified\",\n      \"GITHUB_DOMAIN\": \"github.com\"\n    }\n  },\n  \"phases\": {\n    \"install\": {\n      \"commands\": [\n        \"nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay2 &\",\n        \"timeout 15 sh -c \\\"until docker info; do echo .; sleep 1; done\\\"\",\n        \"sudo -Hu runner /home/runner/config.sh --unattended --url \\\"https://${GITHUB_DOMAIN}/${OWNER}/${REPO}\\\" --token \\\"${RUNNER_TOKEN}\\\" --ephemeral --work _work --labels \\\"${RUNNER_LABEL}\\\" --disableupdate --name \\\"${RUNNER_NAME}\\\"\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"sudo --preserve-env=AWS_CONTAINER_CREDENTIALS_RELATIVE_URI,AWS_DEFAULT_REGION,AWS_REGION -Hu runner /home/runner/run.sh\"\n      ]\n    }\n  }\n}"
+                          "buildSpec": "{\n  \"version\": \"0.2\",\n  \"env\": {\n    \"variables\": {\n      \"RUNNER_TOKEN\": \"unspecified\",\n      \"RUNNER_NAME\": \"unspecified\",\n      \"RUNNER_LABEL\": \"unspecified\",\n      \"OWNER\": \"unspecified\",\n      \"REPO\": \"unspecified\",\n      \"GITHUB_DOMAIN\": \"github.com\"\n    }\n  },\n  \"phases\": {\n    \"install\": {\n      \"commands\": [\n        \"nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay2 &\",\n        \"timeout 15 sh -c \\\"until docker info; do echo .; sleep 1; done\\\"\",\n        \"if [ \\\"${RUNNER_VERSION}\\\" = \\\"latest\\\" ]; then RUNNER_FLAGS=\\\"\\\"; else RUNNER_FLAGS=\\\"--disableupdate\\\"; fi\",\n        \"sudo -Hu runner /home/runner/config.sh --unattended --url \\\"https://${GITHUB_DOMAIN}/${OWNER}/${REPO}\\\" --token \\\"${RUNNER_TOKEN}\\\" --ephemeral --work _work --labels \\\"${RUNNER_LABEL}\\\" ${RUNNER_FLAGS} --name \\\"${RUNNER_NAME}\\\"\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"sudo --preserve-env=AWS_CONTAINER_CREDENTIALS_RELATIVE_URI,AWS_DEFAULT_REGION,AWS_REGION -Hu runner /home/runner/run.sh\"\n      ]\n    }\n  }\n}"
                         },
                         "cache": {
                           "type": "NO_CACHE"
@@ -6041,7 +6041,7 @@
                         },
                         "source": {
                           "type": "NO_SOURCE",
-                          "buildSpec": "{\n  \"version\": \"0.2\",\n  \"env\": {\n    \"variables\": {\n      \"RUNNER_TOKEN\": \"unspecified\",\n      \"RUNNER_NAME\": \"unspecified\",\n      \"RUNNER_LABEL\": \"unspecified\",\n      \"OWNER\": \"unspecified\",\n      \"REPO\": \"unspecified\",\n      \"GITHUB_DOMAIN\": \"github.com\"\n    }\n  },\n  \"phases\": {\n    \"install\": {\n      \"commands\": [\n        \"cd \\\\actions\",\n        \"./config.cmd --unattended --url \\\"https://${Env:GITHUB_DOMAIN}/${Env:OWNER}/${Env:REPO}\\\" --token \\\"${Env:RUNNER_TOKEN}\\\" --ephemeral --work _work --labels \\\"${Env:RUNNER_LABEL}\\\" --disableupdate --name \\\"${Env:RUNNER_NAME}\\\"\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"cd \\\\actions\",\n        \"./run.cmd\"\n      ]\n    }\n  }\n}"
+                          "buildSpec": "{\n  \"version\": \"0.2\",\n  \"env\": {\n    \"variables\": {\n      \"RUNNER_TOKEN\": \"unspecified\",\n      \"RUNNER_NAME\": \"unspecified\",\n      \"RUNNER_LABEL\": \"unspecified\",\n      \"OWNER\": \"unspecified\",\n      \"REPO\": \"unspecified\",\n      \"GITHUB_DOMAIN\": \"github.com\"\n    }\n  },\n  \"phases\": {\n    \"install\": {\n      \"commands\": [\n        \"cd \\\\actions\",\n        \"if (${Env:RUNNER_VERSION} -eq \\\"latest\\\") { $RunnerFlags = \\\"\\\" } else  { $RunnerFlags = \\\"--disableupdate\\\" }\",\n        \"./config.cmd --unattended --url \\\"https://${Env:GITHUB_DOMAIN}/${Env:OWNER}/${Env:REPO}\\\" --token \\\"${Env:RUNNER_TOKEN}\\\" --ephemeral --work _work --labels \\\"${Env:RUNNER_LABEL}\\\" ${RunnerFlags} --name \\\"${Env:RUNNER_NAME}\\\"\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"cd \\\\actions\",\n        \"./run.cmd\"\n      ]\n    }\n  }\n}"
                         },
                         "cache": {
                           "type": "NO_CACHE"
@@ -6866,7 +6866,7 @@
                                               {
                                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                               },
-                                              "/d5545963484b1928f0ce61ce92cbf507d5c906258787f5d1c662525f5b02f03a.zip"
+                                              "/fd74efb11a23e888bfdda26033271f933286246b5b17741e787125a962a76dcc.zip"
                                             ]
                                           ]
                                         }
@@ -7069,7 +7069,7 @@
                                 {
                                   "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                 },
-                                "/d5545963484b1928f0ce61ce92cbf507d5c906258787f5d1c662525f5b02f03a.zip"
+                                "/fd74efb11a23e888bfdda26033271f933286246b5b17741e787125a962a76dcc.zip"
                               ]
                             ]
                           },
@@ -7903,7 +7903,7 @@
                             "command": [
                               "sh",
                               "-c",
-                              "./config.sh --unattended --url \"https://${GITHUB_DOMAIN}/${OWNER}/${REPO}\" --token \"${RUNNER_TOKEN}\" --ephemeral --work _work --labels \"${RUNNER_LABEL}\" --disableupdate --name \"${RUNNER_NAME}\" && ./run.sh"
+                              "if [ \"${RUNNER_VERSION}\" = \"latest\" ]; then RUNNER_FLAGS=\"\"; else RUNNER_FLAGS=\"--disableupdate\"; fi && ./config.sh --unattended --url \"https://${GITHUB_DOMAIN}/${OWNER}/${REPO}\" --token \"${RUNNER_TOKEN}\" --ephemeral --work _work --labels \"${RUNNER_LABEL}\" ${RUNNER_FLAGS} --name \"${RUNNER_NAME}\" && ./run.sh"
                             ],
                             "essential": true,
                             "image": {
@@ -8238,7 +8238,7 @@
                             "command": [
                               "sh",
                               "-c",
-                              "./config.sh --unattended --url \"https://${GITHUB_DOMAIN}/${OWNER}/${REPO}\" --token \"${RUNNER_TOKEN}\" --ephemeral --work _work --labels \"${RUNNER_LABEL}\" --disableupdate --name \"${RUNNER_NAME}\" && ./run.sh"
+                              "if [ \"${RUNNER_VERSION}\" = \"latest\" ]; then RUNNER_FLAGS=\"\"; else RUNNER_FLAGS=\"--disableupdate\"; fi && ./config.sh --unattended --url \"https://${GITHUB_DOMAIN}/${OWNER}/${REPO}\" --token \"${RUNNER_TOKEN}\" --ephemeral --work _work --labels \"${RUNNER_LABEL}\" ${RUNNER_FLAGS} --name \"${RUNNER_NAME}\" && ./run.sh"
                             ],
                             "essential": true,
                             "image": {
@@ -8573,7 +8573,7 @@
                             "command": [
                               "sh",
                               "-c",
-                              "./config.sh --unattended --url \"https://${GITHUB_DOMAIN}/${OWNER}/${REPO}\" --token \"${RUNNER_TOKEN}\" --ephemeral --work _work --labels \"${RUNNER_LABEL}\" --disableupdate --name \"${RUNNER_NAME}\" && ./run.sh"
+                              "if [ \"${RUNNER_VERSION}\" = \"latest\" ]; then RUNNER_FLAGS=\"\"; else RUNNER_FLAGS=\"--disableupdate\"; fi && ./config.sh --unattended --url \"https://${GITHUB_DOMAIN}/${OWNER}/${REPO}\" --token \"${RUNNER_TOKEN}\" --ephemeral --work _work --labels \"${RUNNER_LABEL}\" ${RUNNER_FLAGS} --name \"${RUNNER_NAME}\" && ./run.sh"
                             ],
                             "essential": true,
                             "image": {
@@ -8908,7 +8908,7 @@
                             "command": [
                               "sh",
                               "-c",
-                              "./config.sh --unattended --url \"https://${GITHUB_DOMAIN}/${OWNER}/${REPO}\" --token \"${RUNNER_TOKEN}\" --ephemeral --work _work --labels \"${RUNNER_LABEL}\" --disableupdate --name \"${RUNNER_NAME}\" && ./run.sh"
+                              "if [ \"${RUNNER_VERSION}\" = \"latest\" ]; then RUNNER_FLAGS=\"\"; else RUNNER_FLAGS=\"--disableupdate\"; fi && ./config.sh --unattended --url \"https://${GITHUB_DOMAIN}/${OWNER}/${REPO}\" --token \"${RUNNER_TOKEN}\" --ephemeral --work _work --labels \"${RUNNER_LABEL}\" ${RUNNER_FLAGS} --name \"${RUNNER_NAME}\" && ./run.sh"
                             ],
                             "essential": true,
                             "image": {
@@ -9243,7 +9243,7 @@
                             "command": [
                               "powershell",
                               "-Command",
-                              "cd \\actions ; ./config.cmd --unattended --url \"https://${Env:GITHUB_DOMAIN}/${Env:OWNER}/${Env:REPO}\" --token \"${Env:RUNNER_TOKEN}\" --ephemeral --work _work --labels \"${Env:RUNNER_LABEL}\" --disableupdate --name \"${Env:RUNNER_NAME}\" ; ./run.cmd"
+                              "if (${Env:RUNNER_VERSION} -eq \"latest\") { $RunnerFlags = \"\" } else { $RunnerFlags = \"--disableupdate\" } ; cd \\actions ; ./config.cmd --unattended --url \"https://${Env:GITHUB_DOMAIN}/${Env:OWNER}/${Env:REPO}\" --token \"${Env:RUNNER_TOKEN}\" --ephemeral --work _work --labels \"${Env:RUNNER_LABEL}\" ${RunnerFlags} --name \"${Env:RUNNER_NAME}\" ; ./run.cmd"
                             ],
                             "essential": true,
                             "image": {


### PR DESCRIPTION
Some GitHub Enterprise instances forbid runners from using --disableupdate. We only truly need it when a user a chooses a specific runner version. When we update the runner image with its version every week, disabling updates shouldn't matter anyway. GitHub Actions seems to only auto-update the runner if we're two versions behind and that would be very rare in the span of a week (default image rebuild interval).

Originally we wanted to disable auto-updates because our runners are ephemeral and updating them for every single job would be wasteful. Since they only auto-update if we're two versions behind, I feel like we can drop this flag.

Fixes #112
Replaces #120