### PR TITLE
fix: Don't ignore Windows integration test results

### DIFF
--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -133,7 +133,8 @@ jobs:
           }
       - name: Checkout
         uses: actions/checkout@v3
-      - run: |
+      - name: ls
+        run: |
           $ErrorActionPreference = 'Stop'
           ls
       - name: github script

--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -67,8 +67,24 @@ jobs:
             runs-on: [self-hosted, linux, ec2, arm64]
             docker: true
             sudo: true
+          - os: windows
+            arch: X64
+            runs-on: [self-hosted, windows, codebuild, x64]
+            docker: false
+            sudo: false
+          - os: windows
+            arch: X64
+            runs-on: [self-hosted, windows, fargate, x64]
+            docker: false
+            sudo: false
+          - os: windows
+            arch: X64
+            runs-on: [self-hosted, windows, ec2, x64]
+            docker: true
+            sudo: false
 
     runs-on: ${{ matrix.runs-on }}
+    shell: bash
     steps:
       - run: export
       - name: Check arch
@@ -82,59 +98,6 @@ jobs:
       - run: ls -lah
       - run: sudo ls -lah
         if: ${{ matrix.sudo }}
-      - name: github script
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            console.log("hello world");
-      - name: git
-        run: git --version
-      - name: aws
-        run: |
-          aws --version
-          aws sts get-caller-identity
-      - name: gh
-        run: gh --version
-      - name: docker
-        if: ${{ matrix.docker }}
-        run: |
-          echo FROM public.ecr.aws/docker/library/bash > Dockerfile
-          docker build  .
-          docker-compose --version
-          docker compose version
-
-  self-hosted-windows:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: windows
-            arch: X64
-            runs-on: [self-hosted, windows, codebuild, x64]
-            docker: false
-          - os: windows
-            arch: X64
-            runs-on: [self-hosted, windows, fargate, x64]
-            docker: false
-          - os: windows
-            arch: X64
-            runs-on: [self-hosted, windows, ec2, x64]
-            docker: true
-
-    runs-on: ${{ matrix.runs-on }}
-    steps:
-      - run: |
-          Get-ChildItem env:
-      - name: Check arch
-        run: |
-          if (Compare-Object "${{ matrix.arch }}" $Env:RUNNER_ARCH) {
-            Write-Host "Expected RUNNER_ARCH to be ${{ matrix.arch }} but it's $Env:RUNNER_ARCH"
-            exit 1
-          }
-      - name: Checkout
-        uses: actions/checkout@v3
-      - run: ls
       - name: github script
         uses: actions/github-script@v6
         with:

--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -67,25 +67,6 @@ jobs:
             runs-on: [self-hosted, linux, ec2, arm64]
             docker: true
             sudo: true
-          - os: windows
-            arch: X64
-            runs-on: [self-hosted, windows, codebuild, x64]
-            docker: false
-            sudo: false
-          - os: windows
-            arch: X64
-            runs-on: [self-hosted, windows, fargate, x64]
-            docker: false
-            sudo: false
-          - os: windows
-            arch: X64
-            runs-on: [self-hosted, windows, ec2, x64]
-            docker: true
-            sudo: false
-
-    defaults:
-      run:
-        shell: bash
 
     runs-on: ${{ matrix.runs-on }}
     steps:
@@ -119,6 +100,66 @@ jobs:
         if: ${{ matrix.docker }}
         run: |
           echo FROM public.ecr.aws/docker/library/bash > Dockerfile
+          docker build  .
+          docker-compose --version
+          docker compose version
+  self-hosted-windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows
+            arch: X64
+            runs-on: [self-hosted, windows, codebuild, x64]
+            docker: false
+          - os: windows
+            arch: X64
+            runs-on: [self-hosted, windows, fargate, x64]
+            docker: false
+          - os: windows
+            arch: X64
+            runs-on: [self-hosted, windows, ec2, x64]
+            docker: true
+
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - run: |
+          Get-ChildItem env:
+      - name: Check arch
+        run: |
+          if (Compare-Object "${{ matrix.arch }}" $Env:RUNNER_ARCH) {
+            Write-Host "Expected RUNNER_ARCH to be ${{ matrix.arch }} but it's $Env:RUNNER_ARCH"
+            exit 1
+          }
+      - name: Checkout
+        uses: actions/checkout@v3
+      - run: |
+          $ErrorActionPreference = 'Stop'
+          ls
+      - name: github script
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            console.log("hello world");
+      - name: git
+        run: |
+          $ErrorActionPreference = 'Stop'
+          git --version
+      - name: aws
+        run: |
+          $ErrorActionPreference = 'Stop'
+          aws --version
+          aws sts get-caller-identity
+      - name: gh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          gh --version
+      - name: docker
+        if: ${{ matrix.docker }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          echo "FROM public.ecr.aws/docker/library/bash" | Out-File -encoding ASCII Dockerfile
           docker build  .
           docker-compose --version
           docker compose version

--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -83,8 +83,11 @@ jobs:
             docker: true
             sudo: false
 
+    defaults:
+      run:
+        shell: bash
+
     runs-on: ${{ matrix.runs-on }}
-    shell: bash
     steps:
       - run: export
       - name: Check arch


### PR DESCRIPTION
GitHub Actions don't check if any single commands are failing while using the default shell (PowerShell). Switch to bash so we don't ignore errors.

https://github.com/actions/runner-images/issues/6668

Fixes #253