### PR TITLE
fix: Lambda runners can't use npm install

### DIFF
--- a/src/providers/docker-images/lambda/linux-arm64/runner.sh
+++ b/src/providers/docker-images/lambda/linux-arm64/runner.sh
@@ -4,6 +4,8 @@ set -e -u -o pipefail
 
 cp -r /runner /tmp/
 cd /tmp/runner
+mkdir /tmp/home
+export HOME=/tmp/home
 
 if [ "${RUNNER_VERSION}" = "latest" ]; then RUNNER_FLAGS=""; else RUNNER_FLAGS="--disableupdate"; fi
 ./config.sh --unattended --url "https://${GITHUB_DOMAIN}/${OWNER}/${REPO}" --token "${RUNNER_TOKEN}" --ephemeral --work _work --labels "${RUNNER_LABEL}" --name "${RUNNER_NAME}" ${RUNNER_FLAGS}

--- a/src/providers/docker-images/lambda/linux-x64/runner.sh
+++ b/src/providers/docker-images/lambda/linux-x64/runner.sh
@@ -4,6 +4,8 @@ set -e -u -o pipefail
 
 cp -r /runner /tmp/
 cd /tmp/runner
+mkdir /tmp/home
+export HOME=/tmp/home
 
 if [ "${RUNNER_VERSION}" = "latest" ]; then RUNNER_FLAGS=""; else RUNNER_FLAGS="--disableupdate"; fi
 ./config.sh --unattended --url "https://${GITHUB_DOMAIN}/${OWNER}/${REPO}" --token "${RUNNER_TOKEN}" --ephemeral --work _work --labels "${RUNNER_LABEL}" --name "${RUNNER_NAME}" ${RUNNER_FLAGS}

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -27,15 +27,15 @@
         }
       }
     },
-    "719a3a6918de22e066f2368ac5b23e039f9611031fab1754dfda06eff0c0d6bb": {
+    "c6586c763100b9311cadceb2a66b5cd94d96d0f4f402d8c4c26b09b74cb79712": {
       "source": {
-        "path": "asset.719a3a6918de22e066f2368ac5b23e039f9611031fab1754dfda06eff0c0d6bb",
+        "path": "asset.c6586c763100b9311cadceb2a66b5cd94d96d0f4f402d8c4c26b09b74cb79712",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "719a3a6918de22e066f2368ac5b23e039f9611031fab1754dfda06eff0c0d6bb.zip",
+          "objectKey": "c6586c763100b9311cadceb2a66b5cd94d96d0f4f402d8c4c26b09b74cb79712.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -131,15 +131,15 @@
         }
       }
     },
-    "fd74efb11a23e888bfdda26033271f933286246b5b17741e787125a962a76dcc": {
+    "8c55ea107f6e2196a0031415c01f5379272fd74e2e444a90fee3c356b9ecf5a2": {
       "source": {
-        "path": "asset.fd74efb11a23e888bfdda26033271f933286246b5b17741e787125a962a76dcc",
+        "path": "asset.8c55ea107f6e2196a0031415c01f5379272fd74e2e444a90fee3c356b9ecf5a2",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "fd74efb11a23e888bfdda26033271f933286246b5b17741e787125a962a76dcc.zip",
+          "objectKey": "8c55ea107f6e2196a0031415c01f5379272fd74e2e444a90fee3c356b9ecf5a2.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -209,7 +209,7 @@
         }
       }
     },
-    "781555d4398f204bfb758b16f21421a3df3ec23beb045a6ef4a3d5be8d7069a1": {
+    "f0860ccabb38ab61646cabb656366fa8af7ae4ade42b5c906d2556a3d009c103": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -217,7 +217,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "781555d4398f204bfb758b16f21421a3df3ec23beb045a6ef4a3d5be8d7069a1.json",
+          "objectKey": "f0860ccabb38ab61646cabb656366fa8af7ae4ade42b5c906d2556a3d009c103.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -1268,7 +1268,7 @@
            {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
            },
-           "/719a3a6918de22e066f2368ac5b23e039f9611031fab1754dfda06eff0c0d6bb.zip"
+           "/c6586c763100b9311cadceb2a66b5cd94d96d0f4f402d8c4c26b09b74cb79712.zip"
           ]
          ]
         }
@@ -1515,7 +1515,7 @@
         {
          "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
         },
-        "/719a3a6918de22e066f2368ac5b23e039f9611031fab1754dfda06eff0c0d6bb.zip"
+        "/c6586c763100b9311cadceb2a66b5cd94d96d0f4f402d8c4c26b09b74cb79712.zip"
        ]
       ]
      },
@@ -1634,7 +1634,7 @@
     "ProjectName": {
      "Ref": "LambdaImageBuilderx64CodeBuild67DE14C8"
     },
-    "BuildHash": "cf38cf969269cc4f367ffeae2f956fc0"
+    "BuildHash": "616a9a0d9fd5bd03cbfa717386a62d88"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
@@ -4908,7 +4908,7 @@
            {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
            },
-           "/fd74efb11a23e888bfdda26033271f933286246b5b17741e787125a962a76dcc.zip"
+           "/8c55ea107f6e2196a0031415c01f5379272fd74e2e444a90fee3c356b9ecf5a2.zip"
           ]
          ]
         }
@@ -5155,7 +5155,7 @@
         {
          "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
         },
-        "/fd74efb11a23e888bfdda26033271f933286246b5b17741e787125a962a76dcc.zip"
+        "/8c55ea107f6e2196a0031415c01f5379272fd74e2e444a90fee3c356b9ecf5a2.zip"
        ]
       ]
      },
@@ -5274,7 +5274,7 @@
     "ProjectName": {
      "Ref": "LambdaImageBuilderzCodeBuild73AB6718"
     },
-    "BuildHash": "1ac14d78ea3f88cbc7d1ed3b6529c4c9"
+    "BuildHash": "d6bdc06d728db2eea9d3dfc09adc2865"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",

--- a/test/default.integ.snapshot/manifest.json
+++ b/test/default.integ.snapshot/manifest.json
@@ -23,7 +23,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/781555d4398f204bfb758b16f21421a3df3ec23beb045a6ef4a3d5be8d7069a1.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/f0860ccabb38ab61646cabb656366fa8af7ae4ade42b5c906d2556a3d009c103.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/default.integ.snapshot/tree.json
+++ b/test/default.integ.snapshot/tree.json
@@ -1902,7 +1902,7 @@
                                               {
                                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                               },
-                                              "/719a3a6918de22e066f2368ac5b23e039f9611031fab1754dfda06eff0c0d6bb.zip"
+                                              "/c6586c763100b9311cadceb2a66b5cd94d96d0f4f402d8c4c26b09b74cb79712.zip"
                                             ]
                                           ]
                                         }
@@ -2105,7 +2105,7 @@
                                 {
                                   "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                 },
-                                "/719a3a6918de22e066f2368ac5b23e039f9611031fab1754dfda06eff0c0d6bb.zip"
+                                "/c6586c763100b9311cadceb2a66b5cd94d96d0f4f402d8c4c26b09b74cb79712.zip"
                               ]
                             ]
                           },
@@ -6866,7 +6866,7 @@
                                               {
                                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                               },
-                                              "/fd74efb11a23e888bfdda26033271f933286246b5b17741e787125a962a76dcc.zip"
+                                              "/8c55ea107f6e2196a0031415c01f5379272fd74e2e444a90fee3c356b9ecf5a2.zip"
                                             ]
                                           ]
                                         }
@@ -7069,7 +7069,7 @@
                                 {
                                   "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                 },
-                                "/fd74efb11a23e888bfdda26033271f933286246b5b17741e787125a962a76dcc.zip"
+                                "/8c55ea107f6e2196a0031415c01f5379272fd74e2e444a90fee3c356b9ecf5a2.zip"
                               ]
                             ]
                           },


### PR DESCRIPTION
This happens because Lambdas don't set the HOME environment variable or even create a home directory. It seems like npm guesses the home directory and fails because it's not writable. This fix will create a writable home directory and set HOME environment variable to it.

Fixes #153