### PR TITLE
fix: ContainerImageBuilder.addExtraCertificates and AmiBuilder.addExtraCertificates do not work on Linux

### DIFF
--- a/API.md
+++ b/API.md
@@ -4142,6 +4142,7 @@ new LinuxUbuntuComponents()
 | --- | --- |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.LinuxUbuntuComponents.awsCli">awsCli</a></code> | *No description.* |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.LinuxUbuntuComponents.docker">docker</a></code> | *No description.* |
+| <code><a href="#@cloudsnorkel/cdk-github-runners.LinuxUbuntuComponents.extraCertificates">extraCertificates</a></code> | *No description.* |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.LinuxUbuntuComponents.git">git</a></code> | *No description.* |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.LinuxUbuntuComponents.githubCli">githubCli</a></code> | *No description.* |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.LinuxUbuntuComponents.githubRunner">githubRunner</a></code> | *No description.* |
@@ -4199,6 +4200,32 @@ LinuxUbuntuComponents.docker(scope: Construct, id: string, _architecture: Archit
 ###### `_architecture`<sup>Required</sup> <a name="_architecture" id="@cloudsnorkel/cdk-github-runners.LinuxUbuntuComponents.docker.parameter._architecture"></a>
 
 - *Type:* <a href="#@cloudsnorkel/cdk-github-runners.Architecture">Architecture</a>
+
+---
+
+##### `extraCertificates` <a name="extraCertificates" id="@cloudsnorkel/cdk-github-runners.LinuxUbuntuComponents.extraCertificates"></a>
+
+```typescript
+import { LinuxUbuntuComponents } from '@cloudsnorkel/cdk-github-runners'
+
+LinuxUbuntuComponents.extraCertificates(scope: Construct, id: string, path: string)
+```
+
+###### `scope`<sup>Required</sup> <a name="scope" id="@cloudsnorkel/cdk-github-runners.LinuxUbuntuComponents.extraCertificates.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+###### `id`<sup>Required</sup> <a name="id" id="@cloudsnorkel/cdk-github-runners.LinuxUbuntuComponents.extraCertificates.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+###### `path`<sup>Required</sup> <a name="path" id="@cloudsnorkel/cdk-github-runners.LinuxUbuntuComponents.extraCertificates.parameter.path"></a>
+
+- *Type:* string
 
 ---
 
@@ -4693,6 +4720,7 @@ new WindowsComponents()
 | <code><a href="#@cloudsnorkel/cdk-github-runners.WindowsComponents.awsCli">awsCli</a></code> | *No description.* |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.WindowsComponents.cloudwatchAgent">cloudwatchAgent</a></code> | *No description.* |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.WindowsComponents.docker">docker</a></code> | *No description.* |
+| <code><a href="#@cloudsnorkel/cdk-github-runners.WindowsComponents.extraCertificates">extraCertificates</a></code> | *No description.* |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.WindowsComponents.git">git</a></code> | *No description.* |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.WindowsComponents.githubCli">githubCli</a></code> | *No description.* |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.WindowsComponents.githubRunner">githubRunner</a></code> | *No description.* |
@@ -4754,6 +4782,32 @@ WindowsComponents.docker(scope: Construct, id: string)
 ---
 
 ###### `id`<sup>Required</sup> <a name="id" id="@cloudsnorkel/cdk-github-runners.WindowsComponents.docker.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+##### `extraCertificates` <a name="extraCertificates" id="@cloudsnorkel/cdk-github-runners.WindowsComponents.extraCertificates"></a>
+
+```typescript
+import { WindowsComponents } from '@cloudsnorkel/cdk-github-runners'
+
+WindowsComponents.extraCertificates(scope: Construct, id: string, path: string)
+```
+
+###### `scope`<sup>Required</sup> <a name="scope" id="@cloudsnorkel/cdk-github-runners.WindowsComponents.extraCertificates.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+###### `id`<sup>Required</sup> <a name="id" id="@cloudsnorkel/cdk-github-runners.WindowsComponents.extraCertificates.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+###### `path`<sup>Required</sup> <a name="path" id="@cloudsnorkel/cdk-github-runners.WindowsComponents.extraCertificates.parameter.path"></a>
 
 - *Type:* string
 

--- a/src/providers/image-builders/linux-components.ts
+++ b/src/providers/image-builders/linux-components.ts
@@ -1,3 +1,4 @@
+import { aws_s3_assets as s3_assets } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { Architecture, RunnerVersion } from '../common';
 import { ImageBuilderComponent } from './common';
@@ -146,6 +147,25 @@ export class LinuxUbuntuComponents {
         'DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin',
         'usermod -aG docker runner',
         'ln -s /usr/libexec/docker/cli-plugins/docker-compose /usr/bin/docker-compose',
+      ],
+    });
+  }
+
+  public static extraCertificates(scope: Construct, id: string, path: string) {
+    return new ImageBuilderComponent(scope, id, {
+      platform: 'Linux',
+      displayName: 'Extra certificates',
+      description: 'Install self-signed certificates to provide access to GitHub Enterprise Server',
+      commands: [
+        'set -ex',
+        'cp certs/certs.pem /usr/local/share/ca-certificates/github-enterprise-server.crt',
+        'update-ca-certificates',
+      ],
+      assets: [
+        {
+          path: 'certs',
+          asset: new s3_assets.Asset(scope, `${id} Asset`, { path }),
+        },
       ],
     });
   }

--- a/src/providers/image-builders/windows-components.ts
+++ b/src/providers/image-builders/windows-components.ts
@@ -1,3 +1,4 @@
+import { aws_s3_assets as s3_assets } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { RunnerVersion } from '../common';
 import { ImageBuilderComponent } from './common';
@@ -111,6 +112,24 @@ export class WindowsComponents {
         '$LatestDockerCompose = ($LatestUrl -Split \'/\')[-1]',
         'Invoke-WebRequest -UseBasicParsing -Uri  "https://github.com/docker/compose/releases/download/${LatestDockerCompose}/docker-compose-Windows-x86_64.exe" -OutFile $Env:ProgramFiles\\Docker\\docker-compose.exe',
         'copy $Env:ProgramFiles\\Docker\\docker-compose.exe $Env:ProgramFiles\\Docker\\cli-plugins\\docker-compose.exe',
+      ],
+    });
+  }
+
+  public static extraCertificates(scope: Construct, id: string, path: string) {
+    return new ImageBuilderComponent(scope, id, {
+      platform: 'Windows',
+      displayName: 'Extra certificates',
+      description: 'Install self-signed certificates to provide access to GitHub Enterprise Server',
+      commands: [
+        '$ErrorActionPreference = \'Stop\'',
+        'Import-Certificate -FilePath certs\\certs.pem -CertStoreLocation Cert:\\LocalMachine\\Root',
+      ],
+      assets: [
+        {
+          path: 'certs',
+          asset: new s3_assets.Asset(scope, `${id} Asset`, { path }),
+        },
       ],
     });
   }


### PR DESCRIPTION
Fixes #147