### PR TITLE
fix: Ignore failure on creation of /tmp/home

### DIFF
--- a/src/providers/docker-images/lambda/linux-arm64/runner.sh
+++ b/src/providers/docker-images/lambda/linux-arm64/runner.sh
@@ -4,7 +4,7 @@ set -e -u -o pipefail
 
 cp -r /runner /tmp/
 cd /tmp/runner
-mkdir /tmp/home
+mkdir /tmp/home || true
 export HOME=/tmp/home
 
 if [ "${RUNNER_VERSION}" = "latest" ]; then RUNNER_FLAGS=""; else RUNNER_FLAGS="--disableupdate"; fi

--- a/src/providers/docker-images/lambda/linux-arm64/runner.sh
+++ b/src/providers/docker-images/lambda/linux-arm64/runner.sh
@@ -4,7 +4,7 @@ set -e -u -o pipefail
 
 cp -r /runner /tmp/
 cd /tmp/runner
-mkdir /tmp/home || true
+mkdir -p /tmp/home
 export HOME=/tmp/home
 
 if [ "${RUNNER_VERSION}" = "latest" ]; then RUNNER_FLAGS=""; else RUNNER_FLAGS="--disableupdate"; fi

--- a/src/providers/docker-images/lambda/linux-x64/runner.sh
+++ b/src/providers/docker-images/lambda/linux-x64/runner.sh
@@ -4,7 +4,7 @@ set -e -u -o pipefail
 
 cp -r /runner /tmp/
 cd /tmp/runner
-mkdir /tmp/home
+mkdir /tmp/home || true
 export HOME=/tmp/home
 
 if [ "${RUNNER_VERSION}" = "latest" ]; then RUNNER_FLAGS=""; else RUNNER_FLAGS="--disableupdate"; fi

--- a/src/providers/docker-images/lambda/linux-x64/runner.sh
+++ b/src/providers/docker-images/lambda/linux-x64/runner.sh
@@ -4,7 +4,7 @@ set -e -u -o pipefail
 
 cp -r /runner /tmp/
 cd /tmp/runner
-mkdir /tmp/home || true
+mkdir -p /tmp/home
 export HOME=/tmp/home
 
 if [ "${RUNNER_VERSION}" = "latest" ]; then RUNNER_FLAGS=""; else RUNNER_FLAGS="--disableupdate"; fi

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -27,15 +27,15 @@
         }
       }
     },
-    "35b43c1bd758381cc1156a4423ce9aa1cd1179195d173a9798caddab9ea9c1b9": {
+    "d0f41cb3ffaf59833eb0a5a2bfa51517fd1355417251e3239c73bd07bc11b3ad": {
       "source": {
-        "path": "asset.35b43c1bd758381cc1156a4423ce9aa1cd1179195d173a9798caddab9ea9c1b9",
+        "path": "asset.d0f41cb3ffaf59833eb0a5a2bfa51517fd1355417251e3239c73bd07bc11b3ad",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "35b43c1bd758381cc1156a4423ce9aa1cd1179195d173a9798caddab9ea9c1b9.zip",
+          "objectKey": "d0f41cb3ffaf59833eb0a5a2bfa51517fd1355417251e3239c73bd07bc11b3ad.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -131,15 +131,15 @@
         }
       }
     },
-    "957afa1928595609e8a66240dc846b4e8fc1cf8ad1d4cfb76f4ec81853f2ae97": {
+    "99e7f30a15606f77d86003b506907ee44f64af10a56007d5d24f8a47b7aed7e0": {
       "source": {
-        "path": "asset.957afa1928595609e8a66240dc846b4e8fc1cf8ad1d4cfb76f4ec81853f2ae97",
+        "path": "asset.99e7f30a15606f77d86003b506907ee44f64af10a56007d5d24f8a47b7aed7e0",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "957afa1928595609e8a66240dc846b4e8fc1cf8ad1d4cfb76f4ec81853f2ae97.zip",
+          "objectKey": "99e7f30a15606f77d86003b506907ee44f64af10a56007d5d24f8a47b7aed7e0.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -222,7 +222,7 @@
         }
       }
     },
-    "d1008d239c5d0ef35f8f9fcd9246d5db94116b8b151920565c3f2dd33d29358d": {
+    "e987f0c6f034458f63a2566fd75f8a6f469bc10b58bdf6f19e2a273df6062c63": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -230,7 +230,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "d1008d239c5d0ef35f8f9fcd9246d5db94116b8b151920565c3f2dd33d29358d.json",
+          "objectKey": "e987f0c6f034458f63a2566fd75f8a6f469bc10b58bdf6f19e2a273df6062c63.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -1284,7 +1284,7 @@
            {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
            },
-           "/35b43c1bd758381cc1156a4423ce9aa1cd1179195d173a9798caddab9ea9c1b9.zip"
+           "/d0f41cb3ffaf59833eb0a5a2bfa51517fd1355417251e3239c73bd07bc11b3ad.zip"
           ]
          ]
         }
@@ -1539,7 +1539,7 @@
         {
          "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
         },
-        "/35b43c1bd758381cc1156a4423ce9aa1cd1179195d173a9798caddab9ea9c1b9.zip"
+        "/d0f41cb3ffaf59833eb0a5a2bfa51517fd1355417251e3239c73bd07bc11b3ad.zip"
        ]
       ]
      },
@@ -1658,7 +1658,7 @@
     "ProjectName": {
      "Ref": "LambdaImageBuilderx64CodeBuild67DE14C8"
     },
-    "BuildHash": "9929eb58cf629b06c71feb97d526c68a"
+    "BuildHash": "0fd9c5246493d4f0a256280a2bd764c6"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
@@ -5950,7 +5950,7 @@
            {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
            },
-           "/957afa1928595609e8a66240dc846b4e8fc1cf8ad1d4cfb76f4ec81853f2ae97.zip"
+           "/99e7f30a15606f77d86003b506907ee44f64af10a56007d5d24f8a47b7aed7e0.zip"
           ]
          ]
         }
@@ -6205,7 +6205,7 @@
         {
          "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
         },
-        "/957afa1928595609e8a66240dc846b4e8fc1cf8ad1d4cfb76f4ec81853f2ae97.zip"
+        "/99e7f30a15606f77d86003b506907ee44f64af10a56007d5d24f8a47b7aed7e0.zip"
        ]
       ]
      },
@@ -6324,7 +6324,7 @@
     "ProjectName": {
      "Ref": "LambdaImageBuilderzCodeBuild73AB6718"
     },
-    "BuildHash": "f6743527e85fbde9ee36a21da05c4251"
+    "BuildHash": "7b0c042d89affec2026f94fad8afde5d"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",

--- a/test/default.integ.snapshot/manifest.json
+++ b/test/default.integ.snapshot/manifest.json
@@ -23,7 +23,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/d1008d239c5d0ef35f8f9fcd9246d5db94116b8b151920565c3f2dd33d29358d.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/e987f0c6f034458f63a2566fd75f8a6f469bc10b58bdf6f19e2a273df6062c63.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/default.integ.snapshot/tree.json
+++ b/test/default.integ.snapshot/tree.json
@@ -1918,7 +1918,7 @@
                                               {
                                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                               },
-                                              "/35b43c1bd758381cc1156a4423ce9aa1cd1179195d173a9798caddab9ea9c1b9.zip"
+                                              "/d0f41cb3ffaf59833eb0a5a2bfa51517fd1355417251e3239c73bd07bc11b3ad.zip"
                                             ]
                                           ]
                                         }
@@ -2121,7 +2121,7 @@
                                 {
                                   "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                 },
-                                "/35b43c1bd758381cc1156a4423ce9aa1cd1179195d173a9798caddab9ea9c1b9.zip"
+                                "/d0f41cb3ffaf59833eb0a5a2bfa51517fd1355417251e3239c73bd07bc11b3ad.zip"
                               ]
                             ]
                           },
@@ -8036,7 +8036,7 @@
                                               {
                                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                               },
-                                              "/957afa1928595609e8a66240dc846b4e8fc1cf8ad1d4cfb76f4ec81853f2ae97.zip"
+                                              "/99e7f30a15606f77d86003b506907ee44f64af10a56007d5d24f8a47b7aed7e0.zip"
                                             ]
                                           ]
                                         }
@@ -8239,7 +8239,7 @@
                                 {
                                   "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                 },
-                                "/957afa1928595609e8a66240dc846b4e8fc1cf8ad1d4cfb76f4ec81853f2ae97.zip"
+                                "/99e7f30a15606f77d86003b506907ee44f64af10a56007d5d24f8a47b7aed7e0.zip"
                               ]
                             ]
                           },


### PR DESCRIPTION
If the Lambda doesn't have a coldstart, the runner will fail because `/tmp/home` already exists. 