### PR TITLE
fix: Image builder getting stuck in apt-get

### DIFF
--- a/src/providers/docker-images/codebuild/linux-arm64/Dockerfile
+++ b/src/providers/docker-images/codebuild/linux-arm64/Dockerfile
@@ -6,6 +6,7 @@ RUN addgroup runner && adduser --system --disabled-password --home /home/runner 
 
 # add dependencies and sudo
 ARG EXTRA_PACKAGES=""
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get upgrade -y && apt-get install -y curl sudo jq bash zip unzip iptables software-properties-common ca-certificates $EXTRA_PACKAGES && \
     usermod -aG sudo runner && \
     echo "%sudo   ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/runner

--- a/src/providers/docker-images/codebuild/linux-x64/Dockerfile
+++ b/src/providers/docker-images/codebuild/linux-x64/Dockerfile
@@ -6,6 +6,7 @@ RUN addgroup runner && adduser --system --disabled-password --home /home/runner 
 
 # add dependencies and sudo
 ARG EXTRA_PACKAGES=""
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get upgrade -y && apt-get install -y curl sudo jq bash zip unzip iptables software-properties-common ca-certificates $EXTRA_PACKAGES && \
     usermod -aG sudo runner && \
     echo "%sudo   ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/runner

--- a/src/providers/docker-images/fargate/linux-arm64/Dockerfile
+++ b/src/providers/docker-images/fargate/linux-arm64/Dockerfile
@@ -6,6 +6,7 @@ RUN addgroup runner && adduser --system --disabled-password --home /home/runner 
 
 # add dependencies and sudo
 ARG EXTRA_PACKAGES=""
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get upgrade -y && apt-get install -y curl sudo jq bash zip unzip software-properties-common ca-certificates $EXTRA_PACKAGES && \
     usermod -aG sudo runner && \
     echo "%sudo   ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/runner

--- a/src/providers/docker-images/fargate/linux-x64/Dockerfile
+++ b/src/providers/docker-images/fargate/linux-x64/Dockerfile
@@ -6,6 +6,7 @@ RUN addgroup runner && adduser --system --disabled-password --home /home/runner 
 
 # add dependencies and sudo
 ARG EXTRA_PACKAGES=""
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get upgrade -y && apt-get install -y curl sudo jq bash zip unzip software-properties-common ca-certificates $EXTRA_PACKAGES && \
     usermod -aG sudo runner && \
     echo "%sudo   ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/runner

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -1,28 +1,28 @@
 {
   "version": "20.0.0",
   "files": {
-    "ff33ef8c42c19a3b1919fad5b849b69b1979dcfaceb2eb58695b4f124e16a818": {
+    "7016cd24653d28ac7705bc5ec6608f27c8625b2871072fba158790922d95eef1": {
       "source": {
-        "path": "asset.ff33ef8c42c19a3b1919fad5b849b69b1979dcfaceb2eb58695b4f124e16a818",
+        "path": "asset.7016cd24653d28ac7705bc5ec6608f27c8625b2871072fba158790922d95eef1",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "ff33ef8c42c19a3b1919fad5b849b69b1979dcfaceb2eb58695b4f124e16a818.zip",
+          "objectKey": "7016cd24653d28ac7705bc5ec6608f27c8625b2871072fba158790922d95eef1.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "0b985e7436349a499cd2e6551aa8c08f3a42276bfdaf949f98be4d3af2c33de3": {
+    "fcdd8c8653be84158994fea0b9638c46cdd8fa303dec32dc3ea5f506b8ecff39": {
       "source": {
-        "path": "asset.0b985e7436349a499cd2e6551aa8c08f3a42276bfdaf949f98be4d3af2c33de3",
+        "path": "asset.fcdd8c8653be84158994fea0b9638c46cdd8fa303dec32dc3ea5f506b8ecff39",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "0b985e7436349a499cd2e6551aa8c08f3a42276bfdaf949f98be4d3af2c33de3.zip",
+          "objectKey": "fcdd8c8653be84158994fea0b9638c46cdd8fa303dec32dc3ea5f506b8ecff39.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -66,15 +66,15 @@
         }
       }
     },
-    "5ddcf0270bec799efcd364faedadaa445365fef56d807626d8708ab83f24f7e2": {
+    "cf6c81647b444e50910bbd38ad5bd5b74170fa75de8878c6b108a0be22fe8da2": {
       "source": {
-        "path": "asset.5ddcf0270bec799efcd364faedadaa445365fef56d807626d8708ab83f24f7e2",
+        "path": "asset.cf6c81647b444e50910bbd38ad5bd5b74170fa75de8878c6b108a0be22fe8da2",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "5ddcf0270bec799efcd364faedadaa445365fef56d807626d8708ab83f24f7e2.zip",
+          "objectKey": "cf6c81647b444e50910bbd38ad5bd5b74170fa75de8878c6b108a0be22fe8da2.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -92,15 +92,15 @@
         }
       }
     },
-    "b26ba58062e07311ed57d94ceb9332e828312745abd3718f2d296206e9ec05c2": {
+    "c521fa041f1b5714edf8fab8f33b2c6e7fa2c95cb57217bdb0a663d2245a28d6": {
       "source": {
-        "path": "asset.b26ba58062e07311ed57d94ceb9332e828312745abd3718f2d296206e9ec05c2",
+        "path": "asset.c521fa041f1b5714edf8fab8f33b2c6e7fa2c95cb57217bdb0a663d2245a28d6",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "b26ba58062e07311ed57d94ceb9332e828312745abd3718f2d296206e9ec05c2.zip",
+          "objectKey": "c521fa041f1b5714edf8fab8f33b2c6e7fa2c95cb57217bdb0a663d2245a28d6.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -209,7 +209,7 @@
         }
       }
     },
-    "f0860ccabb38ab61646cabb656366fa8af7ae4ade42b5c906d2556a3d009c103": {
+    "4e7a3e93473b0c1049f3a07356558f5ed0dca3921665378153dd1e52dd4260aa": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -217,7 +217,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "f0860ccabb38ab61646cabb656366fa8af7ae4ade42b5c906d2556a3d009c103.json",
+          "objectKey": "4e7a3e93473b0c1049f3a07356558f5ed0dca3921665378153dd1e52dd4260aa.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -276,7 +276,7 @@
            {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
            },
-           "/ff33ef8c42c19a3b1919fad5b849b69b1979dcfaceb2eb58695b4f124e16a818.zip"
+           "/7016cd24653d28ac7705bc5ec6608f27c8625b2871072fba158790922d95eef1.zip"
           ]
          ]
         }
@@ -523,7 +523,7 @@
         {
          "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
         },
-        "/ff33ef8c42c19a3b1919fad5b849b69b1979dcfaceb2eb58695b4f124e16a818.zip"
+        "/7016cd24653d28ac7705bc5ec6608f27c8625b2871072fba158790922d95eef1.zip"
        ]
       ]
      },
@@ -642,7 +642,7 @@
     "ProjectName": {
      "Ref": "FargatebuilderCodeBuild4F182743"
     },
-    "BuildHash": "f96c1387dfc95855528e1ea35e89099a"
+    "BuildHash": "ac1ffc5169a5fe69907bb4638ebb989e"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
@@ -772,7 +772,7 @@
            {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
            },
-           "/0b985e7436349a499cd2e6551aa8c08f3a42276bfdaf949f98be4d3af2c33de3.zip"
+           "/fcdd8c8653be84158994fea0b9638c46cdd8fa303dec32dc3ea5f506b8ecff39.zip"
           ]
          ]
         }
@@ -1019,7 +1019,7 @@
         {
          "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
         },
-        "/0b985e7436349a499cd2e6551aa8c08f3a42276bfdaf949f98be4d3af2c33de3.zip"
+        "/fcdd8c8653be84158994fea0b9638c46cdd8fa303dec32dc3ea5f506b8ecff39.zip"
        ]
       ]
      },
@@ -1138,7 +1138,7 @@
     "ProjectName": {
      "Ref": "FargatebuilderarmCodeBuild0D30679A"
     },
-    "BuildHash": "6436dadc6315feff90e0f57aeabb4277"
+    "BuildHash": "2d28bc55d37386fa2d542ed1c80b78b8"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
@@ -2638,7 +2638,7 @@
            {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
            },
-           "/5ddcf0270bec799efcd364faedadaa445365fef56d807626d8708ab83f24f7e2.zip"
+           "/cf6c81647b444e50910bbd38ad5bd5b74170fa75de8878c6b108a0be22fe8da2.zip"
           ]
          ]
         }
@@ -2885,7 +2885,7 @@
         {
          "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
         },
-        "/5ddcf0270bec799efcd364faedadaa445365fef56d807626d8708ab83f24f7e2.zip"
+        "/cf6c81647b444e50910bbd38ad5bd5b74170fa75de8878c6b108a0be22fe8da2.zip"
        ]
       ]
      },
@@ -3004,7 +3004,7 @@
     "ProjectName": {
      "Ref": "CodeBuildImageBuilderCodeBuild38ECAA44"
     },
-    "BuildHash": "de25425e71d05e436bd5efac4ba6fdce"
+    "BuildHash": "f84032774d6cd70e4b154460cac04f6b"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
@@ -3462,7 +3462,7 @@
            {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
            },
-           "/b26ba58062e07311ed57d94ceb9332e828312745abd3718f2d296206e9ec05c2.zip"
+           "/c521fa041f1b5714edf8fab8f33b2c6e7fa2c95cb57217bdb0a663d2245a28d6.zip"
           ]
          ]
         }
@@ -3709,7 +3709,7 @@
         {
          "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
         },
-        "/b26ba58062e07311ed57d94ceb9332e828312745abd3718f2d296206e9ec05c2.zip"
+        "/c521fa041f1b5714edf8fab8f33b2c6e7fa2c95cb57217bdb0a663d2245a28d6.zip"
        ]
       ]
      },
@@ -3828,7 +3828,7 @@
     "ProjectName": {
      "Ref": "CodeBuildImageBuilderarmCodeBuildBFF1CF57"
     },
-    "BuildHash": "a91e13fe5beeead09aad02f402aaaee0"
+    "BuildHash": "b9438c08aa22255bdaefe9ec669a80aa"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",

--- a/test/default.integ.snapshot/manifest.json
+++ b/test/default.integ.snapshot/manifest.json
@@ -23,7 +23,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/f0860ccabb38ab61646cabb656366fa8af7ae4ade42b5c906d2556a3d009c103.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/4e7a3e93473b0c1049f3a07356558f5ed0dca3921665378153dd1e52dd4260aa.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/default.integ.snapshot/tree.json
+++ b/test/default.integ.snapshot/tree.json
@@ -532,7 +532,7 @@
                                               {
                                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                               },
-                                              "/ff33ef8c42c19a3b1919fad5b849b69b1979dcfaceb2eb58695b4f124e16a818.zip"
+                                              "/7016cd24653d28ac7705bc5ec6608f27c8625b2871072fba158790922d95eef1.zip"
                                             ]
                                           ]
                                         }
@@ -735,7 +735,7 @@
                                 {
                                   "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                 },
-                                "/ff33ef8c42c19a3b1919fad5b849b69b1979dcfaceb2eb58695b4f124e16a818.zip"
+                                "/7016cd24653d28ac7705bc5ec6608f27c8625b2871072fba158790922d95eef1.zip"
                               ]
                             ]
                           },
@@ -1217,7 +1217,7 @@
                                               {
                                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                               },
-                                              "/0b985e7436349a499cd2e6551aa8c08f3a42276bfdaf949f98be4d3af2c33de3.zip"
+                                              "/fcdd8c8653be84158994fea0b9638c46cdd8fa303dec32dc3ea5f506b8ecff39.zip"
                                             ]
                                           ]
                                         }
@@ -1420,7 +1420,7 @@
                                 {
                                   "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                 },
-                                "/0b985e7436349a499cd2e6551aa8c08f3a42276bfdaf949f98be4d3af2c33de3.zip"
+                                "/fcdd8c8653be84158994fea0b9638c46cdd8fa303dec32dc3ea5f506b8ecff39.zip"
                               ]
                             ]
                           },
@@ -3691,7 +3691,7 @@
                                               {
                                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                               },
-                                              "/5ddcf0270bec799efcd364faedadaa445365fef56d807626d8708ab83f24f7e2.zip"
+                                              "/cf6c81647b444e50910bbd38ad5bd5b74170fa75de8878c6b108a0be22fe8da2.zip"
                                             ]
                                           ]
                                         }
@@ -3894,7 +3894,7 @@
                                 {
                                   "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                 },
-                                "/5ddcf0270bec799efcd364faedadaa445365fef56d807626d8708ab83f24f7e2.zip"
+                                "/cf6c81647b444e50910bbd38ad5bd5b74170fa75de8878c6b108a0be22fe8da2.zip"
                               ]
                             ]
                           },
@@ -4854,7 +4854,7 @@
                                               {
                                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                               },
-                                              "/b26ba58062e07311ed57d94ceb9332e828312745abd3718f2d296206e9ec05c2.zip"
+                                              "/c521fa041f1b5714edf8fab8f33b2c6e7fa2c95cb57217bdb0a663d2245a28d6.zip"
                                             ]
                                           ]
                                         }
@@ -5057,7 +5057,7 @@
                                 {
                                   "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                 },
-                                "/b26ba58062e07311ed57d94ceb9332e828312745abd3718f2d296206e9ec05c2.zip"
+                                "/c521fa041f1b5714edf8fab8f33b2c6e7fa2c95cb57217bdb0a663d2245a28d6.zip"
                               ]
                             ]
                           },


### PR DESCRIPTION
Certain packages like tzdata and keyboard-configuration prompt the user for information. This causes apt-get to hang while waiting for input that will never come. We need to tell apt-get user input is not allowed as it's not available while building a Docker image.

Fixes #154