### PR TITLE
fix: Resource of type 'AWS::ImageBuilder::ImageRecipe' with identifier 'ImageRecipeArn' already exists.

### DIFF
--- a/src/providers/image-builders/ami.ts
+++ b/src/providers/image-builders/ami.ts
@@ -167,6 +167,7 @@ class AmiRecipe extends ImageBuilderObjectBase {
       version: this.version('ImageRecipe', name, {
         platform: props.platform,
         components,
+        parentAmi,
       }),
       parentImage: parentAmi,
       components,

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -222,7 +222,7 @@
         }
       }
     },
-    "552eaa07c541739a7eb27fb78c02c891351b4dc4aebeb643cca4ed528c2ef241": {
+    "4bf5f53a266310182b6e51e5351110c13fa926bac52054ae7c8b7c11d1bd523c": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -230,7 +230,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "552eaa07c541739a7eb27fb78c02c891351b4dc4aebeb643cca4ed528c2ef241.json",
+          "objectKey": "4bf5f53a266310182b6e51e5351110c13fa926bac52054ae7c8b7c11d1bd523c.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -3096,7 +3096,10 @@
         ]
        }
       }
-     ]
+     ],
+     "parentAmi": {
+      "Ref": "SsmParameterValueawsservicecanonicalubuntuserverfocalstablecurrentamd64hvmebsgp2amiidC96584B6F00A464EAD1953AFF4B05118Parameter"
+     }
     }
    },
    "UpdateReplacePolicy": "Retain",
@@ -8371,7 +8374,10 @@
         ]
        }
       }
-     ]
+     ],
+     "parentAmi": {
+      "Ref": "SsmParameterValueawsservicecanonicalubuntuserverfocalstablecurrentarm64hvmebsgp2amiidC96584B6F00A464EAD1953AFF4B05118Parameter"
+     }
     }
    },
    "UpdateReplacePolicy": "Retain",
@@ -9230,7 +9236,10 @@
         ]
        }
       }
-     ]
+     ],
+     "parentAmi": {
+      "Ref": "SsmParameterValueawsserviceamiwindowslatestWindowsServer2022EnglishFullContainersLatestC96584B6F00A464EAD1953AFF4B05118Parameter"
+     }
     }
    },
    "UpdateReplacePolicy": "Retain",

--- a/test/default.integ.snapshot/manifest.json
+++ b/test/default.integ.snapshot/manifest.json
@@ -23,7 +23,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/552eaa07c541739a7eb27fb78c02c891351b4dc4aebeb643cca4ed528c2ef241.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/4bf5f53a266310182b6e51e5351110c13fa926bac52054ae7c8b7c11d1bd523c.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [


### PR DESCRIPTION
We need to create a new version number for AMI recipe when the parent AMI changes. That can happen every deploy because the parent AMI is dynamically queried for the latest id.