### PR TITLE
fix: Clean-up Lambda /tmp directory for a fresh runner

### DIFF
--- a/src/providers/docker-images/lambda/linux-arm64/runner.sh
+++ b/src/providers/docker-images/lambda/linux-arm64/runner.sh
@@ -2,16 +2,22 @@
 
 set -e -u -o pipefail
 
+# cleanup
+find /tmp -mindepth 1 -maxdepth 1 -exec rm -rf '{}' \;
+# copy runner code (it needs a writable directory)
 cp -r /runner /tmp/
 cd /tmp/runner
-mkdir -p /tmp/home
+# setup home directory
+mkdir /tmp/home
 export HOME=/tmp/home
 
+# start runner
 if [ "${RUNNER_VERSION}" = "latest" ]; then RUNNER_FLAGS=""; else RUNNER_FLAGS="--disableupdate"; fi
 ./config.sh --unattended --url "https://${GITHUB_DOMAIN}/${OWNER}/${REPO}" --token "${RUNNER_TOKEN}" --ephemeral --work _work --labels "${RUNNER_LABEL}" --name "${RUNNER_NAME}" ${RUNNER_FLAGS}
 echo Config done
 ./run.sh
 echo Run done
 
+# print status for metrics
 STATUS=$(grep -Phors "finish job request for job [0-9a-f\-]+ with result: \K.*" _diag/ | tail -n1)
 [ -n "$STATUS" ] && echo CDKGHA JOB DONE "$RUNNER_LABEL" "$STATUS"

--- a/src/providers/docker-images/lambda/linux-x64/runner.sh
+++ b/src/providers/docker-images/lambda/linux-x64/runner.sh
@@ -2,16 +2,22 @@
 
 set -e -u -o pipefail
 
+# cleanup
+find /tmp -mindepth 1 -maxdepth 1 -exec rm -rf '{}' \;
+# copy runner code (it needs a writable directory)
 cp -r /runner /tmp/
 cd /tmp/runner
-mkdir -p /tmp/home
+# setup home directory
+mkdir /tmp/home
 export HOME=/tmp/home
 
+# start runner
 if [ "${RUNNER_VERSION}" = "latest" ]; then RUNNER_FLAGS=""; else RUNNER_FLAGS="--disableupdate"; fi
 ./config.sh --unattended --url "https://${GITHUB_DOMAIN}/${OWNER}/${REPO}" --token "${RUNNER_TOKEN}" --ephemeral --work _work --labels "${RUNNER_LABEL}" --name "${RUNNER_NAME}" ${RUNNER_FLAGS}
 echo Config done
 ./run.sh
 echo Run done
 
+# print status for metrics
 STATUS=$(grep -Phors "finish job request for job [0-9a-f\-]+ with result: \K.*" _diag/ | tail -n1)
 [ -n "$STATUS" ] && echo CDKGHA JOB DONE "$RUNNER_LABEL" "$STATUS"

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -27,15 +27,15 @@
         }
       }
     },
-    "d0f41cb3ffaf59833eb0a5a2bfa51517fd1355417251e3239c73bd07bc11b3ad": {
+    "62a61b3949f1689cbe3d634ea53cdf3653739068ea82405b3f5daa6af112cd14": {
       "source": {
-        "path": "asset.d0f41cb3ffaf59833eb0a5a2bfa51517fd1355417251e3239c73bd07bc11b3ad",
+        "path": "asset.62a61b3949f1689cbe3d634ea53cdf3653739068ea82405b3f5daa6af112cd14",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "d0f41cb3ffaf59833eb0a5a2bfa51517fd1355417251e3239c73bd07bc11b3ad.zip",
+          "objectKey": "62a61b3949f1689cbe3d634ea53cdf3653739068ea82405b3f5daa6af112cd14.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -131,15 +131,15 @@
         }
       }
     },
-    "99e7f30a15606f77d86003b506907ee44f64af10a56007d5d24f8a47b7aed7e0": {
+    "91095b20a1ffa4f95834cb332fde4bda534f434fcdd9ea642110a24e343c7756": {
       "source": {
-        "path": "asset.99e7f30a15606f77d86003b506907ee44f64af10a56007d5d24f8a47b7aed7e0",
+        "path": "asset.91095b20a1ffa4f95834cb332fde4bda534f434fcdd9ea642110a24e343c7756",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "99e7f30a15606f77d86003b506907ee44f64af10a56007d5d24f8a47b7aed7e0.zip",
+          "objectKey": "91095b20a1ffa4f95834cb332fde4bda534f434fcdd9ea642110a24e343c7756.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -222,7 +222,7 @@
         }
       }
     },
-    "e987f0c6f034458f63a2566fd75f8a6f469bc10b58bdf6f19e2a273df6062c63": {
+    "6e8975ed119d1f7f505caddd0ae58abe25145850dbcf411d35b94dea9090b2e2": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -230,7 +230,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "e987f0c6f034458f63a2566fd75f8a6f469bc10b58bdf6f19e2a273df6062c63.json",
+          "objectKey": "6e8975ed119d1f7f505caddd0ae58abe25145850dbcf411d35b94dea9090b2e2.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -1284,7 +1284,7 @@
            {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
            },
-           "/d0f41cb3ffaf59833eb0a5a2bfa51517fd1355417251e3239c73bd07bc11b3ad.zip"
+           "/62a61b3949f1689cbe3d634ea53cdf3653739068ea82405b3f5daa6af112cd14.zip"
           ]
          ]
         }
@@ -1539,7 +1539,7 @@
         {
          "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
         },
-        "/d0f41cb3ffaf59833eb0a5a2bfa51517fd1355417251e3239c73bd07bc11b3ad.zip"
+        "/62a61b3949f1689cbe3d634ea53cdf3653739068ea82405b3f5daa6af112cd14.zip"
        ]
       ]
      },
@@ -1658,7 +1658,7 @@
     "ProjectName": {
      "Ref": "LambdaImageBuilderx64CodeBuild67DE14C8"
     },
-    "BuildHash": "0fd9c5246493d4f0a256280a2bd764c6"
+    "BuildHash": "77b8f5dad1e9729b3b7e6d367706e97d"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
@@ -5950,7 +5950,7 @@
            {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
            },
-           "/99e7f30a15606f77d86003b506907ee44f64af10a56007d5d24f8a47b7aed7e0.zip"
+           "/91095b20a1ffa4f95834cb332fde4bda534f434fcdd9ea642110a24e343c7756.zip"
           ]
          ]
         }
@@ -6205,7 +6205,7 @@
         {
          "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
         },
-        "/99e7f30a15606f77d86003b506907ee44f64af10a56007d5d24f8a47b7aed7e0.zip"
+        "/91095b20a1ffa4f95834cb332fde4bda534f434fcdd9ea642110a24e343c7756.zip"
        ]
       ]
      },
@@ -6324,7 +6324,7 @@
     "ProjectName": {
      "Ref": "LambdaImageBuilderzCodeBuild73AB6718"
     },
-    "BuildHash": "7b0c042d89affec2026f94fad8afde5d"
+    "BuildHash": "3709ba4b6f968ba6cb6e9ab467a81291"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",

--- a/test/default.integ.snapshot/manifest.json
+++ b/test/default.integ.snapshot/manifest.json
@@ -23,7 +23,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/e987f0c6f034458f63a2566fd75f8a6f469bc10b58bdf6f19e2a273df6062c63.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/6e8975ed119d1f7f505caddd0ae58abe25145850dbcf411d35b94dea9090b2e2.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/default.integ.snapshot/tree.json
+++ b/test/default.integ.snapshot/tree.json
@@ -1918,7 +1918,7 @@
                                               {
                                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                               },
-                                              "/d0f41cb3ffaf59833eb0a5a2bfa51517fd1355417251e3239c73bd07bc11b3ad.zip"
+                                              "/62a61b3949f1689cbe3d634ea53cdf3653739068ea82405b3f5daa6af112cd14.zip"
                                             ]
                                           ]
                                         }
@@ -2121,7 +2121,7 @@
                                 {
                                   "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                 },
-                                "/d0f41cb3ffaf59833eb0a5a2bfa51517fd1355417251e3239c73bd07bc11b3ad.zip"
+                                "/62a61b3949f1689cbe3d634ea53cdf3653739068ea82405b3f5daa6af112cd14.zip"
                               ]
                             ]
                           },
@@ -8036,7 +8036,7 @@
                                               {
                                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                               },
-                                              "/99e7f30a15606f77d86003b506907ee44f64af10a56007d5d24f8a47b7aed7e0.zip"
+                                              "/91095b20a1ffa4f95834cb332fde4bda534f434fcdd9ea642110a24e343c7756.zip"
                                             ]
                                           ]
                                         }
@@ -8239,7 +8239,7 @@
                                 {
                                   "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                 },
-                                "/99e7f30a15606f77d86003b506907ee44f64af10a56007d5d24f8a47b7aed7e0.zip"
+                                "/91095b20a1ffa4f95834cb332fde4bda534f434fcdd9ea642110a24e343c7756.zip"
                               ]
                             ]
                           },


### PR DESCRIPTION
The `/tmp` directory can have some files left behind from previous runs when a Lambda instance is reused. We want a clean home directory and clean `/tmp` directory so one run can break the next one.

See #242