### PR TITLE
feat: Option to not install Docker Desktop

### DIFF
--- a/API.md
+++ b/API.md
@@ -2379,6 +2379,7 @@ const amiBuilderProps: AmiBuilderProps = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.AmiBuilderProps.property.architecture">architecture</a></code> | <code><a href="#@cloudsnorkel/cdk-github-runners.Architecture">Architecture</a></code> | Image architecture. |
+| <code><a href="#@cloudsnorkel/cdk-github-runners.AmiBuilderProps.property.installDocker">installDocker</a></code> | <code>boolean</code> | Install Docker inside the image, so it can be used by the runner. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.AmiBuilderProps.property.instanceType">instanceType</a></code> | <code>aws-cdk-lib.aws_ec2.InstanceType</code> | The instance type used to build the image. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.AmiBuilderProps.property.logRemovalPolicy">logRemovalPolicy</a></code> | <code>aws-cdk-lib.RemovalPolicy</code> | Removal policy for logs of image builds. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.AmiBuilderProps.property.logRetention">logRetention</a></code> | <code>aws-cdk-lib.aws_logs.RetentionDays</code> | The number of days log events are kept in CloudWatch Logs. |
@@ -2402,6 +2403,21 @@ public readonly architecture: Architecture;
 - *Default:* Architecture.X86_64
 
 Image architecture.
+
+---
+
+##### `installDocker`<sup>Optional</sup> <a name="installDocker" id="@cloudsnorkel/cdk-github-runners.AmiBuilderProps.property.installDocker"></a>
+
+```typescript
+public readonly installDocker: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Install Docker inside the image, so it can be used by the runner.
+
+You may want to disable this if you are building a Windows image and don't have a Docker Desktop license.
 
 ---
 
@@ -5691,7 +5707,7 @@ Log group name for the image builder where history of image builds can be analyz
 
 ### IRunnerProvider <a name="IRunnerProvider" id="@cloudsnorkel/cdk-github-runners.IRunnerProvider"></a>
 
-- *Extends:* aws-cdk-lib.aws_ec2.IConnectable, aws-cdk-lib.aws_iam.IGrantable
+- *Extends:* aws-cdk-lib.aws_ec2.IConnectable, aws-cdk-lib.aws_iam.IGrantable, constructs.IConstruct
 
 - *Implemented By:* <a href="#@cloudsnorkel/cdk-github-runners.CodeBuildRunner">CodeBuildRunner</a>, <a href="#@cloudsnorkel/cdk-github-runners.Ec2Runner">Ec2Runner</a>, <a href="#@cloudsnorkel/cdk-github-runners.FargateRunner">FargateRunner</a>, <a href="#@cloudsnorkel/cdk-github-runners.LambdaRunner">LambdaRunner</a>, <a href="#@cloudsnorkel/cdk-github-runners.IRunnerProvider">IRunnerProvider</a>
 
@@ -5770,6 +5786,7 @@ grantable for the status function.
 | --- | --- | --- |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.IRunnerProvider.property.connections">connections</a></code> | <code>aws-cdk-lib.aws_ec2.Connections</code> | The network connections associated with this resource. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.IRunnerProvider.property.grantPrincipal">grantPrincipal</a></code> | <code>aws-cdk-lib.aws_iam.IPrincipal</code> | The principal to grant permissions to. |
+| <code><a href="#@cloudsnorkel/cdk-github-runners.IRunnerProvider.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.IRunnerProvider.property.labels">labels</a></code> | <code>string[]</code> | GitHub Actions labels used for this provider. |
 
 ---
@@ -5795,6 +5812,18 @@ public readonly grantPrincipal: IPrincipal;
 - *Type:* aws-cdk-lib.aws_iam.IPrincipal
 
 The principal to grant permissions to.
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="@cloudsnorkel/cdk-github-runners.IRunnerProvider.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- *Type:* constructs.Node
+
+The tree node.
 
 ---
 

--- a/test/default.integ.snapshot/tree.json
+++ b/test/default.integ.snapshot/tree.json
@@ -10682,17 +10682,17 @@
                   "version": "2.50.0"
                 }
               },
-              "ec2, linux, x64 ${Token[TOKEN.369]}": {
-                "id": "ec2, linux, x64 ${Token[TOKEN.369]}",
-                "path": "github-runners-test/EC2 Linux/ec2, linux, x64 ${Token[TOKEN.369]}",
+              "ec2, linux, x64 ${Token[TOKEN.370]}": {
+                "id": "ec2, linux, x64 ${Token[TOKEN.370]}",
+                "path": "github-runners-test/EC2 Linux/ec2, linux, x64 ${Token[TOKEN.370]}",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_stepfunctions_tasks.CallAwsService",
                   "version": "2.50.0"
                 }
               },
-              "ec2, linux, x64 ${Token[TOKEN.385]}": {
-                "id": "ec2, linux, x64 ${Token[TOKEN.385]}",
-                "path": "github-runners-test/EC2 Linux/ec2, linux, x64 ${Token[TOKEN.385]}",
+              "ec2, linux, x64 ${Token[TOKEN.386]}": {
+                "id": "ec2, linux, x64 ${Token[TOKEN.386]}",
+                "path": "github-runners-test/EC2 Linux/ec2, linux, x64 ${Token[TOKEN.386]}",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_stepfunctions_tasks.CallAwsService",
                   "version": "2.50.0"
@@ -11127,17 +11127,17 @@
                   "version": "2.50.0"
                 }
               },
-              "ec2-spot, linux, x64 ${Token[TOKEN.369]}": {
-                "id": "ec2-spot, linux, x64 ${Token[TOKEN.369]}",
-                "path": "github-runners-test/EC2 Spot Linux/ec2-spot, linux, x64 ${Token[TOKEN.369]}",
+              "ec2-spot, linux, x64 ${Token[TOKEN.370]}": {
+                "id": "ec2-spot, linux, x64 ${Token[TOKEN.370]}",
+                "path": "github-runners-test/EC2 Spot Linux/ec2-spot, linux, x64 ${Token[TOKEN.370]}",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_stepfunctions_tasks.CallAwsService",
                   "version": "2.50.0"
                 }
               },
-              "ec2-spot, linux, x64 ${Token[TOKEN.385]}": {
-                "id": "ec2-spot, linux, x64 ${Token[TOKEN.385]}",
-                "path": "github-runners-test/EC2 Spot Linux/ec2-spot, linux, x64 ${Token[TOKEN.385]}",
+              "ec2-spot, linux, x64 ${Token[TOKEN.386]}": {
+                "id": "ec2-spot, linux, x64 ${Token[TOKEN.386]}",
+                "path": "github-runners-test/EC2 Spot Linux/ec2-spot, linux, x64 ${Token[TOKEN.386]}",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_stepfunctions_tasks.CallAwsService",
                   "version": "2.50.0"
@@ -12262,17 +12262,17 @@
                   "version": "2.50.0"
                 }
               },
-              "ec2, linux, arm64 ${Token[TOKEN.369]}": {
-                "id": "ec2, linux, arm64 ${Token[TOKEN.369]}",
-                "path": "github-runners-test/EC2 Linux arm64/ec2, linux, arm64 ${Token[TOKEN.369]}",
+              "ec2, linux, arm64 ${Token[TOKEN.370]}": {
+                "id": "ec2, linux, arm64 ${Token[TOKEN.370]}",
+                "path": "github-runners-test/EC2 Linux arm64/ec2, linux, arm64 ${Token[TOKEN.370]}",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_stepfunctions_tasks.CallAwsService",
                   "version": "2.50.0"
                 }
               },
-              "ec2, linux, arm64 ${Token[TOKEN.385]}": {
-                "id": "ec2, linux, arm64 ${Token[TOKEN.385]}",
-                "path": "github-runners-test/EC2 Linux arm64/ec2, linux, arm64 ${Token[TOKEN.385]}",
+              "ec2, linux, arm64 ${Token[TOKEN.386]}": {
+                "id": "ec2, linux, arm64 ${Token[TOKEN.386]}",
+                "path": "github-runners-test/EC2 Linux arm64/ec2, linux, arm64 ${Token[TOKEN.386]}",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_stepfunctions_tasks.CallAwsService",
                   "version": "2.50.0"
@@ -13357,17 +13357,17 @@
                   "version": "2.50.0"
                 }
               },
-              "ec2, windows, x64 ${Token[TOKEN.369]}": {
-                "id": "ec2, windows, x64 ${Token[TOKEN.369]}",
-                "path": "github-runners-test/EC2 Windows/ec2, windows, x64 ${Token[TOKEN.369]}",
+              "ec2, windows, x64 ${Token[TOKEN.370]}": {
+                "id": "ec2, windows, x64 ${Token[TOKEN.370]}",
+                "path": "github-runners-test/EC2 Windows/ec2, windows, x64 ${Token[TOKEN.370]}",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_stepfunctions_tasks.CallAwsService",
                   "version": "2.50.0"
                 }
               },
-              "ec2, windows, x64 ${Token[TOKEN.385]}": {
-                "id": "ec2, windows, x64 ${Token[TOKEN.385]}",
-                "path": "github-runners-test/EC2 Windows/ec2, windows, x64 ${Token[TOKEN.385]}",
+              "ec2, windows, x64 ${Token[TOKEN.386]}": {
+                "id": "ec2, windows, x64 ${Token[TOKEN.386]}",
+                "path": "github-runners-test/EC2 Windows/ec2, windows, x64 ${Token[TOKEN.386]}",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_stepfunctions_tasks.CallAwsService",
                   "version": "2.50.0"


### PR DESCRIPTION
Since Docker Desktop requires a license for big companies, users may want to skip installing it on certain runner images built for Windows.

Fixes #215