### PR TITLE
fix: Try running EC2 instances in all selected subnets

### DIFF
--- a/src/providers/common.ts
+++ b/src/providers/common.ts
@@ -474,7 +474,7 @@ export abstract class BaseProvider extends Construct {
     return [defaultLabel];
   }
 
-  protected addRetry(task: stepfunctions.TaskStateBase, errors: string[]) {
+  protected addRetry(task: stepfunctions.TaskStateBase | stepfunctions.Parallel, errors: string[]) {
     if (this.retryOptions?.retry ?? true) {
       task.addRetry({
         errors,

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -222,7 +222,7 @@
         }
       }
     },
-    "d03524251450243230a44df8c2447eabc0fd932b4708ed03be8cff20efe6dad0": {
+    "30b4d3bd98d6ae09f6d6fb23f0a4ce8ff0ffc03d5fd8c8e98a31554fa7662835": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -230,7 +230,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "d03524251450243230a44df8c2447eabc0fd932b4708ed03be8cff20efe6dad0.json",
+          "objectKey": "30b4d3bd98d6ae09f6d6fb23f0a4ce8ff0ffc03d5fd8c8e98a31554fa7662835.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -11315,7 +11315,19 @@
          "GroupId"
         ]
        },
-       "\"]}},\"Overrides\":{\"ContainerOverrides\":[{\"Name\":\"runner\",\"Environment\":[{\"Name\":\"RUNNER_TOKEN\",\"Value.$\":\"$.runner.token\"},{\"Name\":\"RUNNER_NAME\",\"Value.$\":\"$$.Execution.Name\"},{\"Name\":\"RUNNER_LABEL\",\"Value\":\"fargate,windows,x64\"},{\"Name\":\"GITHUB_DOMAIN\",\"Value.$\":\"$.runner.domain\"},{\"Name\":\"OWNER\",\"Value.$\":\"$.owner\"},{\"Name\":\"REPO\",\"Value.$\":\"$.repo\"}]}]},\"EnableExecuteCommand\":false,\"CapacityProviderStrategy\":[{\"CapacityProvider\":\"FARGATE\"}]}},\"ec2, linux, x64 data\":{\"Type\":\"Pass\",\"ResultPath\":\"$.ec2\",\"Parameters\":{\"userdataTemplate\":\"#!/bin/bash -x\\nTASK_TOKEN=\\\"{}\\\"\\nheartbeat () \\\\{\\n  while true; do\\n    aws stepfunctions send-task-heartbeat --task-token \\\"$TASK_TOKEN\\\"\\n    sleep 60\\n  done\\n\\\\}\\nsetup_logs () \\\\{\\n  cat <<EOF > /tmp/log.conf || exit 1\\n  \\\\{\\n    \\\"logs\\\": \\\\{\\n      \\\"log_stream_name\\\": \\\"unknown\\\",\\n      \\\"logs_collected\\\": \\\\{\\n        \\\"files\\\": \\\\{\\n          \\\"collect_list\\\": [\\n            \\\\{\\n              \\\"file_path\\\": \\\"/var/log/runner.log\\\",\\n              \\\"log_group_name\\\": \\\"{}\\\",\\n              \\\"log_stream_name\\\": \\\"{}\\\",\\n              \\\"timezone\\\": \\\"UTC\\\"\\n            \\\\}\\n          ]\\n        \\\\}\\n      \\\\}\\n    \\\\}\\n  \\\\}\\nEOF\\n  /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/tmp/log.conf || exit 2\\n\\\\}\\naction () \\\\{\\n  sudo -Hu runner /home/runner/config.sh --unattended --url \\\"https://{}/{}/{}\\\" --token \\\"{}\\\" --ephemeral --work _work --labels \\\"{}\\\" {} --name \\\"{}\\\" || exit 1\\n  sudo --preserve-env=AWS_REGION -Hu runner /home/runner/run.sh || exit 2\\n\\\\}\\nheartbeat &\\nif setup_logs && action | tee /var/log/runner.log 2>&1; then\\n  aws stepfunctions send-task-success --task-token \\\"$TASK_TOKEN\\\" --task-output '\\\\{\\\"ok\\\": true\\\\}'\\nelse\\n  aws stepfunctions send-task-failure --task-token \\\"$TASK_TOKEN\\\"\\nfi\\npoweroff\\n\"},\"Next\":\"ec2, linux, x64\"},\"ec2, linux, x64\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Ec2.Ec2Exception\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Type\":\"Task\",\"HeartbeatSeconds\":300,\"Resource\":\"arn:",
+       "\"]}},\"Overrides\":{\"ContainerOverrides\":[{\"Name\":\"runner\",\"Environment\":[{\"Name\":\"RUNNER_TOKEN\",\"Value.$\":\"$.runner.token\"},{\"Name\":\"RUNNER_NAME\",\"Value.$\":\"$$.Execution.Name\"},{\"Name\":\"RUNNER_LABEL\",\"Value\":\"fargate,windows,x64\"},{\"Name\":\"GITHUB_DOMAIN\",\"Value.$\":\"$.runner.domain\"},{\"Name\":\"OWNER\",\"Value.$\":\"$.owner\"},{\"Name\":\"REPO\",\"Value.$\":\"$.repo\"}]}]},\"EnableExecuteCommand\":false,\"CapacityProviderStrategy\":[{\"CapacityProvider\":\"FARGATE\"}]}},\"ec2, linux, x64 data\":{\"Type\":\"Pass\",\"ResultPath\":\"$.ec2\",\"Parameters\":{\"userdataTemplate\":\"#!/bin/bash -x\\nTASK_TOKEN=\\\"{}\\\"\\nheartbeat () \\\\{\\n  while true; do\\n    aws stepfunctions send-task-heartbeat --task-token \\\"$TASK_TOKEN\\\"\\n    sleep 60\\n  done\\n\\\\}\\nsetup_logs () \\\\{\\n  cat <<EOF > /tmp/log.conf || exit 1\\n  \\\\{\\n    \\\"logs\\\": \\\\{\\n      \\\"log_stream_name\\\": \\\"unknown\\\",\\n      \\\"logs_collected\\\": \\\\{\\n        \\\"files\\\": \\\\{\\n          \\\"collect_list\\\": [\\n            \\\\{\\n              \\\"file_path\\\": \\\"/var/log/runner.log\\\",\\n              \\\"log_group_name\\\": \\\"{}\\\",\\n              \\\"log_stream_name\\\": \\\"{}\\\",\\n              \\\"timezone\\\": \\\"UTC\\\"\\n            \\\\}\\n          ]\\n        \\\\}\\n      \\\\}\\n    \\\\}\\n  \\\\}\\nEOF\\n  /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/tmp/log.conf || exit 2\\n\\\\}\\naction () \\\\{\\n  sudo -Hu runner /home/runner/config.sh --unattended --url \\\"https://{}/{}/{}\\\" --token \\\"{}\\\" --ephemeral --work _work --labels \\\"{}\\\" {} --name \\\"{}\\\" || exit 1\\n  sudo --preserve-env=AWS_REGION -Hu runner /home/runner/run.sh || exit 2\\n\\\\}\\nheartbeat &\\nif setup_logs && action | tee /var/log/runner.log 2>&1; then\\n  aws stepfunctions send-task-success --task-token \\\"$TASK_TOKEN\\\" --task-output '\\\\{\\\"ok\\\": true\\\\}'\\nelse\\n  aws stepfunctions send-task-failure --task-token \\\"$TASK_TOKEN\\\"\\nfi\\npoweroff\\n\"},\"Next\":\"ec2, linux, x64 subnet iterator\"},\"ec2, linux, x64 subnet iterator\":{\"Type\":\"Parallel\",\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Ec2.Ec2Exception\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Branches\":[{\"StartAt\":\"ec2, linux, x64 ",
+       {
+        "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
+       },
+       "\",\"States\":{\"ec2, linux, x64 ",
+       {
+        "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
+       },
+       "\":{\"Next\":\"ec2, linux, x64 success\",\"Catch\":[{\"ErrorEquals\":[\"Ec2.Ec2Exception\"],\"ResultPath\":\"$.lastSubnetError\",\"Next\":\"ec2, linux, x64 ",
+       {
+        "Ref": "VpcPublicSubnet2Subnet691E08A3"
+       },
+       "\"}],\"Type\":\"Task\",\"HeartbeatSeconds\":300,\"Resource\":\"arn:",
        {
         "Ref": "AWS::Partition"
        },
@@ -11345,7 +11357,53 @@
        {
         "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
        },
-       "\",\"BlockDeviceMappings\":[{\"DeviceName\":\"/dev/sda1\",\"Ebs\":{\"DeleteOnTermination\":true,\"VolumeSize\":30}}]}},\"ec2-spot, linux, x64 data\":{\"Type\":\"Pass\",\"ResultPath\":\"$.ec2\",\"Parameters\":{\"userdataTemplate\":\"#!/bin/bash -x\\nTASK_TOKEN=\\\"{}\\\"\\nheartbeat () \\\\{\\n  while true; do\\n    aws stepfunctions send-task-heartbeat --task-token \\\"$TASK_TOKEN\\\"\\n    sleep 60\\n  done\\n\\\\}\\nsetup_logs () \\\\{\\n  cat <<EOF > /tmp/log.conf || exit 1\\n  \\\\{\\n    \\\"logs\\\": \\\\{\\n      \\\"log_stream_name\\\": \\\"unknown\\\",\\n      \\\"logs_collected\\\": \\\\{\\n        \\\"files\\\": \\\\{\\n          \\\"collect_list\\\": [\\n            \\\\{\\n              \\\"file_path\\\": \\\"/var/log/runner.log\\\",\\n              \\\"log_group_name\\\": \\\"{}\\\",\\n              \\\"log_stream_name\\\": \\\"{}\\\",\\n              \\\"timezone\\\": \\\"UTC\\\"\\n            \\\\}\\n          ]\\n        \\\\}\\n      \\\\}\\n    \\\\}\\n  \\\\}\\nEOF\\n  /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/tmp/log.conf || exit 2\\n\\\\}\\naction () \\\\{\\n  sudo -Hu runner /home/runner/config.sh --unattended --url \\\"https://{}/{}/{}\\\" --token \\\"{}\\\" --ephemeral --work _work --labels \\\"{}\\\" {} --name \\\"{}\\\" || exit 1\\n  sudo --preserve-env=AWS_REGION -Hu runner /home/runner/run.sh || exit 2\\n\\\\}\\nheartbeat &\\nif setup_logs && action | tee /var/log/runner.log 2>&1; then\\n  aws stepfunctions send-task-success --task-token \\\"$TASK_TOKEN\\\" --task-output '\\\\{\\\"ok\\\": true\\\\}'\\nelse\\n  aws stepfunctions send-task-failure --task-token \\\"$TASK_TOKEN\\\"\\nfi\\npoweroff\\n\"},\"Next\":\"ec2-spot, linux, x64\"},\"ec2-spot, linux, x64\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Ec2.Ec2Exception\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Type\":\"Task\",\"HeartbeatSeconds\":300,\"Resource\":\"arn:",
+       "\",\"BlockDeviceMappings\":[{\"DeviceName\":\"/dev/sda1\",\"Ebs\":{\"DeleteOnTermination\":true,\"VolumeSize\":30}}]}},\"ec2, linux, x64 success\":{\"Type\":\"Succeed\"},\"ec2, linux, x64 ",
+       {
+        "Ref": "VpcPublicSubnet2Subnet691E08A3"
+       },
+       "\":{\"Next\":\"ec2, linux, x64 success\",\"Type\":\"Task\",\"HeartbeatSeconds\":300,\"Resource\":\"arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":states:::aws-sdk:ec2:runInstances.waitForTaskToken\",\"Parameters\":{\"LaunchTemplate\":{\"LaunchTemplateId\":\"",
+       {
+        "Ref": "AMILinuxBuilderLaunchtemplateA29452C4"
+       },
+       "\"},\"MinCount\":1,\"MaxCount\":1,\"InstanceType\":\"m5.large\",\"UserData.$\":\"States.Base64Encode(States.Format($.ec2.userdataTemplate, $$.Task.Token, '",
+       {
+        "Ref": "EC2LinuxLogsC4CD8F14"
+       },
+       "', $$.Execution.Name, $.runner.domain, $.owner, $.repo, $.runner.token, 'ec2,linux,x64', '', $$.Execution.Name))\",\"InstanceInitiatedShutdownBehavior\":\"terminate\",\"IamInstanceProfile\":{\"Arn\":\"",
+       {
+        "Fn::GetAtt": [
+         "EC2LinuxInstanceProfile2D2BB473",
+         "Arn"
+        ]
+       },
+       "\"},\"MetadataOptions\":{\"HttpTokens\":\"required\"},\"SecurityGroupIds\":[\"",
+       {
+        "Fn::GetAtt": [
+         "EC2LinuxSGF5B89300",
+         "GroupId"
+        ]
+       },
+       "\"],\"SubnetId\":\"",
+       {
+        "Ref": "VpcPublicSubnet2Subnet691E08A3"
+       },
+       "\",\"BlockDeviceMappings\":[{\"DeviceName\":\"/dev/sda1\",\"Ebs\":{\"DeleteOnTermination\":true,\"VolumeSize\":30}}]}}}}]},\"ec2-spot, linux, x64 data\":{\"Type\":\"Pass\",\"ResultPath\":\"$.ec2\",\"Parameters\":{\"userdataTemplate\":\"#!/bin/bash -x\\nTASK_TOKEN=\\\"{}\\\"\\nheartbeat () \\\\{\\n  while true; do\\n    aws stepfunctions send-task-heartbeat --task-token \\\"$TASK_TOKEN\\\"\\n    sleep 60\\n  done\\n\\\\}\\nsetup_logs () \\\\{\\n  cat <<EOF > /tmp/log.conf || exit 1\\n  \\\\{\\n    \\\"logs\\\": \\\\{\\n      \\\"log_stream_name\\\": \\\"unknown\\\",\\n      \\\"logs_collected\\\": \\\\{\\n        \\\"files\\\": \\\\{\\n          \\\"collect_list\\\": [\\n            \\\\{\\n              \\\"file_path\\\": \\\"/var/log/runner.log\\\",\\n              \\\"log_group_name\\\": \\\"{}\\\",\\n              \\\"log_stream_name\\\": \\\"{}\\\",\\n              \\\"timezone\\\": \\\"UTC\\\"\\n            \\\\}\\n          ]\\n        \\\\}\\n      \\\\}\\n    \\\\}\\n  \\\\}\\nEOF\\n  /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/tmp/log.conf || exit 2\\n\\\\}\\naction () \\\\{\\n  sudo -Hu runner /home/runner/config.sh --unattended --url \\\"https://{}/{}/{}\\\" --token \\\"{}\\\" --ephemeral --work _work --labels \\\"{}\\\" {} --name \\\"{}\\\" || exit 1\\n  sudo --preserve-env=AWS_REGION -Hu runner /home/runner/run.sh || exit 2\\n\\\\}\\nheartbeat &\\nif setup_logs && action | tee /var/log/runner.log 2>&1; then\\n  aws stepfunctions send-task-success --task-token \\\"$TASK_TOKEN\\\" --task-output '\\\\{\\\"ok\\\": true\\\\}'\\nelse\\n  aws stepfunctions send-task-failure --task-token \\\"$TASK_TOKEN\\\"\\nfi\\npoweroff\\n\"},\"Next\":\"ec2-spot, linux, x64 subnet iterator\"},\"ec2-spot, linux, x64 subnet iterator\":{\"Type\":\"Parallel\",\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Ec2.Ec2Exception\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Branches\":[{\"StartAt\":\"ec2-spot, linux, x64 ",
+       {
+        "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
+       },
+       "\",\"States\":{\"ec2-spot, linux, x64 ",
+       {
+        "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
+       },
+       "\":{\"Next\":\"ec2-spot, linux, x64 success\",\"Catch\":[{\"ErrorEquals\":[\"Ec2.Ec2Exception\"],\"ResultPath\":\"$.lastSubnetError\",\"Next\":\"ec2-spot, linux, x64 ",
+       {
+        "Ref": "VpcPublicSubnet2Subnet691E08A3"
+       },
+       "\"}],\"Type\":\"Task\",\"HeartbeatSeconds\":300,\"Resource\":\"arn:",
        {
         "Ref": "AWS::Partition"
        },
@@ -11375,7 +11433,53 @@
        {
         "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
        },
-       "\",\"BlockDeviceMappings\":[{\"DeviceName\":\"/dev/sda1\",\"Ebs\":{\"DeleteOnTermination\":true,\"VolumeSize\":30}}],\"InstanceMarketOptions\":{\"MarketType\":\"spot\",\"SpotOptions\":{\"SpotInstanceType\":\"one-time\"}}}},\"ec2, linux, arm64 data\":{\"Type\":\"Pass\",\"ResultPath\":\"$.ec2\",\"Parameters\":{\"userdataTemplate\":\"#!/bin/bash -x\\nTASK_TOKEN=\\\"{}\\\"\\nheartbeat () \\\\{\\n  while true; do\\n    aws stepfunctions send-task-heartbeat --task-token \\\"$TASK_TOKEN\\\"\\n    sleep 60\\n  done\\n\\\\}\\nsetup_logs () \\\\{\\n  cat <<EOF > /tmp/log.conf || exit 1\\n  \\\\{\\n    \\\"logs\\\": \\\\{\\n      \\\"log_stream_name\\\": \\\"unknown\\\",\\n      \\\"logs_collected\\\": \\\\{\\n        \\\"files\\\": \\\\{\\n          \\\"collect_list\\\": [\\n            \\\\{\\n              \\\"file_path\\\": \\\"/var/log/runner.log\\\",\\n              \\\"log_group_name\\\": \\\"{}\\\",\\n              \\\"log_stream_name\\\": \\\"{}\\\",\\n              \\\"timezone\\\": \\\"UTC\\\"\\n            \\\\}\\n          ]\\n        \\\\}\\n      \\\\}\\n    \\\\}\\n  \\\\}\\nEOF\\n  /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/tmp/log.conf || exit 2\\n\\\\}\\naction () \\\\{\\n  sudo -Hu runner /home/runner/config.sh --unattended --url \\\"https://{}/{}/{}\\\" --token \\\"{}\\\" --ephemeral --work _work --labels \\\"{}\\\" {} --name \\\"{}\\\" || exit 1\\n  sudo --preserve-env=AWS_REGION -Hu runner /home/runner/run.sh || exit 2\\n\\\\}\\nheartbeat &\\nif setup_logs && action | tee /var/log/runner.log 2>&1; then\\n  aws stepfunctions send-task-success --task-token \\\"$TASK_TOKEN\\\" --task-output '\\\\{\\\"ok\\\": true\\\\}'\\nelse\\n  aws stepfunctions send-task-failure --task-token \\\"$TASK_TOKEN\\\"\\nfi\\npoweroff\\n\"},\"Next\":\"ec2, linux, arm64\"},\"ec2, linux, arm64\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Ec2.Ec2Exception\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Type\":\"Task\",\"HeartbeatSeconds\":300,\"Resource\":\"arn:",
+       "\",\"BlockDeviceMappings\":[{\"DeviceName\":\"/dev/sda1\",\"Ebs\":{\"DeleteOnTermination\":true,\"VolumeSize\":30}}],\"InstanceMarketOptions\":{\"MarketType\":\"spot\",\"SpotOptions\":{\"SpotInstanceType\":\"one-time\"}}}},\"ec2-spot, linux, x64 success\":{\"Type\":\"Succeed\"},\"ec2-spot, linux, x64 ",
+       {
+        "Ref": "VpcPublicSubnet2Subnet691E08A3"
+       },
+       "\":{\"Next\":\"ec2-spot, linux, x64 success\",\"Type\":\"Task\",\"HeartbeatSeconds\":300,\"Resource\":\"arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":states:::aws-sdk:ec2:runInstances.waitForTaskToken\",\"Parameters\":{\"LaunchTemplate\":{\"LaunchTemplateId\":\"",
+       {
+        "Ref": "AMILinuxBuilderLaunchtemplateA29452C4"
+       },
+       "\"},\"MinCount\":1,\"MaxCount\":1,\"InstanceType\":\"m5.large\",\"UserData.$\":\"States.Base64Encode(States.Format($.ec2.userdataTemplate, $$.Task.Token, '",
+       {
+        "Ref": "EC2SpotLinuxLogsF78D5F0E"
+       },
+       "', $$.Execution.Name, $.runner.domain, $.owner, $.repo, $.runner.token, 'ec2-spot,linux,x64', '', $$.Execution.Name))\",\"InstanceInitiatedShutdownBehavior\":\"terminate\",\"IamInstanceProfile\":{\"Arn\":\"",
+       {
+        "Fn::GetAtt": [
+         "EC2SpotLinuxInstanceProfileB12320D4",
+         "Arn"
+        ]
+       },
+       "\"},\"MetadataOptions\":{\"HttpTokens\":\"required\"},\"SecurityGroupIds\":[\"",
+       {
+        "Fn::GetAtt": [
+         "EC2SpotLinuxSG8D846B64",
+         "GroupId"
+        ]
+       },
+       "\"],\"SubnetId\":\"",
+       {
+        "Ref": "VpcPublicSubnet2Subnet691E08A3"
+       },
+       "\",\"BlockDeviceMappings\":[{\"DeviceName\":\"/dev/sda1\",\"Ebs\":{\"DeleteOnTermination\":true,\"VolumeSize\":30}}],\"InstanceMarketOptions\":{\"MarketType\":\"spot\",\"SpotOptions\":{\"SpotInstanceType\":\"one-time\"}}}}}}]},\"ec2, linux, arm64 data\":{\"Type\":\"Pass\",\"ResultPath\":\"$.ec2\",\"Parameters\":{\"userdataTemplate\":\"#!/bin/bash -x\\nTASK_TOKEN=\\\"{}\\\"\\nheartbeat () \\\\{\\n  while true; do\\n    aws stepfunctions send-task-heartbeat --task-token \\\"$TASK_TOKEN\\\"\\n    sleep 60\\n  done\\n\\\\}\\nsetup_logs () \\\\{\\n  cat <<EOF > /tmp/log.conf || exit 1\\n  \\\\{\\n    \\\"logs\\\": \\\\{\\n      \\\"log_stream_name\\\": \\\"unknown\\\",\\n      \\\"logs_collected\\\": \\\\{\\n        \\\"files\\\": \\\\{\\n          \\\"collect_list\\\": [\\n            \\\\{\\n              \\\"file_path\\\": \\\"/var/log/runner.log\\\",\\n              \\\"log_group_name\\\": \\\"{}\\\",\\n              \\\"log_stream_name\\\": \\\"{}\\\",\\n              \\\"timezone\\\": \\\"UTC\\\"\\n            \\\\}\\n          ]\\n        \\\\}\\n      \\\\}\\n    \\\\}\\n  \\\\}\\nEOF\\n  /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/tmp/log.conf || exit 2\\n\\\\}\\naction () \\\\{\\n  sudo -Hu runner /home/runner/config.sh --unattended --url \\\"https://{}/{}/{}\\\" --token \\\"{}\\\" --ephemeral --work _work --labels \\\"{}\\\" {} --name \\\"{}\\\" || exit 1\\n  sudo --preserve-env=AWS_REGION -Hu runner /home/runner/run.sh || exit 2\\n\\\\}\\nheartbeat &\\nif setup_logs && action | tee /var/log/runner.log 2>&1; then\\n  aws stepfunctions send-task-success --task-token \\\"$TASK_TOKEN\\\" --task-output '\\\\{\\\"ok\\\": true\\\\}'\\nelse\\n  aws stepfunctions send-task-failure --task-token \\\"$TASK_TOKEN\\\"\\nfi\\npoweroff\\n\"},\"Next\":\"ec2, linux, arm64 subnet iterator\"},\"ec2, linux, arm64 subnet iterator\":{\"Type\":\"Parallel\",\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Ec2.Ec2Exception\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Branches\":[{\"StartAt\":\"ec2, linux, arm64 ",
+       {
+        "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
+       },
+       "\",\"States\":{\"ec2, linux, arm64 ",
+       {
+        "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
+       },
+       "\":{\"Next\":\"ec2, linux, arm64 success\",\"Catch\":[{\"ErrorEquals\":[\"Ec2.Ec2Exception\"],\"ResultPath\":\"$.lastSubnetError\",\"Next\":\"ec2, linux, arm64 ",
+       {
+        "Ref": "VpcPublicSubnet2Subnet691E08A3"
+       },
+       "\"}],\"Type\":\"Task\",\"HeartbeatSeconds\":300,\"Resource\":\"arn:",
        {
         "Ref": "AWS::Partition"
        },
@@ -11405,7 +11509,53 @@
        {
         "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
        },
-       "\",\"BlockDeviceMappings\":[{\"DeviceName\":\"/dev/sda1\",\"Ebs\":{\"DeleteOnTermination\":true,\"VolumeSize\":30}}]}},\"ec2, windows, x64 data\":{\"Type\":\"Pass\",\"ResultPath\":\"$.ec2\",\"Parameters\":{\"userdataTemplate\":\"<powershell>\\n$TASK_TOKEN = \\\"{}\\\"\\nStart-Job -ScriptBlock \\\\{\\n  while (1) \\\\{\\n    aws stepfunctions send-task-heartbeat --task-token \\\"$using:TASK_TOKEN\\\"\\n    sleep 60\\n  \\\\}\\n\\\\}\\nfunction setup_logs () \\\\{\\n  echo '\\\\{\\n    \\\"logs\\\": \\\\{\\n      \\\"log_stream_name\\\": \\\"unknown\\\",\\n      \\\"logs_collected\\\": \\\\{\\n        \\\"files\\\": \\\\{\\n         \\\"collect_list\\\": [\\n            \\\\{\\n              \\\"file_path\\\": \\\"/actions/runner.log\\\",\\n              \\\"log_group_name\\\": \\\"{}\\\",\\n              \\\"log_stream_name\\\": \\\"{}\\\",\\n              \\\"timezone\\\": \\\"UTC\\\"\\n            \\\\}\\n          ]\\n        \\\\}\\n      \\\\}\\n    \\\\}\\n  \\\\}' | Out-File -Encoding ASCII $Env:TEMP/log.conf\\n  & \\\"C:/Program Files/Amazon/AmazonCloudWatchAgent/amazon-cloudwatch-agent-ctl.ps1\\\" -a fetch-config -m ec2 -s -c file:$Env:TEMP/log.conf\\n\\\\}\\nfunction action () \\\\{\\n  cd /actions\\n  ./config.cmd --unattended --url \\\"https://{}/{}/{}\\\" --token \\\"{}\\\" --ephemeral --work _work --labels \\\"{}\\\" {} --name \\\"{}\\\" 2>&1 | Out-File -Encoding ASCII -Append /actions/runner.log\\n  if ($LASTEXITCODE -ne 0) \\\\{ return 1 \\\\}\\n  ./run.cmd 2>&1 | Out-File -Encoding ASCII -Append /actions/runner.log\\n  if ($LASTEXITCODE -ne 0) \\\\{ return 2 \\\\}\\n  return 0\\n\\\\}\\nsetup_logs\\n$r = action\\nif ($r -eq 0) \\\\{\\n  aws stepfunctions send-task-success --task-token \\\"$TASK_TOKEN\\\" --task-output '\\\\{ \\\\}'\\n\\\\} else \\\\{\\n  aws stepfunctions send-task-failure --task-token \\\"$TASK_TOKEN\\\"\\n\\\\}\\nStop-Computer -ComputerName localhost -Force\\n</powershell>\\n\"},\"Next\":\"ec2, windows, x64\"},\"ec2, windows, x64\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Ec2.Ec2Exception\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Type\":\"Task\",\"HeartbeatSeconds\":300,\"Resource\":\"arn:",
+       "\",\"BlockDeviceMappings\":[{\"DeviceName\":\"/dev/sda1\",\"Ebs\":{\"DeleteOnTermination\":true,\"VolumeSize\":30}}]}},\"ec2, linux, arm64 success\":{\"Type\":\"Succeed\"},\"ec2, linux, arm64 ",
+       {
+        "Ref": "VpcPublicSubnet2Subnet691E08A3"
+       },
+       "\":{\"Next\":\"ec2, linux, arm64 success\",\"Type\":\"Task\",\"HeartbeatSeconds\":300,\"Resource\":\"arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":states:::aws-sdk:ec2:runInstances.waitForTaskToken\",\"Parameters\":{\"LaunchTemplate\":{\"LaunchTemplateId\":\"",
+       {
+        "Ref": "AMILinuxarm64BuilderLaunchtemplate8F5EFF44"
+       },
+       "\"},\"MinCount\":1,\"MaxCount\":1,\"InstanceType\":\"m6g.large\",\"UserData.$\":\"States.Base64Encode(States.Format($.ec2.userdataTemplate, $$.Task.Token, '",
+       {
+        "Ref": "EC2Linuxarm64Logs577E371E"
+       },
+       "', $$.Execution.Name, $.runner.domain, $.owner, $.repo, $.runner.token, 'ec2,linux,arm64', '', $$.Execution.Name))\",\"InstanceInitiatedShutdownBehavior\":\"terminate\",\"IamInstanceProfile\":{\"Arn\":\"",
+       {
+        "Fn::GetAtt": [
+         "EC2Linuxarm64InstanceProfile1E6F8D53",
+         "Arn"
+        ]
+       },
+       "\"},\"MetadataOptions\":{\"HttpTokens\":\"required\"},\"SecurityGroupIds\":[\"",
+       {
+        "Fn::GetAtt": [
+         "EC2Linuxarm64SG550ECD6C",
+         "GroupId"
+        ]
+       },
+       "\"],\"SubnetId\":\"",
+       {
+        "Ref": "VpcPublicSubnet2Subnet691E08A3"
+       },
+       "\",\"BlockDeviceMappings\":[{\"DeviceName\":\"/dev/sda1\",\"Ebs\":{\"DeleteOnTermination\":true,\"VolumeSize\":30}}]}}}}]},\"ec2, windows, x64 data\":{\"Type\":\"Pass\",\"ResultPath\":\"$.ec2\",\"Parameters\":{\"userdataTemplate\":\"<powershell>\\n$TASK_TOKEN = \\\"{}\\\"\\nStart-Job -ScriptBlock \\\\{\\n  while (1) \\\\{\\n    aws stepfunctions send-task-heartbeat --task-token \\\"$using:TASK_TOKEN\\\"\\n    sleep 60\\n  \\\\}\\n\\\\}\\nfunction setup_logs () \\\\{\\n  echo '\\\\{\\n    \\\"logs\\\": \\\\{\\n      \\\"log_stream_name\\\": \\\"unknown\\\",\\n      \\\"logs_collected\\\": \\\\{\\n        \\\"files\\\": \\\\{\\n         \\\"collect_list\\\": [\\n            \\\\{\\n              \\\"file_path\\\": \\\"/actions/runner.log\\\",\\n              \\\"log_group_name\\\": \\\"{}\\\",\\n              \\\"log_stream_name\\\": \\\"{}\\\",\\n              \\\"timezone\\\": \\\"UTC\\\"\\n            \\\\}\\n          ]\\n        \\\\}\\n      \\\\}\\n    \\\\}\\n  \\\\}' | Out-File -Encoding ASCII $Env:TEMP/log.conf\\n  & \\\"C:/Program Files/Amazon/AmazonCloudWatchAgent/amazon-cloudwatch-agent-ctl.ps1\\\" -a fetch-config -m ec2 -s -c file:$Env:TEMP/log.conf\\n\\\\}\\nfunction action () \\\\{\\n  cd /actions\\n  ./config.cmd --unattended --url \\\"https://{}/{}/{}\\\" --token \\\"{}\\\" --ephemeral --work _work --labels \\\"{}\\\" {} --name \\\"{}\\\" 2>&1 | Out-File -Encoding ASCII -Append /actions/runner.log\\n  if ($LASTEXITCODE -ne 0) \\\\{ return 1 \\\\}\\n  ./run.cmd 2>&1 | Out-File -Encoding ASCII -Append /actions/runner.log\\n  if ($LASTEXITCODE -ne 0) \\\\{ return 2 \\\\}\\n  return 0\\n\\\\}\\nsetup_logs\\n$r = action\\nif ($r -eq 0) \\\\{\\n  aws stepfunctions send-task-success --task-token \\\"$TASK_TOKEN\\\" --task-output '\\\\{ \\\\}'\\n\\\\} else \\\\{\\n  aws stepfunctions send-task-failure --task-token \\\"$TASK_TOKEN\\\"\\n\\\\}\\nStop-Computer -ComputerName localhost -Force\\n</powershell>\\n\"},\"Next\":\"ec2, windows, x64 subnet iterator\"},\"ec2, windows, x64 subnet iterator\":{\"Type\":\"Parallel\",\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Ec2.Ec2Exception\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Branches\":[{\"StartAt\":\"ec2, windows, x64 ",
+       {
+        "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
+       },
+       "\",\"States\":{\"ec2, windows, x64 ",
+       {
+        "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
+       },
+       "\":{\"Next\":\"ec2, windows, x64 success\",\"Catch\":[{\"ErrorEquals\":[\"Ec2.Ec2Exception\"],\"ResultPath\":\"$.lastSubnetError\",\"Next\":\"ec2, windows, x64 ",
+       {
+        "Ref": "VpcPublicSubnet2Subnet691E08A3"
+       },
+       "\"}],\"Type\":\"Task\",\"HeartbeatSeconds\":300,\"Resource\":\"arn:",
        {
         "Ref": "AWS::Partition"
        },
@@ -11435,7 +11585,41 @@
        {
         "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
        },
-       "\",\"BlockDeviceMappings\":[{\"DeviceName\":\"/dev/sda1\",\"Ebs\":{\"DeleteOnTermination\":true,\"VolumeSize\":30}}]}}}},{\"StartAt\":\"Wait\",\"States\":{\"Wait\":{\"Type\":\"Wait\",\"Seconds\":600,\"Next\":\"Delete Idle Runner\"},\"Delete Idle Runner\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2}],\"Type\":\"Task\",\"ResultPath\":\"$.delete\",\"Resource\":\"",
+       "\",\"BlockDeviceMappings\":[{\"DeviceName\":\"/dev/sda1\",\"Ebs\":{\"DeleteOnTermination\":true,\"VolumeSize\":30}}]}},\"ec2, windows, x64 success\":{\"Type\":\"Succeed\"},\"ec2, windows, x64 ",
+       {
+        "Ref": "VpcPublicSubnet2Subnet691E08A3"
+       },
+       "\":{\"Next\":\"ec2, windows, x64 success\",\"Type\":\"Task\",\"HeartbeatSeconds\":300,\"Resource\":\"arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":states:::aws-sdk:ec2:runInstances.waitForTaskToken\",\"Parameters\":{\"LaunchTemplate\":{\"LaunchTemplateId\":\"",
+       {
+        "Ref": "WindowsEC2BuilderLaunchtemplate0A66E9C2"
+       },
+       "\"},\"MinCount\":1,\"MaxCount\":1,\"InstanceType\":\"m5.large\",\"UserData.$\":\"States.Base64Encode(States.Format($.ec2.userdataTemplate, $$.Task.Token, '",
+       {
+        "Ref": "EC2WindowsLogsDC1F2ABF"
+       },
+       "', $$.Execution.Name, $.runner.domain, $.owner, $.repo, $.runner.token, 'ec2,windows,x64', '', $$.Execution.Name))\",\"InstanceInitiatedShutdownBehavior\":\"terminate\",\"IamInstanceProfile\":{\"Arn\":\"",
+       {
+        "Fn::GetAtt": [
+         "EC2WindowsInstanceProfileDCA59D9C",
+         "Arn"
+        ]
+       },
+       "\"},\"MetadataOptions\":{\"HttpTokens\":\"required\"},\"SecurityGroupIds\":[\"",
+       {
+        "Fn::GetAtt": [
+         "EC2WindowsSG13E24976",
+         "GroupId"
+        ]
+       },
+       "\"],\"SubnetId\":\"",
+       {
+        "Ref": "VpcPublicSubnet2Subnet691E08A3"
+       },
+       "\",\"BlockDeviceMappings\":[{\"DeviceName\":\"/dev/sda1\",\"Ebs\":{\"DeleteOnTermination\":true,\"VolumeSize\":30}}]}}}}]}}},{\"StartAt\":\"Wait\",\"States\":{\"Wait\":{\"Type\":\"Wait\",\"Seconds\":600,\"Next\":\"Delete Idle Runner\"},\"Delete Idle Runner\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2}],\"Type\":\"Task\",\"ResultPath\":\"$.delete\",\"Resource\":\"",
        {
         "Fn::GetAtt": [
          "runnersdeleterunner7F8D5293",

--- a/test/default.integ.snapshot/manifest.json
+++ b/test/default.integ.snapshot/manifest.json
@@ -23,7 +23,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/d03524251450243230a44df8c2447eabc0fd932b4708ed03be8cff20efe6dad0.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/30b4d3bd98d6ae09f6d6fb23f0a4ce8ff0ffc03d5fd8c8e98a31554fa7662835.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/default.integ.snapshot/tree.json
+++ b/test/default.integ.snapshot/tree.json
@@ -10682,11 +10682,35 @@
                   "version": "2.50.0"
                 }
               },
-              "ec2, linux, x64": {
-                "id": "ec2, linux, x64",
-                "path": "github-runners-test/EC2 Linux/ec2, linux, x64",
+              "ec2, linux, x64 ${Token[TOKEN.373]}": {
+                "id": "ec2, linux, x64 ${Token[TOKEN.373]}",
+                "path": "github-runners-test/EC2 Linux/ec2, linux, x64 ${Token[TOKEN.373]}",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_stepfunctions_tasks.CallAwsService",
+                  "version": "2.50.0"
+                }
+              },
+              "ec2, linux, x64 ${Token[TOKEN.389]}": {
+                "id": "ec2, linux, x64 ${Token[TOKEN.389]}",
+                "path": "github-runners-test/EC2 Linux/ec2, linux, x64 ${Token[TOKEN.389]}",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_stepfunctions_tasks.CallAwsService",
+                  "version": "2.50.0"
+                }
+              },
+              "ec2, linux, x64 subnet iterator": {
+                "id": "ec2, linux, x64 subnet iterator",
+                "path": "github-runners-test/EC2 Linux/ec2, linux, x64 subnet iterator",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_stepfunctions.Parallel",
+                  "version": "2.50.0"
+                }
+              },
+              "ec2, linux, x64 success": {
+                "id": "ec2, linux, x64 success",
+                "path": "github-runners-test/EC2 Linux/ec2, linux, x64 success",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_stepfunctions.Succeed",
                   "version": "2.50.0"
                 }
               }
@@ -11103,11 +11127,35 @@
                   "version": "2.50.0"
                 }
               },
-              "ec2-spot, linux, x64": {
-                "id": "ec2-spot, linux, x64",
-                "path": "github-runners-test/EC2 Spot Linux/ec2-spot, linux, x64",
+              "ec2-spot, linux, x64 ${Token[TOKEN.373]}": {
+                "id": "ec2-spot, linux, x64 ${Token[TOKEN.373]}",
+                "path": "github-runners-test/EC2 Spot Linux/ec2-spot, linux, x64 ${Token[TOKEN.373]}",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_stepfunctions_tasks.CallAwsService",
+                  "version": "2.50.0"
+                }
+              },
+              "ec2-spot, linux, x64 ${Token[TOKEN.389]}": {
+                "id": "ec2-spot, linux, x64 ${Token[TOKEN.389]}",
+                "path": "github-runners-test/EC2 Spot Linux/ec2-spot, linux, x64 ${Token[TOKEN.389]}",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_stepfunctions_tasks.CallAwsService",
+                  "version": "2.50.0"
+                }
+              },
+              "ec2-spot, linux, x64 subnet iterator": {
+                "id": "ec2-spot, linux, x64 subnet iterator",
+                "path": "github-runners-test/EC2 Spot Linux/ec2-spot, linux, x64 subnet iterator",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_stepfunctions.Parallel",
+                  "version": "2.50.0"
+                }
+              },
+              "ec2-spot, linux, x64 success": {
+                "id": "ec2-spot, linux, x64 success",
+                "path": "github-runners-test/EC2 Spot Linux/ec2-spot, linux, x64 success",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_stepfunctions.Succeed",
                   "version": "2.50.0"
                 }
               }
@@ -12214,11 +12262,35 @@
                   "version": "2.50.0"
                 }
               },
-              "ec2, linux, arm64": {
-                "id": "ec2, linux, arm64",
-                "path": "github-runners-test/EC2 Linux arm64/ec2, linux, arm64",
+              "ec2, linux, arm64 ${Token[TOKEN.373]}": {
+                "id": "ec2, linux, arm64 ${Token[TOKEN.373]}",
+                "path": "github-runners-test/EC2 Linux arm64/ec2, linux, arm64 ${Token[TOKEN.373]}",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_stepfunctions_tasks.CallAwsService",
+                  "version": "2.50.0"
+                }
+              },
+              "ec2, linux, arm64 ${Token[TOKEN.389]}": {
+                "id": "ec2, linux, arm64 ${Token[TOKEN.389]}",
+                "path": "github-runners-test/EC2 Linux arm64/ec2, linux, arm64 ${Token[TOKEN.389]}",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_stepfunctions_tasks.CallAwsService",
+                  "version": "2.50.0"
+                }
+              },
+              "ec2, linux, arm64 subnet iterator": {
+                "id": "ec2, linux, arm64 subnet iterator",
+                "path": "github-runners-test/EC2 Linux arm64/ec2, linux, arm64 subnet iterator",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_stepfunctions.Parallel",
+                  "version": "2.50.0"
+                }
+              },
+              "ec2, linux, arm64 success": {
+                "id": "ec2, linux, arm64 success",
+                "path": "github-runners-test/EC2 Linux arm64/ec2, linux, arm64 success",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_stepfunctions.Succeed",
                   "version": "2.50.0"
                 }
               }
@@ -13285,11 +13357,35 @@
                   "version": "2.50.0"
                 }
               },
-              "ec2, windows, x64": {
-                "id": "ec2, windows, x64",
-                "path": "github-runners-test/EC2 Windows/ec2, windows, x64",
+              "ec2, windows, x64 ${Token[TOKEN.373]}": {
+                "id": "ec2, windows, x64 ${Token[TOKEN.373]}",
+                "path": "github-runners-test/EC2 Windows/ec2, windows, x64 ${Token[TOKEN.373]}",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_stepfunctions_tasks.CallAwsService",
+                  "version": "2.50.0"
+                }
+              },
+              "ec2, windows, x64 ${Token[TOKEN.389]}": {
+                "id": "ec2, windows, x64 ${Token[TOKEN.389]}",
+                "path": "github-runners-test/EC2 Windows/ec2, windows, x64 ${Token[TOKEN.389]}",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_stepfunctions_tasks.CallAwsService",
+                  "version": "2.50.0"
+                }
+              },
+              "ec2, windows, x64 subnet iterator": {
+                "id": "ec2, windows, x64 subnet iterator",
+                "path": "github-runners-test/EC2 Windows/ec2, windows, x64 subnet iterator",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_stepfunctions.Parallel",
+                  "version": "2.50.0"
+                }
+              },
+              "ec2, windows, x64 success": {
+                "id": "ec2, windows, x64 success",
+                "path": "github-runners-test/EC2 Windows/ec2, windows, x64 success",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_stepfunctions.Succeed",
                   "version": "2.50.0"
                 }
               }
@@ -15187,7 +15283,19 @@
                                   "GroupId"
                                 ]
                               },
-                              "\"]}},\"Overrides\":{\"ContainerOverrides\":[{\"Name\":\"runner\",\"Environment\":[{\"Name\":\"RUNNER_TOKEN\",\"Value.$\":\"$.runner.token\"},{\"Name\":\"RUNNER_NAME\",\"Value.$\":\"$$.Execution.Name\"},{\"Name\":\"RUNNER_LABEL\",\"Value\":\"fargate,windows,x64\"},{\"Name\":\"GITHUB_DOMAIN\",\"Value.$\":\"$.runner.domain\"},{\"Name\":\"OWNER\",\"Value.$\":\"$.owner\"},{\"Name\":\"REPO\",\"Value.$\":\"$.repo\"}]}]},\"EnableExecuteCommand\":false,\"CapacityProviderStrategy\":[{\"CapacityProvider\":\"FARGATE\"}]}},\"ec2, linux, x64 data\":{\"Type\":\"Pass\",\"ResultPath\":\"$.ec2\",\"Parameters\":{\"userdataTemplate\":\"#!/bin/bash -x\\nTASK_TOKEN=\\\"{}\\\"\\nheartbeat () \\\\{\\n  while true; do\\n    aws stepfunctions send-task-heartbeat --task-token \\\"$TASK_TOKEN\\\"\\n    sleep 60\\n  done\\n\\\\}\\nsetup_logs () \\\\{\\n  cat <<EOF > /tmp/log.conf || exit 1\\n  \\\\{\\n    \\\"logs\\\": \\\\{\\n      \\\"log_stream_name\\\": \\\"unknown\\\",\\n      \\\"logs_collected\\\": \\\\{\\n        \\\"files\\\": \\\\{\\n          \\\"collect_list\\\": [\\n            \\\\{\\n              \\\"file_path\\\": \\\"/var/log/runner.log\\\",\\n              \\\"log_group_name\\\": \\\"{}\\\",\\n              \\\"log_stream_name\\\": \\\"{}\\\",\\n              \\\"timezone\\\": \\\"UTC\\\"\\n            \\\\}\\n          ]\\n        \\\\}\\n      \\\\}\\n    \\\\}\\n  \\\\}\\nEOF\\n  /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/tmp/log.conf || exit 2\\n\\\\}\\naction () \\\\{\\n  sudo -Hu runner /home/runner/config.sh --unattended --url \\\"https://{}/{}/{}\\\" --token \\\"{}\\\" --ephemeral --work _work --labels \\\"{}\\\" {} --name \\\"{}\\\" || exit 1\\n  sudo --preserve-env=AWS_REGION -Hu runner /home/runner/run.sh || exit 2\\n\\\\}\\nheartbeat &\\nif setup_logs && action | tee /var/log/runner.log 2>&1; then\\n  aws stepfunctions send-task-success --task-token \\\"$TASK_TOKEN\\\" --task-output '\\\\{\\\"ok\\\": true\\\\}'\\nelse\\n  aws stepfunctions send-task-failure --task-token \\\"$TASK_TOKEN\\\"\\nfi\\npoweroff\\n\"},\"Next\":\"ec2, linux, x64\"},\"ec2, linux, x64\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Ec2.Ec2Exception\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Type\":\"Task\",\"HeartbeatSeconds\":300,\"Resource\":\"arn:",
+                              "\"]}},\"Overrides\":{\"ContainerOverrides\":[{\"Name\":\"runner\",\"Environment\":[{\"Name\":\"RUNNER_TOKEN\",\"Value.$\":\"$.runner.token\"},{\"Name\":\"RUNNER_NAME\",\"Value.$\":\"$$.Execution.Name\"},{\"Name\":\"RUNNER_LABEL\",\"Value\":\"fargate,windows,x64\"},{\"Name\":\"GITHUB_DOMAIN\",\"Value.$\":\"$.runner.domain\"},{\"Name\":\"OWNER\",\"Value.$\":\"$.owner\"},{\"Name\":\"REPO\",\"Value.$\":\"$.repo\"}]}]},\"EnableExecuteCommand\":false,\"CapacityProviderStrategy\":[{\"CapacityProvider\":\"FARGATE\"}]}},\"ec2, linux, x64 data\":{\"Type\":\"Pass\",\"ResultPath\":\"$.ec2\",\"Parameters\":{\"userdataTemplate\":\"#!/bin/bash -x\\nTASK_TOKEN=\\\"{}\\\"\\nheartbeat () \\\\{\\n  while true; do\\n    aws stepfunctions send-task-heartbeat --task-token \\\"$TASK_TOKEN\\\"\\n    sleep 60\\n  done\\n\\\\}\\nsetup_logs () \\\\{\\n  cat <<EOF > /tmp/log.conf || exit 1\\n  \\\\{\\n    \\\"logs\\\": \\\\{\\n      \\\"log_stream_name\\\": \\\"unknown\\\",\\n      \\\"logs_collected\\\": \\\\{\\n        \\\"files\\\": \\\\{\\n          \\\"collect_list\\\": [\\n            \\\\{\\n              \\\"file_path\\\": \\\"/var/log/runner.log\\\",\\n              \\\"log_group_name\\\": \\\"{}\\\",\\n              \\\"log_stream_name\\\": \\\"{}\\\",\\n              \\\"timezone\\\": \\\"UTC\\\"\\n            \\\\}\\n          ]\\n        \\\\}\\n      \\\\}\\n    \\\\}\\n  \\\\}\\nEOF\\n  /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/tmp/log.conf || exit 2\\n\\\\}\\naction () \\\\{\\n  sudo -Hu runner /home/runner/config.sh --unattended --url \\\"https://{}/{}/{}\\\" --token \\\"{}\\\" --ephemeral --work _work --labels \\\"{}\\\" {} --name \\\"{}\\\" || exit 1\\n  sudo --preserve-env=AWS_REGION -Hu runner /home/runner/run.sh || exit 2\\n\\\\}\\nheartbeat &\\nif setup_logs && action | tee /var/log/runner.log 2>&1; then\\n  aws stepfunctions send-task-success --task-token \\\"$TASK_TOKEN\\\" --task-output '\\\\{\\\"ok\\\": true\\\\}'\\nelse\\n  aws stepfunctions send-task-failure --task-token \\\"$TASK_TOKEN\\\"\\nfi\\npoweroff\\n\"},\"Next\":\"ec2, linux, x64 subnet iterator\"},\"ec2, linux, x64 subnet iterator\":{\"Type\":\"Parallel\",\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Ec2.Ec2Exception\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Branches\":[{\"StartAt\":\"ec2, linux, x64 ",
+                              {
+                                "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
+                              },
+                              "\",\"States\":{\"ec2, linux, x64 ",
+                              {
+                                "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
+                              },
+                              "\":{\"Next\":\"ec2, linux, x64 success\",\"Catch\":[{\"ErrorEquals\":[\"Ec2.Ec2Exception\"],\"ResultPath\":\"$.lastSubnetError\",\"Next\":\"ec2, linux, x64 ",
+                              {
+                                "Ref": "VpcPublicSubnet2Subnet691E08A3"
+                              },
+                              "\"}],\"Type\":\"Task\",\"HeartbeatSeconds\":300,\"Resource\":\"arn:",
                               {
                                 "Ref": "AWS::Partition"
                               },
@@ -15217,7 +15325,53 @@
                               {
                                 "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
                               },
-                              "\",\"BlockDeviceMappings\":[{\"DeviceName\":\"/dev/sda1\",\"Ebs\":{\"DeleteOnTermination\":true,\"VolumeSize\":30}}]}},\"ec2-spot, linux, x64 data\":{\"Type\":\"Pass\",\"ResultPath\":\"$.ec2\",\"Parameters\":{\"userdataTemplate\":\"#!/bin/bash -x\\nTASK_TOKEN=\\\"{}\\\"\\nheartbeat () \\\\{\\n  while true; do\\n    aws stepfunctions send-task-heartbeat --task-token \\\"$TASK_TOKEN\\\"\\n    sleep 60\\n  done\\n\\\\}\\nsetup_logs () \\\\{\\n  cat <<EOF > /tmp/log.conf || exit 1\\n  \\\\{\\n    \\\"logs\\\": \\\\{\\n      \\\"log_stream_name\\\": \\\"unknown\\\",\\n      \\\"logs_collected\\\": \\\\{\\n        \\\"files\\\": \\\\{\\n          \\\"collect_list\\\": [\\n            \\\\{\\n              \\\"file_path\\\": \\\"/var/log/runner.log\\\",\\n              \\\"log_group_name\\\": \\\"{}\\\",\\n              \\\"log_stream_name\\\": \\\"{}\\\",\\n              \\\"timezone\\\": \\\"UTC\\\"\\n            \\\\}\\n          ]\\n        \\\\}\\n      \\\\}\\n    \\\\}\\n  \\\\}\\nEOF\\n  /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/tmp/log.conf || exit 2\\n\\\\}\\naction () \\\\{\\n  sudo -Hu runner /home/runner/config.sh --unattended --url \\\"https://{}/{}/{}\\\" --token \\\"{}\\\" --ephemeral --work _work --labels \\\"{}\\\" {} --name \\\"{}\\\" || exit 1\\n  sudo --preserve-env=AWS_REGION -Hu runner /home/runner/run.sh || exit 2\\n\\\\}\\nheartbeat &\\nif setup_logs && action | tee /var/log/runner.log 2>&1; then\\n  aws stepfunctions send-task-success --task-token \\\"$TASK_TOKEN\\\" --task-output '\\\\{\\\"ok\\\": true\\\\}'\\nelse\\n  aws stepfunctions send-task-failure --task-token \\\"$TASK_TOKEN\\\"\\nfi\\npoweroff\\n\"},\"Next\":\"ec2-spot, linux, x64\"},\"ec2-spot, linux, x64\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Ec2.Ec2Exception\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Type\":\"Task\",\"HeartbeatSeconds\":300,\"Resource\":\"arn:",
+                              "\",\"BlockDeviceMappings\":[{\"DeviceName\":\"/dev/sda1\",\"Ebs\":{\"DeleteOnTermination\":true,\"VolumeSize\":30}}]}},\"ec2, linux, x64 success\":{\"Type\":\"Succeed\"},\"ec2, linux, x64 ",
+                              {
+                                "Ref": "VpcPublicSubnet2Subnet691E08A3"
+                              },
+                              "\":{\"Next\":\"ec2, linux, x64 success\",\"Type\":\"Task\",\"HeartbeatSeconds\":300,\"Resource\":\"arn:",
+                              {
+                                "Ref": "AWS::Partition"
+                              },
+                              ":states:::aws-sdk:ec2:runInstances.waitForTaskToken\",\"Parameters\":{\"LaunchTemplate\":{\"LaunchTemplateId\":\"",
+                              {
+                                "Ref": "AMILinuxBuilderLaunchtemplateA29452C4"
+                              },
+                              "\"},\"MinCount\":1,\"MaxCount\":1,\"InstanceType\":\"m5.large\",\"UserData.$\":\"States.Base64Encode(States.Format($.ec2.userdataTemplate, $$.Task.Token, '",
+                              {
+                                "Ref": "EC2LinuxLogsC4CD8F14"
+                              },
+                              "', $$.Execution.Name, $.runner.domain, $.owner, $.repo, $.runner.token, 'ec2,linux,x64', '', $$.Execution.Name))\",\"InstanceInitiatedShutdownBehavior\":\"terminate\",\"IamInstanceProfile\":{\"Arn\":\"",
+                              {
+                                "Fn::GetAtt": [
+                                  "EC2LinuxInstanceProfile2D2BB473",
+                                  "Arn"
+                                ]
+                              },
+                              "\"},\"MetadataOptions\":{\"HttpTokens\":\"required\"},\"SecurityGroupIds\":[\"",
+                              {
+                                "Fn::GetAtt": [
+                                  "EC2LinuxSGF5B89300",
+                                  "GroupId"
+                                ]
+                              },
+                              "\"],\"SubnetId\":\"",
+                              {
+                                "Ref": "VpcPublicSubnet2Subnet691E08A3"
+                              },
+                              "\",\"BlockDeviceMappings\":[{\"DeviceName\":\"/dev/sda1\",\"Ebs\":{\"DeleteOnTermination\":true,\"VolumeSize\":30}}]}}}}]},\"ec2-spot, linux, x64 data\":{\"Type\":\"Pass\",\"ResultPath\":\"$.ec2\",\"Parameters\":{\"userdataTemplate\":\"#!/bin/bash -x\\nTASK_TOKEN=\\\"{}\\\"\\nheartbeat () \\\\{\\n  while true; do\\n    aws stepfunctions send-task-heartbeat --task-token \\\"$TASK_TOKEN\\\"\\n    sleep 60\\n  done\\n\\\\}\\nsetup_logs () \\\\{\\n  cat <<EOF > /tmp/log.conf || exit 1\\n  \\\\{\\n    \\\"logs\\\": \\\\{\\n      \\\"log_stream_name\\\": \\\"unknown\\\",\\n      \\\"logs_collected\\\": \\\\{\\n        \\\"files\\\": \\\\{\\n          \\\"collect_list\\\": [\\n            \\\\{\\n              \\\"file_path\\\": \\\"/var/log/runner.log\\\",\\n              \\\"log_group_name\\\": \\\"{}\\\",\\n              \\\"log_stream_name\\\": \\\"{}\\\",\\n              \\\"timezone\\\": \\\"UTC\\\"\\n            \\\\}\\n          ]\\n        \\\\}\\n      \\\\}\\n    \\\\}\\n  \\\\}\\nEOF\\n  /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/tmp/log.conf || exit 2\\n\\\\}\\naction () \\\\{\\n  sudo -Hu runner /home/runner/config.sh --unattended --url \\\"https://{}/{}/{}\\\" --token \\\"{}\\\" --ephemeral --work _work --labels \\\"{}\\\" {} --name \\\"{}\\\" || exit 1\\n  sudo --preserve-env=AWS_REGION -Hu runner /home/runner/run.sh || exit 2\\n\\\\}\\nheartbeat &\\nif setup_logs && action | tee /var/log/runner.log 2>&1; then\\n  aws stepfunctions send-task-success --task-token \\\"$TASK_TOKEN\\\" --task-output '\\\\{\\\"ok\\\": true\\\\}'\\nelse\\n  aws stepfunctions send-task-failure --task-token \\\"$TASK_TOKEN\\\"\\nfi\\npoweroff\\n\"},\"Next\":\"ec2-spot, linux, x64 subnet iterator\"},\"ec2-spot, linux, x64 subnet iterator\":{\"Type\":\"Parallel\",\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Ec2.Ec2Exception\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Branches\":[{\"StartAt\":\"ec2-spot, linux, x64 ",
+                              {
+                                "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
+                              },
+                              "\",\"States\":{\"ec2-spot, linux, x64 ",
+                              {
+                                "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
+                              },
+                              "\":{\"Next\":\"ec2-spot, linux, x64 success\",\"Catch\":[{\"ErrorEquals\":[\"Ec2.Ec2Exception\"],\"ResultPath\":\"$.lastSubnetError\",\"Next\":\"ec2-spot, linux, x64 ",
+                              {
+                                "Ref": "VpcPublicSubnet2Subnet691E08A3"
+                              },
+                              "\"}],\"Type\":\"Task\",\"HeartbeatSeconds\":300,\"Resource\":\"arn:",
                               {
                                 "Ref": "AWS::Partition"
                               },
@@ -15247,7 +15401,53 @@
                               {
                                 "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
                               },
-                              "\",\"BlockDeviceMappings\":[{\"DeviceName\":\"/dev/sda1\",\"Ebs\":{\"DeleteOnTermination\":true,\"VolumeSize\":30}}],\"InstanceMarketOptions\":{\"MarketType\":\"spot\",\"SpotOptions\":{\"SpotInstanceType\":\"one-time\"}}}},\"ec2, linux, arm64 data\":{\"Type\":\"Pass\",\"ResultPath\":\"$.ec2\",\"Parameters\":{\"userdataTemplate\":\"#!/bin/bash -x\\nTASK_TOKEN=\\\"{}\\\"\\nheartbeat () \\\\{\\n  while true; do\\n    aws stepfunctions send-task-heartbeat --task-token \\\"$TASK_TOKEN\\\"\\n    sleep 60\\n  done\\n\\\\}\\nsetup_logs () \\\\{\\n  cat <<EOF > /tmp/log.conf || exit 1\\n  \\\\{\\n    \\\"logs\\\": \\\\{\\n      \\\"log_stream_name\\\": \\\"unknown\\\",\\n      \\\"logs_collected\\\": \\\\{\\n        \\\"files\\\": \\\\{\\n          \\\"collect_list\\\": [\\n            \\\\{\\n              \\\"file_path\\\": \\\"/var/log/runner.log\\\",\\n              \\\"log_group_name\\\": \\\"{}\\\",\\n              \\\"log_stream_name\\\": \\\"{}\\\",\\n              \\\"timezone\\\": \\\"UTC\\\"\\n            \\\\}\\n          ]\\n        \\\\}\\n      \\\\}\\n    \\\\}\\n  \\\\}\\nEOF\\n  /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/tmp/log.conf || exit 2\\n\\\\}\\naction () \\\\{\\n  sudo -Hu runner /home/runner/config.sh --unattended --url \\\"https://{}/{}/{}\\\" --token \\\"{}\\\" --ephemeral --work _work --labels \\\"{}\\\" {} --name \\\"{}\\\" || exit 1\\n  sudo --preserve-env=AWS_REGION -Hu runner /home/runner/run.sh || exit 2\\n\\\\}\\nheartbeat &\\nif setup_logs && action | tee /var/log/runner.log 2>&1; then\\n  aws stepfunctions send-task-success --task-token \\\"$TASK_TOKEN\\\" --task-output '\\\\{\\\"ok\\\": true\\\\}'\\nelse\\n  aws stepfunctions send-task-failure --task-token \\\"$TASK_TOKEN\\\"\\nfi\\npoweroff\\n\"},\"Next\":\"ec2, linux, arm64\"},\"ec2, linux, arm64\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Ec2.Ec2Exception\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Type\":\"Task\",\"HeartbeatSeconds\":300,\"Resource\":\"arn:",
+                              "\",\"BlockDeviceMappings\":[{\"DeviceName\":\"/dev/sda1\",\"Ebs\":{\"DeleteOnTermination\":true,\"VolumeSize\":30}}],\"InstanceMarketOptions\":{\"MarketType\":\"spot\",\"SpotOptions\":{\"SpotInstanceType\":\"one-time\"}}}},\"ec2-spot, linux, x64 success\":{\"Type\":\"Succeed\"},\"ec2-spot, linux, x64 ",
+                              {
+                                "Ref": "VpcPublicSubnet2Subnet691E08A3"
+                              },
+                              "\":{\"Next\":\"ec2-spot, linux, x64 success\",\"Type\":\"Task\",\"HeartbeatSeconds\":300,\"Resource\":\"arn:",
+                              {
+                                "Ref": "AWS::Partition"
+                              },
+                              ":states:::aws-sdk:ec2:runInstances.waitForTaskToken\",\"Parameters\":{\"LaunchTemplate\":{\"LaunchTemplateId\":\"",
+                              {
+                                "Ref": "AMILinuxBuilderLaunchtemplateA29452C4"
+                              },
+                              "\"},\"MinCount\":1,\"MaxCount\":1,\"InstanceType\":\"m5.large\",\"UserData.$\":\"States.Base64Encode(States.Format($.ec2.userdataTemplate, $$.Task.Token, '",
+                              {
+                                "Ref": "EC2SpotLinuxLogsF78D5F0E"
+                              },
+                              "', $$.Execution.Name, $.runner.domain, $.owner, $.repo, $.runner.token, 'ec2-spot,linux,x64', '', $$.Execution.Name))\",\"InstanceInitiatedShutdownBehavior\":\"terminate\",\"IamInstanceProfile\":{\"Arn\":\"",
+                              {
+                                "Fn::GetAtt": [
+                                  "EC2SpotLinuxInstanceProfileB12320D4",
+                                  "Arn"
+                                ]
+                              },
+                              "\"},\"MetadataOptions\":{\"HttpTokens\":\"required\"},\"SecurityGroupIds\":[\"",
+                              {
+                                "Fn::GetAtt": [
+                                  "EC2SpotLinuxSG8D846B64",
+                                  "GroupId"
+                                ]
+                              },
+                              "\"],\"SubnetId\":\"",
+                              {
+                                "Ref": "VpcPublicSubnet2Subnet691E08A3"
+                              },
+                              "\",\"BlockDeviceMappings\":[{\"DeviceName\":\"/dev/sda1\",\"Ebs\":{\"DeleteOnTermination\":true,\"VolumeSize\":30}}],\"InstanceMarketOptions\":{\"MarketType\":\"spot\",\"SpotOptions\":{\"SpotInstanceType\":\"one-time\"}}}}}}]},\"ec2, linux, arm64 data\":{\"Type\":\"Pass\",\"ResultPath\":\"$.ec2\",\"Parameters\":{\"userdataTemplate\":\"#!/bin/bash -x\\nTASK_TOKEN=\\\"{}\\\"\\nheartbeat () \\\\{\\n  while true; do\\n    aws stepfunctions send-task-heartbeat --task-token \\\"$TASK_TOKEN\\\"\\n    sleep 60\\n  done\\n\\\\}\\nsetup_logs () \\\\{\\n  cat <<EOF > /tmp/log.conf || exit 1\\n  \\\\{\\n    \\\"logs\\\": \\\\{\\n      \\\"log_stream_name\\\": \\\"unknown\\\",\\n      \\\"logs_collected\\\": \\\\{\\n        \\\"files\\\": \\\\{\\n          \\\"collect_list\\\": [\\n            \\\\{\\n              \\\"file_path\\\": \\\"/var/log/runner.log\\\",\\n              \\\"log_group_name\\\": \\\"{}\\\",\\n              \\\"log_stream_name\\\": \\\"{}\\\",\\n              \\\"timezone\\\": \\\"UTC\\\"\\n            \\\\}\\n          ]\\n        \\\\}\\n      \\\\}\\n    \\\\}\\n  \\\\}\\nEOF\\n  /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/tmp/log.conf || exit 2\\n\\\\}\\naction () \\\\{\\n  sudo -Hu runner /home/runner/config.sh --unattended --url \\\"https://{}/{}/{}\\\" --token \\\"{}\\\" --ephemeral --work _work --labels \\\"{}\\\" {} --name \\\"{}\\\" || exit 1\\n  sudo --preserve-env=AWS_REGION -Hu runner /home/runner/run.sh || exit 2\\n\\\\}\\nheartbeat &\\nif setup_logs && action | tee /var/log/runner.log 2>&1; then\\n  aws stepfunctions send-task-success --task-token \\\"$TASK_TOKEN\\\" --task-output '\\\\{\\\"ok\\\": true\\\\}'\\nelse\\n  aws stepfunctions send-task-failure --task-token \\\"$TASK_TOKEN\\\"\\nfi\\npoweroff\\n\"},\"Next\":\"ec2, linux, arm64 subnet iterator\"},\"ec2, linux, arm64 subnet iterator\":{\"Type\":\"Parallel\",\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Ec2.Ec2Exception\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Branches\":[{\"StartAt\":\"ec2, linux, arm64 ",
+                              {
+                                "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
+                              },
+                              "\",\"States\":{\"ec2, linux, arm64 ",
+                              {
+                                "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
+                              },
+                              "\":{\"Next\":\"ec2, linux, arm64 success\",\"Catch\":[{\"ErrorEquals\":[\"Ec2.Ec2Exception\"],\"ResultPath\":\"$.lastSubnetError\",\"Next\":\"ec2, linux, arm64 ",
+                              {
+                                "Ref": "VpcPublicSubnet2Subnet691E08A3"
+                              },
+                              "\"}],\"Type\":\"Task\",\"HeartbeatSeconds\":300,\"Resource\":\"arn:",
                               {
                                 "Ref": "AWS::Partition"
                               },
@@ -15277,7 +15477,53 @@
                               {
                                 "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
                               },
-                              "\",\"BlockDeviceMappings\":[{\"DeviceName\":\"/dev/sda1\",\"Ebs\":{\"DeleteOnTermination\":true,\"VolumeSize\":30}}]}},\"ec2, windows, x64 data\":{\"Type\":\"Pass\",\"ResultPath\":\"$.ec2\",\"Parameters\":{\"userdataTemplate\":\"<powershell>\\n$TASK_TOKEN = \\\"{}\\\"\\nStart-Job -ScriptBlock \\\\{\\n  while (1) \\\\{\\n    aws stepfunctions send-task-heartbeat --task-token \\\"$using:TASK_TOKEN\\\"\\n    sleep 60\\n  \\\\}\\n\\\\}\\nfunction setup_logs () \\\\{\\n  echo '\\\\{\\n    \\\"logs\\\": \\\\{\\n      \\\"log_stream_name\\\": \\\"unknown\\\",\\n      \\\"logs_collected\\\": \\\\{\\n        \\\"files\\\": \\\\{\\n         \\\"collect_list\\\": [\\n            \\\\{\\n              \\\"file_path\\\": \\\"/actions/runner.log\\\",\\n              \\\"log_group_name\\\": \\\"{}\\\",\\n              \\\"log_stream_name\\\": \\\"{}\\\",\\n              \\\"timezone\\\": \\\"UTC\\\"\\n            \\\\}\\n          ]\\n        \\\\}\\n      \\\\}\\n    \\\\}\\n  \\\\}' | Out-File -Encoding ASCII $Env:TEMP/log.conf\\n  & \\\"C:/Program Files/Amazon/AmazonCloudWatchAgent/amazon-cloudwatch-agent-ctl.ps1\\\" -a fetch-config -m ec2 -s -c file:$Env:TEMP/log.conf\\n\\\\}\\nfunction action () \\\\{\\n  cd /actions\\n  ./config.cmd --unattended --url \\\"https://{}/{}/{}\\\" --token \\\"{}\\\" --ephemeral --work _work --labels \\\"{}\\\" {} --name \\\"{}\\\" 2>&1 | Out-File -Encoding ASCII -Append /actions/runner.log\\n  if ($LASTEXITCODE -ne 0) \\\\{ return 1 \\\\}\\n  ./run.cmd 2>&1 | Out-File -Encoding ASCII -Append /actions/runner.log\\n  if ($LASTEXITCODE -ne 0) \\\\{ return 2 \\\\}\\n  return 0\\n\\\\}\\nsetup_logs\\n$r = action\\nif ($r -eq 0) \\\\{\\n  aws stepfunctions send-task-success --task-token \\\"$TASK_TOKEN\\\" --task-output '\\\\{ \\\\}'\\n\\\\} else \\\\{\\n  aws stepfunctions send-task-failure --task-token \\\"$TASK_TOKEN\\\"\\n\\\\}\\nStop-Computer -ComputerName localhost -Force\\n</powershell>\\n\"},\"Next\":\"ec2, windows, x64\"},\"ec2, windows, x64\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Ec2.Ec2Exception\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Type\":\"Task\",\"HeartbeatSeconds\":300,\"Resource\":\"arn:",
+                              "\",\"BlockDeviceMappings\":[{\"DeviceName\":\"/dev/sda1\",\"Ebs\":{\"DeleteOnTermination\":true,\"VolumeSize\":30}}]}},\"ec2, linux, arm64 success\":{\"Type\":\"Succeed\"},\"ec2, linux, arm64 ",
+                              {
+                                "Ref": "VpcPublicSubnet2Subnet691E08A3"
+                              },
+                              "\":{\"Next\":\"ec2, linux, arm64 success\",\"Type\":\"Task\",\"HeartbeatSeconds\":300,\"Resource\":\"arn:",
+                              {
+                                "Ref": "AWS::Partition"
+                              },
+                              ":states:::aws-sdk:ec2:runInstances.waitForTaskToken\",\"Parameters\":{\"LaunchTemplate\":{\"LaunchTemplateId\":\"",
+                              {
+                                "Ref": "AMILinuxarm64BuilderLaunchtemplate8F5EFF44"
+                              },
+                              "\"},\"MinCount\":1,\"MaxCount\":1,\"InstanceType\":\"m6g.large\",\"UserData.$\":\"States.Base64Encode(States.Format($.ec2.userdataTemplate, $$.Task.Token, '",
+                              {
+                                "Ref": "EC2Linuxarm64Logs577E371E"
+                              },
+                              "', $$.Execution.Name, $.runner.domain, $.owner, $.repo, $.runner.token, 'ec2,linux,arm64', '', $$.Execution.Name))\",\"InstanceInitiatedShutdownBehavior\":\"terminate\",\"IamInstanceProfile\":{\"Arn\":\"",
+                              {
+                                "Fn::GetAtt": [
+                                  "EC2Linuxarm64InstanceProfile1E6F8D53",
+                                  "Arn"
+                                ]
+                              },
+                              "\"},\"MetadataOptions\":{\"HttpTokens\":\"required\"},\"SecurityGroupIds\":[\"",
+                              {
+                                "Fn::GetAtt": [
+                                  "EC2Linuxarm64SG550ECD6C",
+                                  "GroupId"
+                                ]
+                              },
+                              "\"],\"SubnetId\":\"",
+                              {
+                                "Ref": "VpcPublicSubnet2Subnet691E08A3"
+                              },
+                              "\",\"BlockDeviceMappings\":[{\"DeviceName\":\"/dev/sda1\",\"Ebs\":{\"DeleteOnTermination\":true,\"VolumeSize\":30}}]}}}}]},\"ec2, windows, x64 data\":{\"Type\":\"Pass\",\"ResultPath\":\"$.ec2\",\"Parameters\":{\"userdataTemplate\":\"<powershell>\\n$TASK_TOKEN = \\\"{}\\\"\\nStart-Job -ScriptBlock \\\\{\\n  while (1) \\\\{\\n    aws stepfunctions send-task-heartbeat --task-token \\\"$using:TASK_TOKEN\\\"\\n    sleep 60\\n  \\\\}\\n\\\\}\\nfunction setup_logs () \\\\{\\n  echo '\\\\{\\n    \\\"logs\\\": \\\\{\\n      \\\"log_stream_name\\\": \\\"unknown\\\",\\n      \\\"logs_collected\\\": \\\\{\\n        \\\"files\\\": \\\\{\\n         \\\"collect_list\\\": [\\n            \\\\{\\n              \\\"file_path\\\": \\\"/actions/runner.log\\\",\\n              \\\"log_group_name\\\": \\\"{}\\\",\\n              \\\"log_stream_name\\\": \\\"{}\\\",\\n              \\\"timezone\\\": \\\"UTC\\\"\\n            \\\\}\\n          ]\\n        \\\\}\\n      \\\\}\\n    \\\\}\\n  \\\\}' | Out-File -Encoding ASCII $Env:TEMP/log.conf\\n  & \\\"C:/Program Files/Amazon/AmazonCloudWatchAgent/amazon-cloudwatch-agent-ctl.ps1\\\" -a fetch-config -m ec2 -s -c file:$Env:TEMP/log.conf\\n\\\\}\\nfunction action () \\\\{\\n  cd /actions\\n  ./config.cmd --unattended --url \\\"https://{}/{}/{}\\\" --token \\\"{}\\\" --ephemeral --work _work --labels \\\"{}\\\" {} --name \\\"{}\\\" 2>&1 | Out-File -Encoding ASCII -Append /actions/runner.log\\n  if ($LASTEXITCODE -ne 0) \\\\{ return 1 \\\\}\\n  ./run.cmd 2>&1 | Out-File -Encoding ASCII -Append /actions/runner.log\\n  if ($LASTEXITCODE -ne 0) \\\\{ return 2 \\\\}\\n  return 0\\n\\\\}\\nsetup_logs\\n$r = action\\nif ($r -eq 0) \\\\{\\n  aws stepfunctions send-task-success --task-token \\\"$TASK_TOKEN\\\" --task-output '\\\\{ \\\\}'\\n\\\\} else \\\\{\\n  aws stepfunctions send-task-failure --task-token \\\"$TASK_TOKEN\\\"\\n\\\\}\\nStop-Computer -ComputerName localhost -Force\\n</powershell>\\n\"},\"Next\":\"ec2, windows, x64 subnet iterator\"},\"ec2, windows, x64 subnet iterator\":{\"Type\":\"Parallel\",\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Ec2.Ec2Exception\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Branches\":[{\"StartAt\":\"ec2, windows, x64 ",
+                              {
+                                "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
+                              },
+                              "\",\"States\":{\"ec2, windows, x64 ",
+                              {
+                                "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
+                              },
+                              "\":{\"Next\":\"ec2, windows, x64 success\",\"Catch\":[{\"ErrorEquals\":[\"Ec2.Ec2Exception\"],\"ResultPath\":\"$.lastSubnetError\",\"Next\":\"ec2, windows, x64 ",
+                              {
+                                "Ref": "VpcPublicSubnet2Subnet691E08A3"
+                              },
+                              "\"}],\"Type\":\"Task\",\"HeartbeatSeconds\":300,\"Resource\":\"arn:",
                               {
                                 "Ref": "AWS::Partition"
                               },
@@ -15307,7 +15553,41 @@
                               {
                                 "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
                               },
-                              "\",\"BlockDeviceMappings\":[{\"DeviceName\":\"/dev/sda1\",\"Ebs\":{\"DeleteOnTermination\":true,\"VolumeSize\":30}}]}}}},{\"StartAt\":\"Wait\",\"States\":{\"Wait\":{\"Type\":\"Wait\",\"Seconds\":600,\"Next\":\"Delete Idle Runner\"},\"Delete Idle Runner\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2}],\"Type\":\"Task\",\"ResultPath\":\"$.delete\",\"Resource\":\"",
+                              "\",\"BlockDeviceMappings\":[{\"DeviceName\":\"/dev/sda1\",\"Ebs\":{\"DeleteOnTermination\":true,\"VolumeSize\":30}}]}},\"ec2, windows, x64 success\":{\"Type\":\"Succeed\"},\"ec2, windows, x64 ",
+                              {
+                                "Ref": "VpcPublicSubnet2Subnet691E08A3"
+                              },
+                              "\":{\"Next\":\"ec2, windows, x64 success\",\"Type\":\"Task\",\"HeartbeatSeconds\":300,\"Resource\":\"arn:",
+                              {
+                                "Ref": "AWS::Partition"
+                              },
+                              ":states:::aws-sdk:ec2:runInstances.waitForTaskToken\",\"Parameters\":{\"LaunchTemplate\":{\"LaunchTemplateId\":\"",
+                              {
+                                "Ref": "WindowsEC2BuilderLaunchtemplate0A66E9C2"
+                              },
+                              "\"},\"MinCount\":1,\"MaxCount\":1,\"InstanceType\":\"m5.large\",\"UserData.$\":\"States.Base64Encode(States.Format($.ec2.userdataTemplate, $$.Task.Token, '",
+                              {
+                                "Ref": "EC2WindowsLogsDC1F2ABF"
+                              },
+                              "', $$.Execution.Name, $.runner.domain, $.owner, $.repo, $.runner.token, 'ec2,windows,x64', '', $$.Execution.Name))\",\"InstanceInitiatedShutdownBehavior\":\"terminate\",\"IamInstanceProfile\":{\"Arn\":\"",
+                              {
+                                "Fn::GetAtt": [
+                                  "EC2WindowsInstanceProfileDCA59D9C",
+                                  "Arn"
+                                ]
+                              },
+                              "\"},\"MetadataOptions\":{\"HttpTokens\":\"required\"},\"SecurityGroupIds\":[\"",
+                              {
+                                "Fn::GetAtt": [
+                                  "EC2WindowsSG13E24976",
+                                  "GroupId"
+                                ]
+                              },
+                              "\"],\"SubnetId\":\"",
+                              {
+                                "Ref": "VpcPublicSubnet2Subnet691E08A3"
+                              },
+                              "\",\"BlockDeviceMappings\":[{\"DeviceName\":\"/dev/sda1\",\"Ebs\":{\"DeleteOnTermination\":true,\"VolumeSize\":30}}]}}}}]}}},{\"StartAt\":\"Wait\",\"States\":{\"Wait\":{\"Type\":\"Wait\",\"Seconds\":600,\"Next\":\"Delete Idle Runner\"},\"Delete Idle Runner\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2}],\"Type\":\"Task\",\"ResultPath\":\"$.delete\",\"Resource\":\"",
                               {
                                 "Fn::GetAtt": [
                                   "runnersdeleterunner7F8D5293",


### PR DESCRIPTION
Previously we only used the first subnet due to a limitation of ec2:RunInstances. This fix adds step function states to try all subnets one by one until one works. This should avoid issues where some instance types are not available on certain availability zones. Unlike the old way of not specifying a subnet, this should work for both the default VPC and a custom VPC.

We use Parallel block (with one branch so not really parallel) to enable retrying of the whole thing when all subnets fail.

Fixes #214