### PR TITLE
fix: GitHub Enterprise setup fails while complaining about `"public": "false"`

### DIFF
--- a/setup/src/App.svelte
+++ b/setup/src/App.svelte
@@ -211,7 +211,7 @@
               <p class="pt-2">If multiple organizations under the same GitHub Enterprise Server need to use the runners,
                 you can make the app public.</p>
               <div class="form-check">
-                <input class="form-check-input" type="checkbox" bind:value={manifest.public} id="public">
+                <input class="form-check-input" type="checkbox" bind:checked={manifest.public} id="public">
                 <label class="form-check-label" for="public">
                   Public app
                 </label>

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -183,15 +183,15 @@
         }
       }
     },
-    "750c929b25e349d695b6b2d0bcf8571dd0ea7dfe3b44451752108508fb4e8da2": {
+    "bee97de82664ac64739731fd9a0c4e8e2f9f65a527dad245355742dd5cc0adb3": {
       "source": {
-        "path": "asset.750c929b25e349d695b6b2d0bcf8571dd0ea7dfe3b44451752108508fb4e8da2",
+        "path": "asset.bee97de82664ac64739731fd9a0c4e8e2f9f65a527dad245355742dd5cc0adb3",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "750c929b25e349d695b6b2d0bcf8571dd0ea7dfe3b44451752108508fb4e8da2.zip",
+          "objectKey": "bee97de82664ac64739731fd9a0c4e8e2f9f65a527dad245355742dd5cc0adb3.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -209,7 +209,7 @@
         }
       }
     },
-    "706f3231243fc4dde927e591afd319a7eef61aa103cc0cfc2e6d52c045d10a09": {
+    "0af6fbee6791868ba426581a6821e68f6a38b97027206e06133f110edd63318d": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -217,7 +217,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "706f3231243fc4dde927e591afd319a7eef61aa103cc0cfc2e6d52c045d10a09.json",
+          "objectKey": "0af6fbee6791868ba426581a6821e68f6a38b97027206e06133f110edd63318d.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -8416,7 +8416,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "750c929b25e349d695b6b2d0bcf8571dd0ea7dfe3b44451752108508fb4e8da2.zip"
+     "S3Key": "bee97de82664ac64739731fd9a0c4e8e2f9f65a527dad245355742dd5cc0adb3.zip"
     },
     "Role": {
      "Fn::GetAtt": [

--- a/test/default.integ.snapshot/manifest.json
+++ b/test/default.integ.snapshot/manifest.json
@@ -23,7 +23,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/706f3231243fc4dde927e591afd319a7eef61aa103cc0cfc2e6d52c045d10a09.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/0af6fbee6791868ba426581a6821e68f6a38b97027206e06133f110edd63318d.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/default.integ.snapshot/tree.json
+++ b/test/default.integ.snapshot/tree.json
@@ -11789,7 +11789,7 @@
                           "s3Bucket": {
                             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                           },
-                          "s3Key": "750c929b25e349d695b6b2d0bcf8571dd0ea7dfe3b44451752108508fb4e8da2.zip"
+                          "s3Key": "bee97de82664ac64739731fd9a0c4e8e2f9f65a527dad245355742dd5cc0adb3.zip"
                         },
                         "role": {
                           "Fn::GetAtt": [


### PR DESCRIPTION
We were always sending the string `"false"` as `public` in the manifest because the binding was wrong. It's supposed to be a boolean. GitHub was not happy about it and failed to create the app.