### PR TITLE
fix: Setup doesn't load on Firefox

### DIFF
--- a/src/lambdas/setup/index.ts
+++ b/src/lambdas/setup/index.ts
@@ -25,7 +25,7 @@ function response(code: number, body: string): AWSLambda.APIGatewayProxyResultV2
     statusCode: code,
     headers: {
       'Content-Type': 'text/html',
-      'Content-Security-Policy': `default-src 'nonce-${nonce}'; img-src data:; connect-src 'self'; form-action https:; frame-ancestors 'none'`,
+      'Content-Security-Policy': `default-src 'unsafe-inline' 'nonce-${nonce}'; img-src data:; connect-src 'self'; form-action https:; frame-ancestors 'none'; object-src 'none'; base-uri 'self'`,
     },
     body: body,
   };

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -183,15 +183,15 @@
         }
       }
     },
-    "f4a33003d7218cfbd37b7b92b417c1c1e422550c1f612cf8b5c727c8d94d35a3": {
+    "750c929b25e349d695b6b2d0bcf8571dd0ea7dfe3b44451752108508fb4e8da2": {
       "source": {
-        "path": "asset.f4a33003d7218cfbd37b7b92b417c1c1e422550c1f612cf8b5c727c8d94d35a3",
+        "path": "asset.750c929b25e349d695b6b2d0bcf8571dd0ea7dfe3b44451752108508fb4e8da2",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "f4a33003d7218cfbd37b7b92b417c1c1e422550c1f612cf8b5c727c8d94d35a3.zip",
+          "objectKey": "750c929b25e349d695b6b2d0bcf8571dd0ea7dfe3b44451752108508fb4e8da2.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -209,7 +209,7 @@
         }
       }
     },
-    "0fb9178c0c173af702f75e3847ce04062ee0193001c6a6f3662cb1ecf2ea051e": {
+    "706f3231243fc4dde927e591afd319a7eef61aa103cc0cfc2e6d52c045d10a09": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -217,7 +217,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "0fb9178c0c173af702f75e3847ce04062ee0193001c6a6f3662cb1ecf2ea051e.json",
+          "objectKey": "706f3231243fc4dde927e591afd319a7eef61aa103cc0cfc2e6d52c045d10a09.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -8416,7 +8416,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "f4a33003d7218cfbd37b7b92b417c1c1e422550c1f612cf8b5c727c8d94d35a3.zip"
+     "S3Key": "750c929b25e349d695b6b2d0bcf8571dd0ea7dfe3b44451752108508fb4e8da2.zip"
     },
     "Role": {
      "Fn::GetAtt": [

--- a/test/default.integ.snapshot/manifest.json
+++ b/test/default.integ.snapshot/manifest.json
@@ -23,7 +23,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/0fb9178c0c173af702f75e3847ce04062ee0193001c6a6f3662cb1ecf2ea051e.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/706f3231243fc4dde927e591afd319a7eef61aa103cc0cfc2e6d52c045d10a09.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/default.integ.snapshot/tree.json
+++ b/test/default.integ.snapshot/tree.json
@@ -11789,7 +11789,7 @@
                           "s3Bucket": {
                             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                           },
-                          "s3Key": "f4a33003d7218cfbd37b7b92b417c1c1e422550c1f612cf8b5c727c8d94d35a3.zip"
+                          "s3Key": "750c929b25e349d695b6b2d0bcf8571dd0ea7dfe3b44451752108508fb4e8da2.zip"
                         },
                         "role": {
                           "Fn::GetAtt": [


### PR DESCRIPTION
Apparently Firefox doesn't support nonce in `Content-Security-Policy` and we must use `'unsafe-inline'`.

Beef up security with restrictions on `base-uri` and `object-src` while we're here.

Fixes #141