### PR TITLE
fix: AWS Image Builder identifier 'ComponentArn' already exists

### DIFF
--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -1,54 +1,54 @@
 {
   "version": "21.0.0",
   "files": {
-    "7016cd24653d28ac7705bc5ec6608f27c8625b2871072fba158790922d95eef1": {
+    "2b33dabb53d6eb0b6b1ce7fda15c31585fa97a6a170f80d4ecdf3f974f10089e": {
       "source": {
-        "path": "asset.7016cd24653d28ac7705bc5ec6608f27c8625b2871072fba158790922d95eef1",
+        "path": "asset.2b33dabb53d6eb0b6b1ce7fda15c31585fa97a6a170f80d4ecdf3f974f10089e",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "7016cd24653d28ac7705bc5ec6608f27c8625b2871072fba158790922d95eef1.zip",
+          "objectKey": "2b33dabb53d6eb0b6b1ce7fda15c31585fa97a6a170f80d4ecdf3f974f10089e.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "fcdd8c8653be84158994fea0b9638c46cdd8fa303dec32dc3ea5f506b8ecff39": {
+    "c5317a325923734c8558ca73b96d028dfae37645dbe71d4f9ffd500028c10b0a": {
       "source": {
-        "path": "asset.fcdd8c8653be84158994fea0b9638c46cdd8fa303dec32dc3ea5f506b8ecff39",
+        "path": "asset.c5317a325923734c8558ca73b96d028dfae37645dbe71d4f9ffd500028c10b0a",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "fcdd8c8653be84158994fea0b9638c46cdd8fa303dec32dc3ea5f506b8ecff39.zip",
+          "objectKey": "c5317a325923734c8558ca73b96d028dfae37645dbe71d4f9ffd500028c10b0a.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "62a61b3949f1689cbe3d634ea53cdf3653739068ea82405b3f5daa6af112cd14": {
+    "672e6d76b918624744f6bc498b56881eee6fed525922ed0bb6331988f054b7a8": {
       "source": {
-        "path": "asset.62a61b3949f1689cbe3d634ea53cdf3653739068ea82405b3f5daa6af112cd14",
+        "path": "asset.672e6d76b918624744f6bc498b56881eee6fed525922ed0bb6331988f054b7a8",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "62a61b3949f1689cbe3d634ea53cdf3653739068ea82405b3f5daa6af112cd14.zip",
+          "objectKey": "672e6d76b918624744f6bc498b56881eee6fed525922ed0bb6331988f054b7a8.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "4e54985b8639a96d9f381204ae955dbee6d1cb715efa67383d64e0b3cb528146": {
+    "ed9d70b884c710671d2f38d3c07b5be67ed5f512b92922bf21a4ccdf61c3c8b9": {
       "source": {
-        "path": "asset.4e54985b8639a96d9f381204ae955dbee6d1cb715efa67383d64e0b3cb528146.lambda",
+        "path": "asset.ed9d70b884c710671d2f38d3c07b5be67ed5f512b92922bf21a4ccdf61c3c8b9.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "4e54985b8639a96d9f381204ae955dbee6d1cb715efa67383d64e0b3cb528146.zip",
+          "objectKey": "ed9d70b884c710671d2f38d3c07b5be67ed5f512b92922bf21a4ccdf61c3c8b9.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -66,15 +66,15 @@
         }
       }
     },
-    "cf6c81647b444e50910bbd38ad5bd5b74170fa75de8878c6b108a0be22fe8da2": {
+    "30e8ea3f1804cc749ac363d7585201378bee46974cf97bc068f11d27aba32023": {
       "source": {
-        "path": "asset.cf6c81647b444e50910bbd38ad5bd5b74170fa75de8878c6b108a0be22fe8da2",
+        "path": "asset.30e8ea3f1804cc749ac363d7585201378bee46974cf97bc068f11d27aba32023",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "cf6c81647b444e50910bbd38ad5bd5b74170fa75de8878c6b108a0be22fe8da2.zip",
+          "objectKey": "30e8ea3f1804cc749ac363d7585201378bee46974cf97bc068f11d27aba32023.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -92,15 +92,15 @@
         }
       }
     },
-    "c521fa041f1b5714edf8fab8f33b2c6e7fa2c95cb57217bdb0a663d2245a28d6": {
+    "1816d55ba8a8768830cd9ffe21f56596f39886bc87dcec59f072f9892f322adc": {
       "source": {
-        "path": "asset.c521fa041f1b5714edf8fab8f33b2c6e7fa2c95cb57217bdb0a663d2245a28d6",
+        "path": "asset.1816d55ba8a8768830cd9ffe21f56596f39886bc87dcec59f072f9892f322adc",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "c521fa041f1b5714edf8fab8f33b2c6e7fa2c95cb57217bdb0a663d2245a28d6.zip",
+          "objectKey": "1816d55ba8a8768830cd9ffe21f56596f39886bc87dcec59f072f9892f322adc.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -131,15 +131,15 @@
         }
       }
     },
-    "91095b20a1ffa4f95834cb332fde4bda534f434fcdd9ea642110a24e343c7756": {
+    "5525681c52fa50875eb02c1fa3748aea20486a4b97cdb271d1404920c42cf492": {
       "source": {
-        "path": "asset.91095b20a1ffa4f95834cb332fde4bda534f434fcdd9ea642110a24e343c7756",
+        "path": "asset.5525681c52fa50875eb02c1fa3748aea20486a4b97cdb271d1404920c42cf492",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "91095b20a1ffa4f95834cb332fde4bda534f434fcdd9ea642110a24e343c7756.zip",
+          "objectKey": "5525681c52fa50875eb02c1fa3748aea20486a4b97cdb271d1404920c42cf492.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -222,7 +222,7 @@
         }
       }
     },
-    "235acde3a209fda44de83a4736b6c55d86e07e0a1adc29b9a4be9e92df3c14b5": {
+    "bfd9f3fc2cb791ffbd047966fa6c6f3b3042764fa68a39978876ff46edac0f94": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -230,7 +230,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "235acde3a209fda44de83a4736b6c55d86e07e0a1adc29b9a4be9e92df3c14b5.json",
+          "objectKey": "bfd9f3fc2cb791ffbd047966fa6c6f3b3042764fa68a39978876ff46edac0f94.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -1,41 +1,41 @@
 {
   "version": "21.0.0",
   "files": {
-    "2b33dabb53d6eb0b6b1ce7fda15c31585fa97a6a170f80d4ecdf3f974f10089e": {
+    "7016cd24653d28ac7705bc5ec6608f27c8625b2871072fba158790922d95eef1": {
       "source": {
-        "path": "asset.2b33dabb53d6eb0b6b1ce7fda15c31585fa97a6a170f80d4ecdf3f974f10089e",
+        "path": "asset.7016cd24653d28ac7705bc5ec6608f27c8625b2871072fba158790922d95eef1",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "2b33dabb53d6eb0b6b1ce7fda15c31585fa97a6a170f80d4ecdf3f974f10089e.zip",
+          "objectKey": "7016cd24653d28ac7705bc5ec6608f27c8625b2871072fba158790922d95eef1.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "c5317a325923734c8558ca73b96d028dfae37645dbe71d4f9ffd500028c10b0a": {
+    "fcdd8c8653be84158994fea0b9638c46cdd8fa303dec32dc3ea5f506b8ecff39": {
       "source": {
-        "path": "asset.c5317a325923734c8558ca73b96d028dfae37645dbe71d4f9ffd500028c10b0a",
+        "path": "asset.fcdd8c8653be84158994fea0b9638c46cdd8fa303dec32dc3ea5f506b8ecff39",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "c5317a325923734c8558ca73b96d028dfae37645dbe71d4f9ffd500028c10b0a.zip",
+          "objectKey": "fcdd8c8653be84158994fea0b9638c46cdd8fa303dec32dc3ea5f506b8ecff39.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "672e6d76b918624744f6bc498b56881eee6fed525922ed0bb6331988f054b7a8": {
+    "62a61b3949f1689cbe3d634ea53cdf3653739068ea82405b3f5daa6af112cd14": {
       "source": {
-        "path": "asset.672e6d76b918624744f6bc498b56881eee6fed525922ed0bb6331988f054b7a8",
+        "path": "asset.62a61b3949f1689cbe3d634ea53cdf3653739068ea82405b3f5daa6af112cd14",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "672e6d76b918624744f6bc498b56881eee6fed525922ed0bb6331988f054b7a8.zip",
+          "objectKey": "62a61b3949f1689cbe3d634ea53cdf3653739068ea82405b3f5daa6af112cd14.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -66,15 +66,15 @@
         }
       }
     },
-    "30e8ea3f1804cc749ac363d7585201378bee46974cf97bc068f11d27aba32023": {
+    "cf6c81647b444e50910bbd38ad5bd5b74170fa75de8878c6b108a0be22fe8da2": {
       "source": {
-        "path": "asset.30e8ea3f1804cc749ac363d7585201378bee46974cf97bc068f11d27aba32023",
+        "path": "asset.cf6c81647b444e50910bbd38ad5bd5b74170fa75de8878c6b108a0be22fe8da2",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "30e8ea3f1804cc749ac363d7585201378bee46974cf97bc068f11d27aba32023.zip",
+          "objectKey": "cf6c81647b444e50910bbd38ad5bd5b74170fa75de8878c6b108a0be22fe8da2.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -92,15 +92,15 @@
         }
       }
     },
-    "1816d55ba8a8768830cd9ffe21f56596f39886bc87dcec59f072f9892f322adc": {
+    "c521fa041f1b5714edf8fab8f33b2c6e7fa2c95cb57217bdb0a663d2245a28d6": {
       "source": {
-        "path": "asset.1816d55ba8a8768830cd9ffe21f56596f39886bc87dcec59f072f9892f322adc",
+        "path": "asset.c521fa041f1b5714edf8fab8f33b2c6e7fa2c95cb57217bdb0a663d2245a28d6",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "1816d55ba8a8768830cd9ffe21f56596f39886bc87dcec59f072f9892f322adc.zip",
+          "objectKey": "c521fa041f1b5714edf8fab8f33b2c6e7fa2c95cb57217bdb0a663d2245a28d6.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -131,15 +131,15 @@
         }
       }
     },
-    "5525681c52fa50875eb02c1fa3748aea20486a4b97cdb271d1404920c42cf492": {
+    "91095b20a1ffa4f95834cb332fde4bda534f434fcdd9ea642110a24e343c7756": {
       "source": {
-        "path": "asset.5525681c52fa50875eb02c1fa3748aea20486a4b97cdb271d1404920c42cf492",
+        "path": "asset.91095b20a1ffa4f95834cb332fde4bda534f434fcdd9ea642110a24e343c7756",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "5525681c52fa50875eb02c1fa3748aea20486a4b97cdb271d1404920c42cf492.zip",
+          "objectKey": "91095b20a1ffa4f95834cb332fde4bda534f434fcdd9ea642110a24e343c7756.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -222,7 +222,7 @@
         }
       }
     },
-    "bfd9f3fc2cb791ffbd047966fa6c6f3b3042764fa68a39978876ff46edac0f94": {
+    "7c2defdd12ec3725a1db69ebcb80fcf7288ba68a68668276aeaac5a680e763c4": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -230,7 +230,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "bfd9f3fc2cb791ffbd047966fa6c6f3b3042764fa68a39978876ff46edac0f94.json",
+          "objectKey": "7c2defdd12ec3725a1db69ebcb80fcf7288ba68a68668276aeaac5a680e763c4.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -276,7 +276,7 @@
            {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
            },
-           "/2b33dabb53d6eb0b6b1ce7fda15c31585fa97a6a170f80d4ecdf3f974f10089e.zip"
+           "/7016cd24653d28ac7705bc5ec6608f27c8625b2871072fba158790922d95eef1.zip"
           ]
          ]
         }
@@ -531,7 +531,7 @@
         {
          "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
         },
-        "/2b33dabb53d6eb0b6b1ce7fda15c31585fa97a6a170f80d4ecdf3f974f10089e.zip"
+        "/7016cd24653d28ac7705bc5ec6608f27c8625b2871072fba158790922d95eef1.zip"
        ]
       ]
      },
@@ -650,7 +650,7 @@
     "ProjectName": {
      "Ref": "FargatebuilderCodeBuild4F182743"
     },
-    "BuildHash": "442fe120f997b3c1da41ff88638c7a2f"
+    "BuildHash": "ac1ffc5169a5fe69907bb4638ebb989e"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
@@ -780,7 +780,7 @@
            {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
            },
-           "/c5317a325923734c8558ca73b96d028dfae37645dbe71d4f9ffd500028c10b0a.zip"
+           "/fcdd8c8653be84158994fea0b9638c46cdd8fa303dec32dc3ea5f506b8ecff39.zip"
           ]
          ]
         }
@@ -1035,7 +1035,7 @@
         {
          "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
         },
-        "/c5317a325923734c8558ca73b96d028dfae37645dbe71d4f9ffd500028c10b0a.zip"
+        "/fcdd8c8653be84158994fea0b9638c46cdd8fa303dec32dc3ea5f506b8ecff39.zip"
        ]
       ]
      },
@@ -1154,7 +1154,7 @@
     "ProjectName": {
      "Ref": "FargatebuilderarmCodeBuild0D30679A"
     },
-    "BuildHash": "23c8227a7dfddcd343d12e2898eb975e"
+    "BuildHash": "2d28bc55d37386fa2d542ed1c80b78b8"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
@@ -1284,7 +1284,7 @@
            {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
            },
-           "/672e6d76b918624744f6bc498b56881eee6fed525922ed0bb6331988f054b7a8.zip"
+           "/62a61b3949f1689cbe3d634ea53cdf3653739068ea82405b3f5daa6af112cd14.zip"
           ]
          ]
         }
@@ -1539,7 +1539,7 @@
         {
          "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
         },
-        "/672e6d76b918624744f6bc498b56881eee6fed525922ed0bb6331988f054b7a8.zip"
+        "/62a61b3949f1689cbe3d634ea53cdf3653739068ea82405b3f5daa6af112cd14.zip"
        ]
       ]
      },
@@ -1658,7 +1658,7 @@
     "ProjectName": {
      "Ref": "LambdaImageBuilderx64CodeBuild67DE14C8"
     },
-    "BuildHash": "aed1d557692bb175cd1a63b2980ac58b"
+    "BuildHash": "77b8f5dad1e9729b3b7e6d367706e97d"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
@@ -3553,7 +3553,7 @@
            {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
            },
-           "/30e8ea3f1804cc749ac363d7585201378bee46974cf97bc068f11d27aba32023.zip"
+           "/cf6c81647b444e50910bbd38ad5bd5b74170fa75de8878c6b108a0be22fe8da2.zip"
           ]
          ]
         }
@@ -3808,7 +3808,7 @@
         {
          "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
         },
-        "/30e8ea3f1804cc749ac363d7585201378bee46974cf97bc068f11d27aba32023.zip"
+        "/cf6c81647b444e50910bbd38ad5bd5b74170fa75de8878c6b108a0be22fe8da2.zip"
        ]
       ]
      },
@@ -3927,7 +3927,7 @@
     "ProjectName": {
      "Ref": "CodeBuildImageBuilderCodeBuild38ECAA44"
     },
-    "BuildHash": "89dd6703705f86a3604d2b099bdfe0ec"
+    "BuildHash": "f84032774d6cd70e4b154460cac04f6b"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
@@ -4412,7 +4412,7 @@
            {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
            },
-           "/1816d55ba8a8768830cd9ffe21f56596f39886bc87dcec59f072f9892f322adc.zip"
+           "/c521fa041f1b5714edf8fab8f33b2c6e7fa2c95cb57217bdb0a663d2245a28d6.zip"
           ]
          ]
         }
@@ -4667,7 +4667,7 @@
         {
          "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
         },
-        "/1816d55ba8a8768830cd9ffe21f56596f39886bc87dcec59f072f9892f322adc.zip"
+        "/c521fa041f1b5714edf8fab8f33b2c6e7fa2c95cb57217bdb0a663d2245a28d6.zip"
        ]
       ]
      },
@@ -4786,7 +4786,7 @@
     "ProjectName": {
      "Ref": "CodeBuildImageBuilderarmCodeBuildBFF1CF57"
     },
-    "BuildHash": "baab4c5fdc7ca43e01ffc6f727b7164c"
+    "BuildHash": "b9438c08aa22255bdaefe9ec669a80aa"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
@@ -5950,7 +5950,7 @@
            {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
            },
-           "/5525681c52fa50875eb02c1fa3748aea20486a4b97cdb271d1404920c42cf492.zip"
+           "/91095b20a1ffa4f95834cb332fde4bda534f434fcdd9ea642110a24e343c7756.zip"
           ]
          ]
         }
@@ -6205,7 +6205,7 @@
         {
          "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
         },
-        "/5525681c52fa50875eb02c1fa3748aea20486a4b97cdb271d1404920c42cf492.zip"
+        "/91095b20a1ffa4f95834cb332fde4bda534f434fcdd9ea642110a24e343c7756.zip"
        ]
       ]
      },
@@ -6324,7 +6324,7 @@
     "ProjectName": {
      "Ref": "LambdaImageBuilderzCodeBuild73AB6718"
     },
-    "BuildHash": "5ad6ef70fe257e9d2362e766ac679751"
+    "BuildHash": "3709ba4b6f968ba6cb6e9ab467a81291"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -276,7 +276,7 @@
            {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
            },
-           "/7016cd24653d28ac7705bc5ec6608f27c8625b2871072fba158790922d95eef1.zip"
+           "/2b33dabb53d6eb0b6b1ce7fda15c31585fa97a6a170f80d4ecdf3f974f10089e.zip"
           ]
          ]
         }
@@ -531,7 +531,7 @@
         {
          "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
         },
-        "/7016cd24653d28ac7705bc5ec6608f27c8625b2871072fba158790922d95eef1.zip"
+        "/2b33dabb53d6eb0b6b1ce7fda15c31585fa97a6a170f80d4ecdf3f974f10089e.zip"
        ]
       ]
      },
@@ -650,7 +650,7 @@
     "ProjectName": {
      "Ref": "FargatebuilderCodeBuild4F182743"
     },
-    "BuildHash": "ac1ffc5169a5fe69907bb4638ebb989e"
+    "BuildHash": "442fe120f997b3c1da41ff88638c7a2f"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
@@ -780,7 +780,7 @@
            {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
            },
-           "/fcdd8c8653be84158994fea0b9638c46cdd8fa303dec32dc3ea5f506b8ecff39.zip"
+           "/c5317a325923734c8558ca73b96d028dfae37645dbe71d4f9ffd500028c10b0a.zip"
           ]
          ]
         }
@@ -1035,7 +1035,7 @@
         {
          "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
         },
-        "/fcdd8c8653be84158994fea0b9638c46cdd8fa303dec32dc3ea5f506b8ecff39.zip"
+        "/c5317a325923734c8558ca73b96d028dfae37645dbe71d4f9ffd500028c10b0a.zip"
        ]
       ]
      },
@@ -1154,7 +1154,7 @@
     "ProjectName": {
      "Ref": "FargatebuilderarmCodeBuild0D30679A"
     },
-    "BuildHash": "2d28bc55d37386fa2d542ed1c80b78b8"
+    "BuildHash": "23c8227a7dfddcd343d12e2898eb975e"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
@@ -1284,7 +1284,7 @@
            {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
            },
-           "/62a61b3949f1689cbe3d634ea53cdf3653739068ea82405b3f5daa6af112cd14.zip"
+           "/672e6d76b918624744f6bc498b56881eee6fed525922ed0bb6331988f054b7a8.zip"
           ]
          ]
         }
@@ -1539,7 +1539,7 @@
         {
          "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
         },
-        "/62a61b3949f1689cbe3d634ea53cdf3653739068ea82405b3f5daa6af112cd14.zip"
+        "/672e6d76b918624744f6bc498b56881eee6fed525922ed0bb6331988f054b7a8.zip"
        ]
       ]
      },
@@ -1658,7 +1658,7 @@
     "ProjectName": {
      "Ref": "LambdaImageBuilderx64CodeBuild67DE14C8"
     },
-    "BuildHash": "77b8f5dad1e9729b3b7e6d367706e97d"
+    "BuildHash": "aed1d557692bb175cd1a63b2980ac58b"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
@@ -2502,7 +2502,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "4e54985b8639a96d9f381204ae955dbee6d1cb715efa67383d64e0b3cb528146.zip"
+     "S3Key": "ed9d70b884c710671d2f38d3c07b5be67ed5f512b92922bf21a4ccdf61c3c8b9.zip"
     },
     "Role": {
      "Fn::GetAtt": [
@@ -3553,7 +3553,7 @@
            {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
            },
-           "/cf6c81647b444e50910bbd38ad5bd5b74170fa75de8878c6b108a0be22fe8da2.zip"
+           "/30e8ea3f1804cc749ac363d7585201378bee46974cf97bc068f11d27aba32023.zip"
           ]
          ]
         }
@@ -3808,7 +3808,7 @@
         {
          "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
         },
-        "/cf6c81647b444e50910bbd38ad5bd5b74170fa75de8878c6b108a0be22fe8da2.zip"
+        "/30e8ea3f1804cc749ac363d7585201378bee46974cf97bc068f11d27aba32023.zip"
        ]
       ]
      },
@@ -3927,7 +3927,7 @@
     "ProjectName": {
      "Ref": "CodeBuildImageBuilderCodeBuild38ECAA44"
     },
-    "BuildHash": "f84032774d6cd70e4b154460cac04f6b"
+    "BuildHash": "89dd6703705f86a3604d2b099bdfe0ec"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
@@ -4412,7 +4412,7 @@
            {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
            },
-           "/c521fa041f1b5714edf8fab8f33b2c6e7fa2c95cb57217bdb0a663d2245a28d6.zip"
+           "/1816d55ba8a8768830cd9ffe21f56596f39886bc87dcec59f072f9892f322adc.zip"
           ]
          ]
         }
@@ -4667,7 +4667,7 @@
         {
          "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
         },
-        "/c521fa041f1b5714edf8fab8f33b2c6e7fa2c95cb57217bdb0a663d2245a28d6.zip"
+        "/1816d55ba8a8768830cd9ffe21f56596f39886bc87dcec59f072f9892f322adc.zip"
        ]
       ]
      },
@@ -4786,7 +4786,7 @@
     "ProjectName": {
      "Ref": "CodeBuildImageBuilderarmCodeBuildBFF1CF57"
     },
-    "BuildHash": "b9438c08aa22255bdaefe9ec669a80aa"
+    "BuildHash": "baab4c5fdc7ca43e01ffc6f727b7164c"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
@@ -5950,7 +5950,7 @@
            {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
            },
-           "/91095b20a1ffa4f95834cb332fde4bda534f434fcdd9ea642110a24e343c7756.zip"
+           "/5525681c52fa50875eb02c1fa3748aea20486a4b97cdb271d1404920c42cf492.zip"
           ]
          ]
         }
@@ -6205,7 +6205,7 @@
         {
          "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
         },
-        "/91095b20a1ffa4f95834cb332fde4bda534f434fcdd9ea642110a24e343c7756.zip"
+        "/5525681c52fa50875eb02c1fa3748aea20486a4b97cdb271d1404920c42cf492.zip"
        ]
       ]
      },
@@ -6324,7 +6324,7 @@
     "ProjectName": {
      "Ref": "LambdaImageBuilderzCodeBuild73AB6718"
     },
-    "BuildHash": "3709ba4b6f968ba6cb6e9ab467a81291"
+    "BuildHash": "5ad6ef70fe257e9d2362e766ac679751"
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",

--- a/test/default.integ.snapshot/manifest.json
+++ b/test/default.integ.snapshot/manifest.json
@@ -23,7 +23,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/235acde3a209fda44de83a4736b6c55d86e07e0a1adc29b9a4be9e92df3c14b5.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/bfd9f3fc2cb791ffbd047966fa6c6f3b3042764fa68a39978876ff46edac0f94.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/default.integ.snapshot/manifest.json
+++ b/test/default.integ.snapshot/manifest.json
@@ -23,7 +23,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/bfd9f3fc2cb791ffbd047966fa6c6f3b3042764fa68a39978876ff46edac0f94.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/7c2defdd12ec3725a1db69ebcb80fcf7288ba68a68668276aeaac5a680e763c4.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/default.integ.snapshot/tree.json
+++ b/test/default.integ.snapshot/tree.json
@@ -532,7 +532,7 @@
                                               {
                                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                               },
-                                              "/7016cd24653d28ac7705bc5ec6608f27c8625b2871072fba158790922d95eef1.zip"
+                                              "/2b33dabb53d6eb0b6b1ce7fda15c31585fa97a6a170f80d4ecdf3f974f10089e.zip"
                                             ]
                                           ]
                                         }
@@ -735,7 +735,7 @@
                                 {
                                   "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                 },
-                                "/7016cd24653d28ac7705bc5ec6608f27c8625b2871072fba158790922d95eef1.zip"
+                                "/2b33dabb53d6eb0b6b1ce7fda15c31585fa97a6a170f80d4ecdf3f974f10089e.zip"
                               ]
                             ]
                           },
@@ -1225,7 +1225,7 @@
                                               {
                                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                               },
-                                              "/fcdd8c8653be84158994fea0b9638c46cdd8fa303dec32dc3ea5f506b8ecff39.zip"
+                                              "/c5317a325923734c8558ca73b96d028dfae37645dbe71d4f9ffd500028c10b0a.zip"
                                             ]
                                           ]
                                         }
@@ -1428,7 +1428,7 @@
                                 {
                                   "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                 },
-                                "/fcdd8c8653be84158994fea0b9638c46cdd8fa303dec32dc3ea5f506b8ecff39.zip"
+                                "/c5317a325923734c8558ca73b96d028dfae37645dbe71d4f9ffd500028c10b0a.zip"
                               ]
                             ]
                           },
@@ -1918,7 +1918,7 @@
                                               {
                                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                               },
-                                              "/62a61b3949f1689cbe3d634ea53cdf3653739068ea82405b3f5daa6af112cd14.zip"
+                                              "/672e6d76b918624744f6bc498b56881eee6fed525922ed0bb6331988f054b7a8.zip"
                                             ]
                                           ]
                                         }
@@ -2121,7 +2121,7 @@
                                 {
                                   "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                 },
-                                "/62a61b3949f1689cbe3d634ea53cdf3653739068ea82405b3f5daa6af112cd14.zip"
+                                "/672e6d76b918624744f6bc498b56881eee6fed525922ed0bb6331988f054b7a8.zip"
                               ]
                             ]
                           },
@@ -3416,7 +3416,7 @@
                       "s3Bucket": {
                         "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                       },
-                      "s3Key": "4e54985b8639a96d9f381204ae955dbee6d1cb715efa67383d64e0b3cb528146.zip"
+                      "s3Key": "ed9d70b884c710671d2f38d3c07b5be67ed5f512b92922bf21a4ccdf61c3c8b9.zip"
                     },
                     "role": {
                       "Fn::GetAtt": [
@@ -4664,7 +4664,7 @@
                                               {
                                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                               },
-                                              "/cf6c81647b444e50910bbd38ad5bd5b74170fa75de8878c6b108a0be22fe8da2.zip"
+                                              "/30e8ea3f1804cc749ac363d7585201378bee46974cf97bc068f11d27aba32023.zip"
                                             ]
                                           ]
                                         }
@@ -4867,7 +4867,7 @@
                                 {
                                   "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                 },
-                                "/cf6c81647b444e50910bbd38ad5bd5b74170fa75de8878c6b108a0be22fe8da2.zip"
+                                "/30e8ea3f1804cc749ac363d7585201378bee46974cf97bc068f11d27aba32023.zip"
                               ]
                             ]
                           },
@@ -5879,7 +5879,7 @@
                                               {
                                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                               },
-                                              "/c521fa041f1b5714edf8fab8f33b2c6e7fa2c95cb57217bdb0a663d2245a28d6.zip"
+                                              "/1816d55ba8a8768830cd9ffe21f56596f39886bc87dcec59f072f9892f322adc.zip"
                                             ]
                                           ]
                                         }
@@ -6082,7 +6082,7 @@
                                 {
                                   "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                 },
-                                "/c521fa041f1b5714edf8fab8f33b2c6e7fa2c95cb57217bdb0a663d2245a28d6.zip"
+                                "/1816d55ba8a8768830cd9ffe21f56596f39886bc87dcec59f072f9892f322adc.zip"
                               ]
                             ]
                           },
@@ -8036,7 +8036,7 @@
                                               {
                                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                               },
-                                              "/91095b20a1ffa4f95834cb332fde4bda534f434fcdd9ea642110a24e343c7756.zip"
+                                              "/5525681c52fa50875eb02c1fa3748aea20486a4b97cdb271d1404920c42cf492.zip"
                                             ]
                                           ]
                                         }
@@ -8239,7 +8239,7 @@
                                 {
                                   "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                 },
-                                "/91095b20a1ffa4f95834cb332fde4bda534f434fcdd9ea642110a24e343c7756.zip"
+                                "/5525681c52fa50875eb02c1fa3748aea20486a4b97cdb271d1404920c42cf492.zip"
                               ]
                             ]
                           },

--- a/test/default.integ.snapshot/tree.json
+++ b/test/default.integ.snapshot/tree.json
@@ -532,7 +532,7 @@
                                               {
                                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                               },
-                                              "/2b33dabb53d6eb0b6b1ce7fda15c31585fa97a6a170f80d4ecdf3f974f10089e.zip"
+                                              "/7016cd24653d28ac7705bc5ec6608f27c8625b2871072fba158790922d95eef1.zip"
                                             ]
                                           ]
                                         }
@@ -735,7 +735,7 @@
                                 {
                                   "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                 },
-                                "/2b33dabb53d6eb0b6b1ce7fda15c31585fa97a6a170f80d4ecdf3f974f10089e.zip"
+                                "/7016cd24653d28ac7705bc5ec6608f27c8625b2871072fba158790922d95eef1.zip"
                               ]
                             ]
                           },
@@ -1225,7 +1225,7 @@
                                               {
                                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                               },
-                                              "/c5317a325923734c8558ca73b96d028dfae37645dbe71d4f9ffd500028c10b0a.zip"
+                                              "/fcdd8c8653be84158994fea0b9638c46cdd8fa303dec32dc3ea5f506b8ecff39.zip"
                                             ]
                                           ]
                                         }
@@ -1428,7 +1428,7 @@
                                 {
                                   "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                 },
-                                "/c5317a325923734c8558ca73b96d028dfae37645dbe71d4f9ffd500028c10b0a.zip"
+                                "/fcdd8c8653be84158994fea0b9638c46cdd8fa303dec32dc3ea5f506b8ecff39.zip"
                               ]
                             ]
                           },
@@ -1918,7 +1918,7 @@
                                               {
                                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                               },
-                                              "/672e6d76b918624744f6bc498b56881eee6fed525922ed0bb6331988f054b7a8.zip"
+                                              "/62a61b3949f1689cbe3d634ea53cdf3653739068ea82405b3f5daa6af112cd14.zip"
                                             ]
                                           ]
                                         }
@@ -2121,7 +2121,7 @@
                                 {
                                   "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                 },
-                                "/672e6d76b918624744f6bc498b56881eee6fed525922ed0bb6331988f054b7a8.zip"
+                                "/62a61b3949f1689cbe3d634ea53cdf3653739068ea82405b3f5daa6af112cd14.zip"
                               ]
                             ]
                           },
@@ -4664,7 +4664,7 @@
                                               {
                                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                               },
-                                              "/30e8ea3f1804cc749ac363d7585201378bee46974cf97bc068f11d27aba32023.zip"
+                                              "/cf6c81647b444e50910bbd38ad5bd5b74170fa75de8878c6b108a0be22fe8da2.zip"
                                             ]
                                           ]
                                         }
@@ -4867,7 +4867,7 @@
                                 {
                                   "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                 },
-                                "/30e8ea3f1804cc749ac363d7585201378bee46974cf97bc068f11d27aba32023.zip"
+                                "/cf6c81647b444e50910bbd38ad5bd5b74170fa75de8878c6b108a0be22fe8da2.zip"
                               ]
                             ]
                           },
@@ -5879,7 +5879,7 @@
                                               {
                                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                               },
-                                              "/1816d55ba8a8768830cd9ffe21f56596f39886bc87dcec59f072f9892f322adc.zip"
+                                              "/c521fa041f1b5714edf8fab8f33b2c6e7fa2c95cb57217bdb0a663d2245a28d6.zip"
                                             ]
                                           ]
                                         }
@@ -6082,7 +6082,7 @@
                                 {
                                   "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                 },
-                                "/1816d55ba8a8768830cd9ffe21f56596f39886bc87dcec59f072f9892f322adc.zip"
+                                "/c521fa041f1b5714edf8fab8f33b2c6e7fa2c95cb57217bdb0a663d2245a28d6.zip"
                               ]
                             ]
                           },
@@ -8036,7 +8036,7 @@
                                               {
                                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                               },
-                                              "/5525681c52fa50875eb02c1fa3748aea20486a4b97cdb271d1404920c42cf492.zip"
+                                              "/91095b20a1ffa4f95834cb332fde4bda534f434fcdd9ea642110a24e343c7756.zip"
                                             ]
                                           ]
                                         }
@@ -8239,7 +8239,7 @@
                                 {
                                   "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                                 },
-                                "/5525681c52fa50875eb02c1fa3748aea20486a4b97cdb271d1404920c42cf492.zip"
+                                "/91095b20a1ffa4f95834cb332fde4bda534f434fcdd9ea642110a24e343c7756.zip"
                               ]
                             ]
                           },


### PR DESCRIPTION
AWS Image Builder APIs don't go over all resources by themselves when filters are applied. We still need to manually iterate everything with `nextToken`. This caused our code to not find all deployed versions. The code then assumed 1.0.1 which was already in use.