### PR TITLE
fix: EBS snapshots are not cleaned-up along with AMIs

### DIFF
--- a/src/lambdas/delete-ami/index.ts
+++ b/src/lambdas/delete-ami/index.ts
@@ -66,6 +66,16 @@ async function deleteAmis(launchTemplateId: string, stackName: string, builderNa
     await ec2.deregisterImage({
       ImageId: image.ImageId,
     }).promise();
+
+    for (const blockMapping of image.BlockDeviceMappings ?? []) {
+      if (blockMapping.Ebs?.SnapshotId) {
+        console.log(`Deleting ${blockMapping.Ebs.SnapshotId}`);
+
+        await ec2.deleteSnapshot({
+          SnapshotId: blockMapping.Ebs.SnapshotId,
+        }).promise();
+      }
+    }
   }
 }
 

--- a/src/providers/image-builders/ami.ts
+++ b/src/providers/image-builders/ami.ts
@@ -378,7 +378,7 @@ export class AmiBuilder extends ImageBuilderBase implements IAmiBuilder {
     const deleter = BundledNodejsFunction.singleton(this, 'delete-ami', {
       initialPolicy: [
         new iam.PolicyStatement({
-          actions: ['ec2:DescribeLaunchTemplateVersions', 'ec2:DescribeImages', 'ec2:DeregisterImage'],
+          actions: ['ec2:DescribeLaunchTemplateVersions', 'ec2:DescribeImages', 'ec2:DeregisterImage', 'ec2:DeleteSnapshot'],
           resources: ['*'],
         }),
       ],

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -144,15 +144,15 @@
         }
       }
     },
-    "2c96dbfaf75649542d8681744e77d3ef4a03a20df5e171ce2a0a72b0a18e5928": {
+    "466fbf6571844801c02e50bc555ab5db8b0c815ba43ada9ed03eea664be890f3": {
       "source": {
-        "path": "asset.2c96dbfaf75649542d8681744e77d3ef4a03a20df5e171ce2a0a72b0a18e5928",
+        "path": "asset.466fbf6571844801c02e50bc555ab5db8b0c815ba43ada9ed03eea664be890f3",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "2c96dbfaf75649542d8681744e77d3ef4a03a20df5e171ce2a0a72b0a18e5928.zip",
+          "objectKey": "466fbf6571844801c02e50bc555ab5db8b0c815ba43ada9ed03eea664be890f3.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -222,7 +222,7 @@
         }
       }
     },
-    "dc06872a30546303e89ea9f669e7d67b70ca294e8a4b7af0dc37858208774af0": {
+    "5cf4a4bc7736f2d378f04a69c050d27cafba9011a8cfdd8f490781d577649a82": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -230,7 +230,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "dc06872a30546303e89ea9f669e7d67b70ca294e8a4b7af0dc37858208774af0.json",
+          "objectKey": "5cf4a4bc7736f2d378f04a69c050d27cafba9011a8cfdd8f490781d577649a82.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -144,15 +144,15 @@
         }
       }
     },
-    "466fbf6571844801c02e50bc555ab5db8b0c815ba43ada9ed03eea664be890f3": {
+    "75363707e2756a09f31a94eec0a191c8f38b873bd96bf4fd5d21b6c6e7612ba4": {
       "source": {
-        "path": "asset.466fbf6571844801c02e50bc555ab5db8b0c815ba43ada9ed03eea664be890f3",
+        "path": "asset.75363707e2756a09f31a94eec0a191c8f38b873bd96bf4fd5d21b6c6e7612ba4",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "466fbf6571844801c02e50bc555ab5db8b0c815ba43ada9ed03eea664be890f3.zip",
+          "objectKey": "75363707e2756a09f31a94eec0a191c8f38b873bd96bf4fd5d21b6c6e7612ba4.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -222,7 +222,7 @@
         }
       }
     },
-    "5cf4a4bc7736f2d378f04a69c050d27cafba9011a8cfdd8f490781d577649a82": {
+    "5bdb97545990fafb65ad252cd2694d12749d3d887cfd0327feb65c50a3ec1d0d": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -230,7 +230,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "5cf4a4bc7736f2d378f04a69c050d27cafba9011a8cfdd8f490781d577649a82.json",
+          "objectKey": "5bdb97545990fafb65ad252cd2694d12749d3d887cfd0327feb65c50a3ec1d0d.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -7779,7 +7779,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "466fbf6571844801c02e50bc555ab5db8b0c815ba43ada9ed03eea664be890f3.zip"
+     "S3Key": "75363707e2756a09f31a94eec0a191c8f38b873bd96bf4fd5d21b6c6e7612ba4.zip"
     },
     "Role": {
      "Fn::GetAtt": [

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -7755,7 +7755,8 @@
        "Action": [
         "ec2:DescribeLaunchTemplateVersions",
         "ec2:DescribeImages",
-        "ec2:DeregisterImage"
+        "ec2:DeregisterImage",
+        "ec2:DeleteSnapshot"
        ],
        "Effect": "Allow",
        "Resource": "*"
@@ -7778,7 +7779,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "2c96dbfaf75649542d8681744e77d3ef4a03a20df5e171ce2a0a72b0a18e5928.zip"
+     "S3Key": "466fbf6571844801c02e50bc555ab5db8b0c815ba43ada9ed03eea664be890f3.zip"
     },
     "Role": {
      "Fn::GetAtt": [

--- a/test/default.integ.snapshot/manifest.json
+++ b/test/default.integ.snapshot/manifest.json
@@ -23,7 +23,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/5cf4a4bc7736f2d378f04a69c050d27cafba9011a8cfdd8f490781d577649a82.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/5bdb97545990fafb65ad252cd2694d12749d3d887cfd0327feb65c50a3ec1d0d.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/default.integ.snapshot/manifest.json
+++ b/test/default.integ.snapshot/manifest.json
@@ -23,7 +23,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/dc06872a30546303e89ea9f669e7d67b70ca294e8a4b7af0dc37858208774af0.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/5cf4a4bc7736f2d378f04a69c050d27cafba9011a8cfdd8f490781d577649a82.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/default.integ.snapshot/tree.json
+++ b/test/default.integ.snapshot/tree.json
@@ -10845,7 +10845,7 @@
                       "s3Bucket": {
                         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                       },
-                      "s3Key": "466fbf6571844801c02e50bc555ab5db8b0c815ba43ada9ed03eea664be890f3.zip"
+                      "s3Key": "75363707e2756a09f31a94eec0a191c8f38b873bd96bf4fd5d21b6c6e7612ba4.zip"
                     },
                     "role": {
                       "Fn::GetAtt": [

--- a/test/default.integ.snapshot/tree.json
+++ b/test/default.integ.snapshot/tree.json
@@ -10775,7 +10775,8 @@
                                   "Action": [
                                     "ec2:DescribeLaunchTemplateVersions",
                                     "ec2:DescribeImages",
-                                    "ec2:DeregisterImage"
+                                    "ec2:DeregisterImage",
+                                    "ec2:DeleteSnapshot"
                                   ],
                                   "Effect": "Allow",
                                   "Resource": "*"
@@ -10844,7 +10845,7 @@
                       "s3Bucket": {
                         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                       },
-                      "s3Key": "2c96dbfaf75649542d8681744e77d3ef4a03a20df5e171ce2a0a72b0a18e5928.zip"
+                      "s3Key": "466fbf6571844801c02e50bc555ab5db8b0c815ba43ada9ed03eea664be890f3.zip"
                     },
                     "role": {
                       "Fn::GetAtt": [


### PR DESCRIPTION
We need to manually delete EBS snapshots as they are not automatically deleted when deregistering AMIs.

Fixes #184