### PR TITLE
feat: Optional faster CodeBuild provider without privileged mode

### DIFF
--- a/API.md
+++ b/API.md
@@ -2772,6 +2772,7 @@ const codeBuildRunnerProps: CodeBuildRunnerProps = { ... }
 | --- | --- | --- |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.CodeBuildRunnerProps.property.logRetention">logRetention</a></code> | <code>aws-cdk-lib.aws_logs.RetentionDays</code> | The number of days log events are kept in CloudWatch Logs. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.CodeBuildRunnerProps.property.computeType">computeType</a></code> | <code>aws-cdk-lib.aws_codebuild.ComputeType</code> | The type of compute to use for this build. |
+| <code><a href="#@cloudsnorkel/cdk-github-runners.CodeBuildRunnerProps.property.dockerInDocker">dockerInDocker</a></code> | <code>boolean</code> | Support building and running Docker images by enabling Docker-in-Docker (dind) and the required CodeBuild privileged mode. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.CodeBuildRunnerProps.property.imageBuilder">imageBuilder</a></code> | <code><a href="#@cloudsnorkel/cdk-github-runners.IImageBuilder">IImageBuilder</a></code> | Image builder for CodeBuild image with GitHub runner pre-configured. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.CodeBuildRunnerProps.property.label">label</a></code> | <code>string</code> | GitHub Actions label used for this provider. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.CodeBuildRunnerProps.property.labels">labels</a></code> | <code>string[]</code> | GitHub Actions labels used for this provider. |
@@ -2812,6 +2813,22 @@ public readonly computeType: ComputeType;
 The type of compute to use for this build.
 
 See the {@link ComputeType} enum for the possible values.
+
+---
+
+##### `dockerInDocker`<sup>Optional</sup> <a name="dockerInDocker" id="@cloudsnorkel/cdk-github-runners.CodeBuildRunnerProps.property.dockerInDocker"></a>
+
+```typescript
+public readonly dockerInDocker: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Support building and running Docker images by enabling Docker-in-Docker (dind) and the required CodeBuild privileged mode.
+
+Disabling this can
+speed up provisioning of CodeBuild runners. If you don't intend on running or building Docker images, disable this for faster start-up times.
 
 ---
 

--- a/src/providers/codebuild.ts
+++ b/src/providers/codebuild.ts
@@ -100,6 +100,14 @@ export interface CodeBuildRunnerProps extends RunnerProviderProps {
    * @default Duration.hours(1)
    */
   readonly timeout?: Duration;
+
+  /**
+   * Support building and running Docker images by enabling Docker-in-Docker (dind) and the required CodeBuild privileged mode. Disabling this can
+   * speed up provisioning of CodeBuild runners. If you don't intend on running or building Docker images, disable this for faster start-up times.
+   *
+   * @default true
+   */
+  readonly dockerInDocker?: boolean;
 }
 
 /**

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -20,6 +20,35 @@ test('CodeBuild provider', () => {
   }));
 });
 
+test('CodeBuild provider privileged', () => {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, 'test');
+
+  new CodeBuildRunner(stack, 'provider false', {
+    dockerInDocker: false,
+  });
+
+  new CodeBuildRunner(stack, 'provider true', {
+    dockerInDocker: true,
+  });
+
+  new CodeBuildRunner(stack, 'provider default');
+
+  const template = Template.fromStack(stack);
+
+  template.resourcePropertiesCountIs('AWS::CodeBuild::Project', Match.objectLike({
+    Environment: {
+      PrivilegedMode: true,
+    },
+  }), 2/*runners*/+3/*image builders*/);
+
+  template.hasResourceProperties('AWS::CodeBuild::Project', Match.objectLike({
+    Environment: {
+      PrivilegedMode: false,
+    },
+  }));
+});
+
 test('Lambda provider', () => {
   const app = new cdk.App();
   const stack = new cdk.Stack(app, 'test');


### PR DESCRIPTION
Give the user the ability to turn off Docker-in-Docker (dind) support, which lets us use non-privileged CodeBuild projects. These projects should provision faster and not require us to wait for Docker to start-up.

Fixes #195