### PR TITLE
feat: ECS runner provider

### DIFF
--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -27,13 +27,13 @@ jobs:
           - name: ecs x64
             os: linux
             arch: X64
-            runs-on: [ self-hosted, linux, ecs, X64 ]
+            runs-on: [self-hosted, linux, ecs, X64]
             docker: true
             sudo: true
-          - name: codebuild arm64
+          - name: ecs arm64
             os: linux
             arch: ARM64
-            runs-on: [ self-hosted, linux, ecs, arm64 ]
+            runs-on: [self-hosted, linux, ecs, arm64]
             docker: true
             sudo: true
           - name: lambda x64
@@ -146,8 +146,8 @@ jobs:
           - name: ecs windows
             os: windows
             arch: X64
-            runs-on: [ self-hosted, windows, ecs, x64 ]
-            docker: true
+            runs-on: [self-hosted, windows, ecs, x64]
+            docker: false
           - name: fargate windows
             os: windows
             arch: X64

--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -12,61 +12,86 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: linux
+          - name: codebuild x64
+            os: linux
             arch: X64
             runs-on: [self-hosted, linux, X64, codebuild-x64]
             docker: true
             sudo: true
-          - os: linux
+          - name: codebuild arm64
+            os: linux
             arch: ARM64
             runs-on: [self-hosted, linux, codebuild, arm64]
             docker: true
             sudo: true
-          - os: linux
+          - name: ecs x64
+            os: linux
+            arch: X64
+            runs-on: [ self-hosted, linux, ecs, X64 ]
+            docker: true
+            sudo: true
+          - name: codebuild arm64
+            os: linux
+            arch: ARM64
+            runs-on: [ self-hosted, linux, ecs, arm64 ]
+            docker: true
+            sudo: true
+          - name: lambda x64
+            os: linux
             arch: X64
             runs-on: [self-hosted, linux, lambda, x64]
             docker: false
             sudo: false
-          - os: linux
+          - name: lambda arm64
+            os: linux
             arch: ARM64
             runs-on: [self-hosted, linux, lambda, arm64]
             docker: false
             sudo: false
-          - os: linux
+          - name: fargate x64
+            os: linux
             arch: X64
             runs-on: [self-hosted, linux, fargate, x64]
             docker: false
             sudo: true
-          - os: linux
+          - name: fargate arm64
+            os: linux
             arch: ARM64
             runs-on: [self-hosted, linux, fargate, arm64]
             docker: false
             sudo: true
-          - os: linux
+          - name: fargate x64 (spot)
+            os: linux
             arch: X64
             runs-on: [self-hosted, linux, fargate-spot, x64]
             docker: false
             sudo: true
-          - os: linux
+          - name: fargate arm64 (spot)
+            os: linux
             arch: ARM64
             runs-on: [self-hosted, linux, fargate-spot, arm64]
             docker: false
             sudo: true
-          - os: linux
+          - name: ec2 x64
+            os: linux
             arch: X64
             runs-on: [self-hosted, linux, ec2, x64]
             docker: true
             sudo: true
-          - os: linux
+          - name: ec2 x64 (spot)
+            os: linux
             arch: X64
             runs-on: [self-hosted, linux, ec2-spot, x64]
             docker: true
             sudo: true
-          - os: linux
+          - name: ec2 arm64
+            os: linux
             arch: ARM64
             runs-on: [self-hosted, linux, ec2, arm64]
             docker: true
             sudo: true
+
+    name: ${{ matrix.name }}
 
     runs-on: ${{ matrix.runs-on }}
     steps:
@@ -113,18 +138,28 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows
+          - name: codebuild windows
+            os: windows
             arch: X64
             runs-on: [self-hosted, windows, codebuild, x64]
             docker: false
-          - os: windows
+          - name: ecs windows
+            os: windows
+            arch: X64
+            runs-on: [ self-hosted, windows, ecs, x64 ]
+            docker: true
+          - name: fargate windows
+            os: windows
             arch: X64
             runs-on: [self-hosted, windows, fargate, x64]
             docker: false
-          - os: windows
+          - name: ec2 windows
+            os: windows
             arch: X64
             runs-on: [self-hosted, windows, ec2, x64]
             docker: true
+
+    name: ${{ matrix.name }}
 
     runs-on: ${{ matrix.runs-on }}
     steps:

--- a/src/providers/ecs.ts
+++ b/src/providers/ecs.ts
@@ -1,0 +1,441 @@
+import {
+  aws_ec2 as ec2,
+  aws_ecs as ecs,
+  aws_iam as iam,
+  aws_logs as logs,
+  aws_stepfunctions as stepfunctions,
+  aws_stepfunctions_tasks as stepfunctions_tasks,
+  RemovalPolicy,
+  Stack,
+} from 'aws-cdk-lib';
+import * as autoscaling from 'aws-cdk-lib/aws-autoscaling';
+import { MachineImageType } from 'aws-cdk-lib/aws-ecs';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { IntegrationPattern } from 'aws-cdk-lib/aws-stepfunctions';
+import { Construct } from 'constructs';
+import {
+  Architecture,
+  BaseProvider,
+  IRunnerProvider,
+  IRunnerProviderStatus,
+  Os,
+  RunnerImage,
+  RunnerProviderProps,
+  RunnerRuntimeParameters,
+  RunnerVersion,
+} from './common';
+import { ecsRunCommand } from './fargate';
+import { IRunnerImageBuilder, RunnerImageBuilder, RunnerImageBuilderProps, RunnerImageComponent } from './image-builders';
+
+/**
+ * Properties for FargateRunner.
+ */
+export interface FargateRunnerProviderProps extends RunnerProviderProps {
+  /**
+   * Runner image builder used to build Docker images containing GitHub Runner and all requirements.
+   *
+   * The image builder determines the OS and architecture of the runner.
+   *
+   * @default FargateRunnerProviderProps.imageBuilder()
+   */
+  readonly imageBuilder?: IRunnerImageBuilder;
+
+  /**
+   * GitHub Actions labels used for this provider.
+   *
+   * These labels are used to identify which provider should spawn a new on-demand runner. Every job sends a webhook with the labels it's looking for
+   * based on runs-on. We match the labels from the webhook with the labels specified here. If all the labels specified here are present in the
+   * job's labels, this provider will be chosen and spawn a new runner.
+   *
+   * @default ['ecs']
+   */
+  readonly labels?: string[];
+
+  /**
+   * VPC to launch the runners in.
+   *
+   * @default default account VPC
+   */
+  readonly vpc?: ec2.IVpc;
+
+  /**
+   * Subnets to run the runners in.
+   *
+   * @default ECS default
+   */
+  readonly subnetSelection?: ec2.SubnetSelection;
+
+  /**
+   * Security groups to assign to the task.
+   *
+   * @default a new security group
+   */
+  readonly securityGroups?: ec2.ISecurityGroup[];
+
+  /**
+   * Existing ECS cluster to use.
+   *
+   * @default a new cluster
+   */
+  readonly cluster?: ecs.Cluster;
+
+  /**
+   * Existing capacity provider to use.
+   *
+   * @default new capacity provider
+   */
+  readonly capacityProvider?: ecs.AsgCapacityProvider;
+
+  /**
+   * Assign public IP to the runner task.
+   *
+   * Make sure the task will have access to GitHub. A public IP might be required unless you have NAT gateway.
+   *
+   * @default true
+   */
+  readonly assignPublicIp?: boolean;
+
+  /**
+   * The number of cpu units used by the task. 1024 units is 1 vCPU. Fractions of a vCPU are supported.
+   *
+   * @default 1024
+   */
+  readonly cpu?: number;
+
+  /**
+   * The amount (in MiB) of memory used by the task.
+   *
+   * @default 3500
+   */
+  readonly memoryLimitMiB?: number;
+
+  /**
+   * Instance type of ECS cluster instances. Only used when creating a new cluster.
+   *
+   * @default m5.large or m6g.large
+   */
+  readonly instanceType?: ec2.InstanceType;
+
+  /**
+   * The minimum number of instances to run in the cluster. Only used when creating a new cluster.
+   *
+   * @default 0
+   */
+  readonly minInstances?: number;
+
+  /**
+   * The maximum number of instances to run in the cluster. Only used when creating a new cluster.
+   *
+   * @default 5
+   */
+  readonly maxInstances?: number;
+}
+
+interface EcsEc2LaunchTargetProps {
+  readonly capacityProvider: string;
+}
+
+class EcsEc2LaunchTarget implements stepfunctions_tasks.IEcsLaunchTarget {
+  constructor(readonly props: EcsEc2LaunchTargetProps) {
+  }
+
+  /**
+   * Called when the ECS launch type configured on RunTask
+   */
+  public bind(_task: stepfunctions_tasks.EcsRunTask,
+    _launchTargetOptions: stepfunctions_tasks.LaunchTargetBindOptions): stepfunctions_tasks.EcsLaunchTargetConfig {
+    return {
+      parameters: {
+        PropagateTags: ecs.PropagatedTagSource.TASK_DEFINITION,
+        CapacityProviderStrategy: [
+          {
+            CapacityProvider: this.props.capacityProvider,
+          },
+        ],
+      },
+    };
+  }
+}
+
+/**
+ * GitHub Actions runner provider using Fargate to execute jobs.
+ *
+ * Creates a task definition with a single container that gets started for each job.
+ *
+ * This construct is not meant to be used by itself. It should be passed in the providers property for GitHubRunners.
+ */
+export class EcsRunnerProvider extends BaseProvider implements IRunnerProvider {
+  /**
+   * Create new image builder that builds Fargate specific runner images using Ubuntu.
+   *
+   * Included components:
+   *  * `RunnerImageComponent.requiredPackages()`
+   *  * `RunnerImageComponent.runnerUser()`
+   *  * `RunnerImageComponent.git()`
+   *  * `RunnerImageComponent.githubCli()`
+   *  * `RunnerImageComponent.awsCli()`
+   *  * `RunnerImageComponent.dockerInDocker()`
+   *  * `RunnerImageComponent.githubRunner()`
+   */
+  public static imageBuilder(scope: Construct, id: string, props?: RunnerImageBuilderProps): RunnerImageBuilder {
+    return RunnerImageBuilder.new(scope, id, {
+      os: Os.LINUX_UBUNTU,
+      architecture: Architecture.X86_64,
+      components: [
+        RunnerImageComponent.requiredPackages(),
+        RunnerImageComponent.runnerUser(),
+        RunnerImageComponent.git(),
+        RunnerImageComponent.githubCli(),
+        RunnerImageComponent.awsCli(),
+        RunnerImageComponent.dockerInDocker(),
+        RunnerImageComponent.githubRunner(props?.runnerVersion ?? RunnerVersion.latest()),
+      ],
+      ...props,
+    });
+  }
+
+  /**
+   * Cluster hosting the task hosting the runner.
+   */
+  private readonly cluster: ecs.Cluster;
+
+  /**
+   * Capacity provider used to scale the cluster.
+   */
+  private readonly capacityProvider: ecs.AsgCapacityProvider;
+
+  /**
+   * Fargate task hosting the runner.
+   */
+  private readonly task: ecs.Ec2TaskDefinition;
+
+  /**
+   * Container definition hosting the runner.
+   */
+  private readonly container: ecs.ContainerDefinition;
+
+  /**
+   * Labels associated with this provider.
+   */
+  readonly labels: string[];
+
+  /**
+   * VPC used for hosting the runner task.
+   */
+  private readonly vpc?: ec2.IVpc;
+
+  /**
+   * Subnets used for hosting the runner task.
+   */
+  private readonly subnetSelection?: ec2.SubnetSelection;
+
+  /**
+   * Whether runner task will have a public IP.
+   */
+  private readonly assignPublicIp: boolean;
+
+  /**
+   * Grant principal used to add permissions to the runner role.
+   */
+  readonly grantPrincipal: iam.IPrincipal;
+
+  /**
+   * The network connections associated with this resource.
+   */
+  readonly connections: ec2.Connections;
+
+  /**
+   * Docker image loaded with GitHub Actions Runner and its prerequisites. The image is built by an image builder and is specific to Fargate tasks.
+   */
+  private readonly image: RunnerImage;
+
+  /**
+   * Log group where provided runners will save their logs.
+   *
+   * Note that this is not the job log, but the runner itself. It will not contain output from the GitHub Action but only metadata on its execution.
+   */
+  readonly logGroup: logs.ILogGroup;
+
+  /**
+   * Security groups associated with this provider.
+   */
+  private readonly securityGroups: ec2.ISecurityGroup[];
+
+  constructor(scope: Construct, id: string, props?: FargateRunnerProviderProps) {
+    super(scope, id, props);
+
+    this.labels = props?.labels ?? ['ecs'];
+    this.vpc = props?.vpc ?? ec2.Vpc.fromLookup(this, 'default vpc', { isDefault: true });
+    this.subnetSelection = props?.subnetSelection;
+    this.securityGroups = props?.securityGroups ?? [new ec2.SecurityGroup(this, 'security group', { vpc: this.vpc })];
+    this.connections = new ec2.Connections({ securityGroups: this.securityGroups });
+    this.assignPublicIp = props?.assignPublicIp ?? true;
+    this.cluster = props?.cluster ? props.cluster : new ecs.Cluster(
+      this,
+      'cluster',
+      {
+        vpc: this.vpc,
+        enableFargateCapacityProviders: false,
+      },
+    );
+
+    const imageBuilder = props?.imageBuilder ?? EcsRunnerProvider.imageBuilder(this, 'Image Builder');
+    const image = this.image = imageBuilder.bindDockerImage();
+
+    this.capacityProvider = props?.capacityProvider ?? new ecs.AsgCapacityProvider(this, 'Capacity Provider', {
+      autoScalingGroup: new autoscaling.AutoScalingGroup(this, 'Auto Scaling Group', {
+        vpc: this.vpc,
+        vpcSubnets: this.subnetSelection,
+        minCapacity: props?.minInstances ?? 0,
+        maxCapacity: props?.maxInstances ?? 5,
+        machineImage: this.defaultClusterInstanceAmi(),
+        instanceType: props?.instanceType ?? this.defaultClusterInstaceType(),
+      }),
+      spotInstanceDraining: false, // waste of money to restart jobs as the restarted job won't have a token
+    });
+    this.securityGroups.map(sg => this.capacityProvider.autoScalingGroup.addSecurityGroup(sg));
+    this.capacityProvider.autoScalingGroup.role.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'));
+    const thisStack = Stack.of(this);
+    this.capacityProvider.autoScalingGroup.addUserData(
+      `aws ecr get-login-password --region ${thisStack.region} | docker login --username AWS --password-stdin ${thisStack.account}.dkr.ecr.${thisStack.region}.amazonaws.com`,
+      `docker pull ${image.imageRepository.repositoryUri}:${image.imageTag}`,
+    );
+    image.imageRepository.grantPull(this.capacityProvider.autoScalingGroup);
+
+    this.cluster.addAsgCapacityProvider(
+      this.capacityProvider,
+      {
+        spotInstanceDraining: false,
+        machineImageType: MachineImageType.AMAZON_LINUX_2,
+      },
+    );
+
+    this.logGroup = new logs.LogGroup(this, 'logs', {
+      retention: props?.logRetention ?? RetentionDays.ONE_MONTH,
+      removalPolicy: RemovalPolicy.DESTROY,
+    });
+
+    this.task = new ecs.Ec2TaskDefinition(this, 'task');
+    this.container = this.task.addContainer(
+      'runner',
+      {
+        image: ecs.AssetImage.fromEcrRepository(image.imageRepository, image.imageTag),
+        cpu: props?.cpu ?? 1024,
+        memoryLimitMiB: props?.memoryLimitMiB ?? 3500,
+        logging: ecs.AwsLogDriver.awsLogs({
+          logGroup: this.logGroup,
+          streamPrefix: 'runner',
+        }),
+        command: ecsRunCommand(this.image.os),
+        user: image.os.is(Os.WINDOWS) ? undefined : 'runner',
+      },
+    );
+
+    this.grantPrincipal = this.task.taskRole;
+  }
+
+  private defaultClusterInstaceType() {
+    if (this.image.architecture.is(Architecture.X86_64)) {
+      return ec2.InstanceType.of(ec2.InstanceClass.M5, ec2.InstanceSize.LARGE);
+    }
+    if (this.image.architecture.is(Architecture.ARM64)) {
+      return ec2.InstanceType.of(ec2.InstanceClass.M6G, ec2.InstanceSize.LARGE);
+    }
+
+    throw new Error(`Unable to find instance type for ECS instances for ${this.image.architecture.name}`);
+  }
+
+  private defaultClusterInstanceAmi() {
+    if (this.image.os.is(Os.LINUX) || this.image.os.is(Os.LINUX_UBUNTU) || this.image.os.is(Os.LINUX_AMAZON_2)) {
+      if (this.image.architecture.is(Architecture.X86_64)) {
+        return ecs.EcsOptimizedImage.amazonLinux2(ecs.AmiHardwareType.STANDARD);
+      }
+      if (this.image.architecture.is(Architecture.ARM64)) {
+        return ecs.EcsOptimizedImage.amazonLinux2(ecs.AmiHardwareType.ARM);
+      }
+    }
+
+    if (this.image.os.is(Os.WINDOWS)) {
+      return ecs.EcsOptimizedImage.windows(ecs.WindowsOptimizedVersion.SERVER_2019);
+    }
+
+    throw new Error(`Unable to find AMI for ECS instances for ${this.image.os.name}/${this.image.architecture.name}`);
+  }
+
+  /**
+   * Generate step function task(s) to start a new runner.
+   *
+   * Called by GithubRunners and shouldn't be called manually.
+   *
+   * @param parameters workflow job details
+   */
+  getStepFunctionTask(parameters: RunnerRuntimeParameters): stepfunctions.IChainable {
+    const task = new stepfunctions_tasks.EcsRunTask(
+      this,
+      this.labels.join(', '),
+      {
+        integrationPattern: IntegrationPattern.RUN_JOB, // sync
+        taskDefinition: this.task,
+        cluster: this.cluster,
+        launchTarget: new EcsEc2LaunchTarget({ capacityProvider: this.capacityProvider.capacityProviderName }),
+        assignPublicIp: this.assignPublicIp,
+        containerOverrides: [
+          {
+            containerDefinition: this.container,
+            environment: [
+              {
+                name: 'RUNNER_TOKEN',
+                value: parameters.runnerTokenPath,
+              },
+              {
+                name: 'RUNNER_NAME',
+                value: parameters.runnerNamePath,
+              },
+              {
+                name: 'RUNNER_LABEL',
+                value: this.labels.join(','),
+              },
+              {
+                name: 'GITHUB_DOMAIN',
+                value: parameters.githubDomainPath,
+              },
+              {
+                name: 'OWNER',
+                value: parameters.ownerPath,
+              },
+              {
+                name: 'REPO',
+                value: parameters.repoPath,
+              },
+            ],
+          },
+        ],
+      },
+    );
+
+    this.addRetry(task, ['Ecs.EcsException', 'Ecs.LimitExceededException', 'Ecs.UpdateInProgressException']);
+
+    return task;
+  }
+
+  grantStateMachine(_: iam.IGrantable) {
+  }
+
+  status(statusFunctionRole: iam.IGrantable): IRunnerProviderStatus {
+    this.image.imageRepository.grant(statusFunctionRole, 'ecr:DescribeImages');
+
+    return {
+      type: this.constructor.name,
+      labels: this.labels,
+      vpcArn: this.vpc?.vpcArn,
+      securityGroups: this.securityGroups.map(sg => sg.securityGroupId),
+      roleArn: this.task.taskRole.roleArn,
+      logGroup: this.logGroup.logGroupName,
+      image: {
+        imageRepository: this.image.imageRepository.repositoryUri,
+        imageTag: this.image.imageTag,
+        imageBuilderLogGroup: this.image.logGroup?.logGroupName,
+      },
+    };
+  }
+}

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -183,7 +183,7 @@
         }
       }
     },
-    "84e2ff4297b23e3e6424bc089be97d55ed8b808a8c163f687a1313ffe1303781": {
+    "4d1b7dc9601c9e6b463cbbe4b0c5a7b0f32c382075796248d49a12aaa2091eef": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -191,7 +191,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "84e2ff4297b23e3e6424bc089be97d55ed8b808a8c163f687a1313ffe1303781.json",
+          "objectKey": "4d1b7dc9601c9e6b463cbbe4b0c5a7b0f32c382075796248d49a12aaa2091eef.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -9082,6 +9082,1700 @@
     "RetentionInDays": 30
    }
   },
+  "ECSsecuritygroup76605212": {
+   "Type": "AWS::EC2::SecurityGroup",
+   "Properties": {
+    "GroupDescription": "github-runners-test/ECS/security group",
+    "SecurityGroupEgress": [
+     {
+      "CidrIp": "0.0.0.0/0",
+      "Description": "Allow all outbound traffic by default",
+      "IpProtocol": "-1"
+     }
+    ],
+    "VpcId": {
+     "Ref": "Vpc8378EB38"
+    }
+   }
+  },
+  "ECScluster20BC0B82": {
+   "Type": "AWS::ECS::Cluster"
+  },
+  "ECScluster9E223943": {
+   "Type": "AWS::ECS::ClusterCapacityProviderAssociations",
+   "Properties": {
+    "CapacityProviders": [
+     {
+      "Ref": "ECSCapacityProviderABF1B146"
+     }
+    ],
+    "Cluster": {
+     "Ref": "ECScluster20BC0B82"
+    },
+    "DefaultCapacityProviderStrategy": []
+   }
+  },
+  "ECSAutoScalingGroupInstanceSecurityGroup87D56BFE": {
+   "Type": "AWS::EC2::SecurityGroup",
+   "Properties": {
+    "GroupDescription": "github-runners-test/ECS/Auto Scaling Group/InstanceSecurityGroup",
+    "SecurityGroupEgress": [
+     {
+      "CidrIp": "0.0.0.0/0",
+      "Description": "Allow all outbound traffic by default",
+      "IpProtocol": "-1"
+     }
+    ],
+    "Tags": [
+     {
+      "Key": "Name",
+      "Value": "github-runners-test/ECS/Auto Scaling Group"
+     }
+    ],
+    "VpcId": {
+     "Ref": "Vpc8378EB38"
+    }
+   }
+  },
+  "ECSAutoScalingGroupInstanceRoleCA234A7C": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": {
+         "Fn::Join": [
+          "",
+          [
+           "ec2.",
+           {
+            "Ref": "AWS::URLSuffix"
+           }
+          ]
+         ]
+        }
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/AmazonSSMManagedInstanceCore"
+       ]
+      ]
+     }
+    ],
+    "Tags": [
+     {
+      "Key": "Name",
+      "Value": "github-runners-test/ECS/Auto Scaling Group"
+     }
+    ]
+   }
+  },
+  "ECSAutoScalingGroupInstanceRoleDefaultPolicy86A5959D": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage"
+       ],
+       "Effect": "Allow",
+       "Resource": {
+        "Ref": "CodeBuildImageBuilderB8638EC8"
+       }
+      },
+      {
+       "Action": "ecr:GetAuthorizationToken",
+       "Effect": "Allow",
+       "Resource": "*"
+      },
+      {
+       "Action": [
+        "ecs:DeregisterContainerInstance",
+        "ecs:RegisterContainerInstance",
+        "ecs:Submit*"
+       ],
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::GetAtt": [
+         "ECScluster20BC0B82",
+         "Arn"
+        ]
+       }
+      },
+      {
+       "Action": [
+        "ecs:Poll",
+        "ecs:StartTelemetrySession"
+       ],
+       "Condition": {
+        "ArnEquals": {
+         "ecs:cluster": {
+          "Fn::GetAtt": [
+           "ECScluster20BC0B82",
+           "Arn"
+          ]
+         }
+        }
+       },
+       "Effect": "Allow",
+       "Resource": "*"
+      },
+      {
+       "Action": [
+        "ecs:DiscoverPollEndpoint",
+        "ecr:GetAuthorizationToken",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "ECSAutoScalingGroupInstanceRoleDefaultPolicy86A5959D",
+    "Roles": [
+     {
+      "Ref": "ECSAutoScalingGroupInstanceRoleCA234A7C"
+     }
+    ]
+   }
+  },
+  "ECSAutoScalingGroupInstanceProfile288AC654": {
+   "Type": "AWS::IAM::InstanceProfile",
+   "Properties": {
+    "Roles": [
+     {
+      "Ref": "ECSAutoScalingGroupInstanceRoleCA234A7C"
+     }
+    ]
+   }
+  },
+  "ECSAutoScalingGroupLaunchConfigC22C3413": {
+   "Type": "AWS::AutoScaling::LaunchConfiguration",
+   "Properties": {
+    "ImageId": {
+     "Ref": "SsmParameterValueawsserviceecsoptimizedamiamazonlinux2recommendedimageidC96584B6F00A464EAD1953AFF4B05118Parameter"
+    },
+    "InstanceType": "m5.large",
+    "IamInstanceProfile": {
+     "Ref": "ECSAutoScalingGroupInstanceProfile288AC654"
+    },
+    "SecurityGroups": [
+     {
+      "Fn::GetAtt": [
+       "ECSAutoScalingGroupInstanceSecurityGroup87D56BFE",
+       "GroupId"
+      ]
+     },
+     {
+      "Fn::GetAtt": [
+       "ECSsecuritygroup76605212",
+       "GroupId"
+      ]
+     }
+    ],
+    "UserData": {
+     "Fn::Base64": {
+      "Fn::Join": [
+       "",
+       [
+        "#!/bin/bash\naws ecr get-login-password --region ",
+        {
+         "Ref": "AWS::Region"
+        },
+        " | docker login --username AWS --password-stdin ",
+        {
+         "Ref": "AWS::AccountId"
+        },
+        ".dkr.ecr.",
+        {
+         "Ref": "AWS::Region"
+        },
+        ".amazonaws.com\ndocker pull ",
+        {
+         "Fn::Select": [
+          4,
+          {
+           "Fn::Split": [
+            ":",
+            {
+             "Ref": "CodeBuildImageBuilderB8638EC8"
+            }
+           ]
+          }
+         ]
+        },
+        ".dkr.ecr.",
+        {
+         "Fn::Select": [
+          3,
+          {
+           "Fn::Split": [
+            ":",
+            {
+             "Ref": "CodeBuildImageBuilderB8638EC8"
+            }
+           ]
+          }
+         ]
+        },
+        ".",
+        {
+         "Ref": "AWS::URLSuffix"
+        },
+        "/",
+        {
+         "Fn::GetAtt": [
+          "CodeBuildImageBuilderB8638EC8",
+          "Name"
+         ]
+        },
+        ":latest\necho ECS_CLUSTER=",
+        {
+         "Ref": "ECScluster20BC0B82"
+        },
+        " >> /etc/ecs/ecs.config\nsudo iptables --insert FORWARD 1 --in-interface docker+ --destination 169.254.169.254/32 --jump DROP\nsudo service iptables save\necho ECS_AWSVPC_BLOCK_IMDS=true >> /etc/ecs/ecs.config"
+       ]
+      ]
+     }
+    }
+   },
+   "DependsOn": [
+    "ECSAutoScalingGroupInstanceRoleDefaultPolicy86A5959D",
+    "ECSAutoScalingGroupInstanceRoleCA234A7C"
+   ]
+  },
+  "ECSAutoScalingGroupASG88763D9A": {
+   "Type": "AWS::AutoScaling::AutoScalingGroup",
+   "Properties": {
+    "MaxSize": "5",
+    "MinSize": "0",
+    "LaunchConfigurationName": {
+     "Ref": "ECSAutoScalingGroupLaunchConfigC22C3413"
+    },
+    "NewInstancesProtectedFromScaleIn": true,
+    "Tags": [
+     {
+      "Key": "Name",
+      "PropagateAtLaunch": true,
+      "Value": "github-runners-test/ECS/Auto Scaling Group"
+     }
+    ],
+    "VPCZoneIdentifier": [
+     {
+      "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
+     },
+     {
+      "Ref": "VpcPublicSubnet2Subnet691E08A3"
+     }
+    ]
+   },
+   "UpdatePolicy": {
+    "AutoScalingScheduledAction": {
+     "IgnoreUnmodifiedGroupSizeProperties": true
+    }
+   }
+  },
+  "ECSCapacityProviderABF1B146": {
+   "Type": "AWS::ECS::CapacityProvider",
+   "Properties": {
+    "AutoScalingGroupProvider": {
+     "AutoScalingGroupArn": {
+      "Ref": "ECSAutoScalingGroupASG88763D9A"
+     },
+     "ManagedScaling": {
+      "Status": "ENABLED",
+      "TargetCapacity": 100
+     },
+     "ManagedTerminationProtection": "ENABLED"
+    }
+   }
+  },
+  "ECSlogs71446134": {
+   "Type": "AWS::Logs::LogGroup",
+   "Properties": {
+    "RetentionInDays": 30
+   },
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete"
+  },
+  "ECSlogslogsfilterC744F425": {
+   "Type": "AWS::Logs::MetricFilter",
+   "Properties": {
+    "FilterPattern": "[..., marker = \"CDKGHA\", job = \"JOB\", done = \"DONE\", labels, status = \"Succeeded\" || status = \"SucceededWithIssues\" || status = \"Failed\" || status = \"Canceled\" || status = \"Skipped\" || status = \"Abandoned\"]",
+    "LogGroupName": {
+     "Ref": "ECSlogs71446134"
+    },
+    "MetricTransformations": [
+     {
+      "Dimensions": [
+       {
+        "Key": "ProviderLabels",
+        "Value": "$labels"
+       },
+       {
+        "Key": "Status",
+        "Value": "$status"
+       }
+      ],
+      "MetricName": "JobCompleted",
+      "MetricNamespace": "GitHubRunners",
+      "MetricValue": "1",
+      "Unit": "Count"
+     }
+    ]
+   }
+  },
+  "ECStaskTaskRoleFE831ECD": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    }
+   }
+  },
+  "ECStask8F0DD550": {
+   "Type": "AWS::ECS::TaskDefinition",
+   "Properties": {
+    "ContainerDefinitions": [
+     {
+      "Command": [
+       "sh",
+       "-c",
+       "cd /home/runner &&\n        if [ \"$RUNNER_VERSION\" = \"latest\" ]; then RUNNER_FLAGS=\"\"; else RUNNER_FLAGS=\"--disableupdate\"; fi &&\n        ./config.sh --unattended --url \"https://$GITHUB_DOMAIN/$OWNER/$REPO\" --token \"$RUNNER_TOKEN\" --ephemeral --work _work --labels \"$RUNNER_LABEL\" $RUNNER_FLAGS --name \"$RUNNER_NAME\" && \n        ./run.sh &&\n        STATUS=$(grep -Phors \"finish job request for job [0-9a-f\\-]+ with result: \\K.*\" _diag/ | tail -n1) &&\n        [ -n \"$STATUS\" ] && echo CDKGHA JOB DONE \"$RUNNER_LABEL\" \"$STATUS\""
+      ],
+      "Cpu": 1024,
+      "Essential": true,
+      "Image": {
+       "Fn::Join": [
+        "",
+        [
+         {
+          "Fn::Select": [
+           4,
+           {
+            "Fn::Split": [
+             ":",
+             {
+              "Ref": "CodeBuildImageBuilderB8638EC8"
+             }
+            ]
+           }
+          ]
+         },
+         ".dkr.ecr.",
+         {
+          "Fn::Select": [
+           3,
+           {
+            "Fn::Split": [
+             ":",
+             {
+              "Ref": "CodeBuildImageBuilderB8638EC8"
+             }
+            ]
+           }
+          ]
+         },
+         ".",
+         {
+          "Ref": "AWS::URLSuffix"
+         },
+         "/",
+         {
+          "Fn::GetAtt": [
+           "CodeBuildImageBuilderB8638EC8",
+           "Name"
+          ]
+         },
+         ":latest"
+        ]
+       ]
+      },
+      "LogConfiguration": {
+       "LogDriver": "awslogs",
+       "Options": {
+        "awslogs-group": {
+         "Ref": "ECSlogs71446134"
+        },
+        "awslogs-stream-prefix": "runner",
+        "awslogs-region": {
+         "Ref": "AWS::Region"
+        }
+       }
+      },
+      "Memory": 3500,
+      "Name": "runner",
+      "User": "runner"
+     }
+    ],
+    "ExecutionRoleArn": {
+     "Fn::GetAtt": [
+      "ECStaskExecutionRole1A6D19A5",
+      "Arn"
+     ]
+    },
+    "Family": "githubrunnerstestECStaskCE74CC84",
+    "NetworkMode": "bridge",
+    "RequiresCompatibilities": [
+     "EC2"
+    ],
+    "TaskRoleArn": {
+     "Fn::GetAtt": [
+      "ECStaskTaskRoleFE831ECD",
+      "Arn"
+     ]
+    }
+   }
+  },
+  "ECStaskExecutionRole1A6D19A5": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    }
+   }
+  },
+  "ECStaskExecutionRoleDefaultPolicy564C1271": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage"
+       ],
+       "Effect": "Allow",
+       "Resource": {
+        "Ref": "CodeBuildImageBuilderB8638EC8"
+       }
+      },
+      {
+       "Action": "ecr:GetAuthorizationToken",
+       "Effect": "Allow",
+       "Resource": "*"
+      },
+      {
+       "Action": [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+       ],
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::GetAtt": [
+         "ECSlogs71446134",
+         "Arn"
+        ]
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "ECStaskExecutionRoleDefaultPolicy564C1271",
+    "Roles": [
+     {
+      "Ref": "ECStaskExecutionRole1A6D19A5"
+     }
+    ]
+   }
+  },
+  "ECSARM64securitygroup281D94B2": {
+   "Type": "AWS::EC2::SecurityGroup",
+   "Properties": {
+    "GroupDescription": "github-runners-test/ECS ARM64/security group",
+    "SecurityGroupEgress": [
+     {
+      "CidrIp": "0.0.0.0/0",
+      "Description": "Allow all outbound traffic by default",
+      "IpProtocol": "-1"
+     }
+    ],
+    "VpcId": {
+     "Ref": "Vpc8378EB38"
+    }
+   }
+  },
+  "ECSARM64cluster4ECAA083": {
+   "Type": "AWS::ECS::Cluster"
+  },
+  "ECSARM64cluster43E75409": {
+   "Type": "AWS::ECS::ClusterCapacityProviderAssociations",
+   "Properties": {
+    "CapacityProviders": [
+     {
+      "Ref": "ECSARM64CapacityProvider8627FEF9"
+     }
+    ],
+    "Cluster": {
+     "Ref": "ECSARM64cluster4ECAA083"
+    },
+    "DefaultCapacityProviderStrategy": []
+   }
+  },
+  "ECSARM64AutoScalingGroupInstanceSecurityGroupB68B781E": {
+   "Type": "AWS::EC2::SecurityGroup",
+   "Properties": {
+    "GroupDescription": "github-runners-test/ECS ARM64/Auto Scaling Group/InstanceSecurityGroup",
+    "SecurityGroupEgress": [
+     {
+      "CidrIp": "0.0.0.0/0",
+      "Description": "Allow all outbound traffic by default",
+      "IpProtocol": "-1"
+     }
+    ],
+    "Tags": [
+     {
+      "Key": "Name",
+      "Value": "github-runners-test/ECS ARM64/Auto Scaling Group"
+     }
+    ],
+    "VpcId": {
+     "Ref": "Vpc8378EB38"
+    }
+   }
+  },
+  "ECSARM64AutoScalingGroupInstanceRole01030665": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": {
+         "Fn::Join": [
+          "",
+          [
+           "ec2.",
+           {
+            "Ref": "AWS::URLSuffix"
+           }
+          ]
+         ]
+        }
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/AmazonSSMManagedInstanceCore"
+       ]
+      ]
+     }
+    ],
+    "Tags": [
+     {
+      "Key": "Name",
+      "Value": "github-runners-test/ECS ARM64/Auto Scaling Group"
+     }
+    ]
+   }
+  },
+  "ECSARM64AutoScalingGroupInstanceRoleDefaultPolicyD0E29275": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage"
+       ],
+       "Effect": "Allow",
+       "Resource": {
+        "Ref": "CodeBuildImageBuilderarmBuilder755EB37D"
+       }
+      },
+      {
+       "Action": "ecr:GetAuthorizationToken",
+       "Effect": "Allow",
+       "Resource": "*"
+      },
+      {
+       "Action": [
+        "ecs:DeregisterContainerInstance",
+        "ecs:RegisterContainerInstance",
+        "ecs:Submit*"
+       ],
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::GetAtt": [
+         "ECSARM64cluster4ECAA083",
+         "Arn"
+        ]
+       }
+      },
+      {
+       "Action": [
+        "ecs:Poll",
+        "ecs:StartTelemetrySession"
+       ],
+       "Condition": {
+        "ArnEquals": {
+         "ecs:cluster": {
+          "Fn::GetAtt": [
+           "ECSARM64cluster4ECAA083",
+           "Arn"
+          ]
+         }
+        }
+       },
+       "Effect": "Allow",
+       "Resource": "*"
+      },
+      {
+       "Action": [
+        "ecs:DiscoverPollEndpoint",
+        "ecr:GetAuthorizationToken",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "ECSARM64AutoScalingGroupInstanceRoleDefaultPolicyD0E29275",
+    "Roles": [
+     {
+      "Ref": "ECSARM64AutoScalingGroupInstanceRole01030665"
+     }
+    ]
+   }
+  },
+  "ECSARM64AutoScalingGroupInstanceProfile768645E6": {
+   "Type": "AWS::IAM::InstanceProfile",
+   "Properties": {
+    "Roles": [
+     {
+      "Ref": "ECSARM64AutoScalingGroupInstanceRole01030665"
+     }
+    ]
+   }
+  },
+  "ECSARM64AutoScalingGroupLaunchConfig9B8B62ED": {
+   "Type": "AWS::AutoScaling::LaunchConfiguration",
+   "Properties": {
+    "ImageId": {
+     "Ref": "SsmParameterValueawsserviceecsoptimizedamiamazonlinux2arm64recommendedimageidC96584B6F00A464EAD1953AFF4B05118Parameter"
+    },
+    "InstanceType": "m6g.large",
+    "IamInstanceProfile": {
+     "Ref": "ECSARM64AutoScalingGroupInstanceProfile768645E6"
+    },
+    "SecurityGroups": [
+     {
+      "Fn::GetAtt": [
+       "ECSARM64AutoScalingGroupInstanceSecurityGroupB68B781E",
+       "GroupId"
+      ]
+     },
+     {
+      "Fn::GetAtt": [
+       "ECSARM64securitygroup281D94B2",
+       "GroupId"
+      ]
+     }
+    ],
+    "UserData": {
+     "Fn::Base64": {
+      "Fn::Join": [
+       "",
+       [
+        "#!/bin/bash\naws ecr get-login-password --region ",
+        {
+         "Ref": "AWS::Region"
+        },
+        " | docker login --username AWS --password-stdin ",
+        {
+         "Ref": "AWS::AccountId"
+        },
+        ".dkr.ecr.",
+        {
+         "Ref": "AWS::Region"
+        },
+        ".amazonaws.com\ndocker pull ",
+        {
+         "Fn::Select": [
+          4,
+          {
+           "Fn::Split": [
+            ":",
+            {
+             "Ref": "CodeBuildImageBuilderarmBuilder755EB37D"
+            }
+           ]
+          }
+         ]
+        },
+        ".dkr.ecr.",
+        {
+         "Fn::Select": [
+          3,
+          {
+           "Fn::Split": [
+            ":",
+            {
+             "Ref": "CodeBuildImageBuilderarmBuilder755EB37D"
+            }
+           ]
+          }
+         ]
+        },
+        ".",
+        {
+         "Ref": "AWS::URLSuffix"
+        },
+        "/",
+        {
+         "Fn::GetAtt": [
+          "CodeBuildImageBuilderarmBuilder755EB37D",
+          "Name"
+         ]
+        },
+        ":latest\necho ECS_CLUSTER=",
+        {
+         "Ref": "ECSARM64cluster4ECAA083"
+        },
+        " >> /etc/ecs/ecs.config\nsudo iptables --insert FORWARD 1 --in-interface docker+ --destination 169.254.169.254/32 --jump DROP\nsudo service iptables save\necho ECS_AWSVPC_BLOCK_IMDS=true >> /etc/ecs/ecs.config"
+       ]
+      ]
+     }
+    }
+   },
+   "DependsOn": [
+    "ECSARM64AutoScalingGroupInstanceRoleDefaultPolicyD0E29275",
+    "ECSARM64AutoScalingGroupInstanceRole01030665"
+   ]
+  },
+  "ECSARM64AutoScalingGroupASGA19FC118": {
+   "Type": "AWS::AutoScaling::AutoScalingGroup",
+   "Properties": {
+    "MaxSize": "5",
+    "MinSize": "0",
+    "LaunchConfigurationName": {
+     "Ref": "ECSARM64AutoScalingGroupLaunchConfig9B8B62ED"
+    },
+    "NewInstancesProtectedFromScaleIn": true,
+    "Tags": [
+     {
+      "Key": "Name",
+      "PropagateAtLaunch": true,
+      "Value": "github-runners-test/ECS ARM64/Auto Scaling Group"
+     }
+    ],
+    "VPCZoneIdentifier": [
+     {
+      "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
+     },
+     {
+      "Ref": "VpcPublicSubnet2Subnet691E08A3"
+     }
+    ]
+   },
+   "UpdatePolicy": {
+    "AutoScalingScheduledAction": {
+     "IgnoreUnmodifiedGroupSizeProperties": true
+    }
+   }
+  },
+  "ECSARM64CapacityProvider8627FEF9": {
+   "Type": "AWS::ECS::CapacityProvider",
+   "Properties": {
+    "AutoScalingGroupProvider": {
+     "AutoScalingGroupArn": {
+      "Ref": "ECSARM64AutoScalingGroupASGA19FC118"
+     },
+     "ManagedScaling": {
+      "Status": "ENABLED",
+      "TargetCapacity": 100
+     },
+     "ManagedTerminationProtection": "ENABLED"
+    }
+   }
+  },
+  "ECSARM64logs1A2F1E00": {
+   "Type": "AWS::Logs::LogGroup",
+   "Properties": {
+    "RetentionInDays": 30
+   },
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete"
+  },
+  "ECSARM64logslogsfilter6914CFA1": {
+   "Type": "AWS::Logs::MetricFilter",
+   "Properties": {
+    "FilterPattern": "[..., marker = \"CDKGHA\", job = \"JOB\", done = \"DONE\", labels, status = \"Succeeded\" || status = \"SucceededWithIssues\" || status = \"Failed\" || status = \"Canceled\" || status = \"Skipped\" || status = \"Abandoned\"]",
+    "LogGroupName": {
+     "Ref": "ECSARM64logs1A2F1E00"
+    },
+    "MetricTransformations": [
+     {
+      "Dimensions": [
+       {
+        "Key": "ProviderLabels",
+        "Value": "$labels"
+       },
+       {
+        "Key": "Status",
+        "Value": "$status"
+       }
+      ],
+      "MetricName": "JobCompleted",
+      "MetricNamespace": "GitHubRunners",
+      "MetricValue": "1",
+      "Unit": "Count"
+     }
+    ]
+   }
+  },
+  "ECSARM64taskTaskRole23B1CB4E": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    }
+   }
+  },
+  "ECSARM64task27EB8443": {
+   "Type": "AWS::ECS::TaskDefinition",
+   "Properties": {
+    "ContainerDefinitions": [
+     {
+      "Command": [
+       "sh",
+       "-c",
+       "cd /home/runner &&\n        if [ \"$RUNNER_VERSION\" = \"latest\" ]; then RUNNER_FLAGS=\"\"; else RUNNER_FLAGS=\"--disableupdate\"; fi &&\n        ./config.sh --unattended --url \"https://$GITHUB_DOMAIN/$OWNER/$REPO\" --token \"$RUNNER_TOKEN\" --ephemeral --work _work --labels \"$RUNNER_LABEL\" $RUNNER_FLAGS --name \"$RUNNER_NAME\" && \n        ./run.sh &&\n        STATUS=$(grep -Phors \"finish job request for job [0-9a-f\\-]+ with result: \\K.*\" _diag/ | tail -n1) &&\n        [ -n \"$STATUS\" ] && echo CDKGHA JOB DONE \"$RUNNER_LABEL\" \"$STATUS\""
+      ],
+      "Cpu": 1024,
+      "Essential": true,
+      "Image": {
+       "Fn::Join": [
+        "",
+        [
+         {
+          "Fn::Select": [
+           4,
+           {
+            "Fn::Split": [
+             ":",
+             {
+              "Ref": "CodeBuildImageBuilderarmBuilder755EB37D"
+             }
+            ]
+           }
+          ]
+         },
+         ".dkr.ecr.",
+         {
+          "Fn::Select": [
+           3,
+           {
+            "Fn::Split": [
+             ":",
+             {
+              "Ref": "CodeBuildImageBuilderarmBuilder755EB37D"
+             }
+            ]
+           }
+          ]
+         },
+         ".",
+         {
+          "Ref": "AWS::URLSuffix"
+         },
+         "/",
+         {
+          "Fn::GetAtt": [
+           "CodeBuildImageBuilderarmBuilder755EB37D",
+           "Name"
+          ]
+         },
+         ":latest"
+        ]
+       ]
+      },
+      "LogConfiguration": {
+       "LogDriver": "awslogs",
+       "Options": {
+        "awslogs-group": {
+         "Ref": "ECSARM64logs1A2F1E00"
+        },
+        "awslogs-stream-prefix": "runner",
+        "awslogs-region": {
+         "Ref": "AWS::Region"
+        }
+       }
+      },
+      "Memory": 3500,
+      "Name": "runner",
+      "User": "runner"
+     }
+    ],
+    "ExecutionRoleArn": {
+     "Fn::GetAtt": [
+      "ECSARM64taskExecutionRoleBF2AE76F",
+      "Arn"
+     ]
+    },
+    "Family": "githubrunnerstestECSARM64taskE94E43A3",
+    "NetworkMode": "bridge",
+    "RequiresCompatibilities": [
+     "EC2"
+    ],
+    "TaskRoleArn": {
+     "Fn::GetAtt": [
+      "ECSARM64taskTaskRole23B1CB4E",
+      "Arn"
+     ]
+    }
+   }
+  },
+  "ECSARM64taskExecutionRoleBF2AE76F": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    }
+   }
+  },
+  "ECSARM64taskExecutionRoleDefaultPolicy17294239": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage"
+       ],
+       "Effect": "Allow",
+       "Resource": {
+        "Ref": "CodeBuildImageBuilderarmBuilder755EB37D"
+       }
+      },
+      {
+       "Action": "ecr:GetAuthorizationToken",
+       "Effect": "Allow",
+       "Resource": "*"
+      },
+      {
+       "Action": [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+       ],
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::GetAtt": [
+         "ECSARM64logs1A2F1E00",
+         "Arn"
+        ]
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "ECSARM64taskExecutionRoleDefaultPolicy17294239",
+    "Roles": [
+     {
+      "Ref": "ECSARM64taskExecutionRoleBF2AE76F"
+     }
+    ]
+   }
+  },
+  "ECSWindowssecuritygroupB4EE54DA": {
+   "Type": "AWS::EC2::SecurityGroup",
+   "Properties": {
+    "GroupDescription": "github-runners-test/ECS Windows/security group",
+    "SecurityGroupEgress": [
+     {
+      "CidrIp": "0.0.0.0/0",
+      "Description": "Allow all outbound traffic by default",
+      "IpProtocol": "-1"
+     }
+    ],
+    "VpcId": {
+     "Ref": "Vpc8378EB38"
+    }
+   }
+  },
+  "ECSWindowscluster14061F74": {
+   "Type": "AWS::ECS::Cluster"
+  },
+  "ECSWindowscluster49B54894": {
+   "Type": "AWS::ECS::ClusterCapacityProviderAssociations",
+   "Properties": {
+    "CapacityProviders": [
+     {
+      "Ref": "ECSWindowsCapacityProvider8F8896A5"
+     }
+    ],
+    "Cluster": {
+     "Ref": "ECSWindowscluster14061F74"
+    },
+    "DefaultCapacityProviderStrategy": []
+   }
+  },
+  "ECSWindowsAutoScalingGroupInstanceSecurityGroupA3DBA17A": {
+   "Type": "AWS::EC2::SecurityGroup",
+   "Properties": {
+    "GroupDescription": "github-runners-test/ECS Windows/Auto Scaling Group/InstanceSecurityGroup",
+    "SecurityGroupEgress": [
+     {
+      "CidrIp": "0.0.0.0/0",
+      "Description": "Allow all outbound traffic by default",
+      "IpProtocol": "-1"
+     }
+    ],
+    "Tags": [
+     {
+      "Key": "Name",
+      "Value": "github-runners-test/ECS Windows/Auto Scaling Group"
+     }
+    ],
+    "VpcId": {
+     "Ref": "Vpc8378EB38"
+    }
+   }
+  },
+  "ECSWindowsAutoScalingGroupInstanceRoleFB287046": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": {
+         "Fn::Join": [
+          "",
+          [
+           "ec2.",
+           {
+            "Ref": "AWS::URLSuffix"
+           }
+          ]
+         ]
+        }
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/AmazonSSMManagedInstanceCore"
+       ]
+      ]
+     }
+    ],
+    "Tags": [
+     {
+      "Key": "Name",
+      "Value": "github-runners-test/ECS Windows/Auto Scaling Group"
+     }
+    ]
+   }
+  },
+  "ECSWindowsAutoScalingGroupInstanceRoleDefaultPolicyAEE83B95": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage"
+       ],
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::Join": [
+         "",
+         [
+          "arn:",
+          {
+           "Ref": "AWS::Partition"
+          },
+          ":ecr:",
+          {
+           "Ref": "AWS::Region"
+          },
+          ":",
+          {
+           "Ref": "AWS::AccountId"
+          },
+          ":repository/",
+          {
+           "Fn::Select": [
+            0,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Fn::Select": [
+                1,
+                {
+                 "Fn::Split": [
+                  "/",
+                  {
+                   "Fn::GetAtt": [
+                    "WindowsImageBuilderDockerImage8672CA3E",
+                    "ImageUri"
+                   ]
+                  }
+                 ]
+                }
+               ]
+              }
+             ]
+            }
+           ]
+          }
+         ]
+        ]
+       }
+      },
+      {
+       "Action": "ecr:GetAuthorizationToken",
+       "Effect": "Allow",
+       "Resource": "*"
+      },
+      {
+       "Action": [
+        "ecs:DeregisterContainerInstance",
+        "ecs:RegisterContainerInstance",
+        "ecs:Submit*"
+       ],
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::GetAtt": [
+         "ECSWindowscluster14061F74",
+         "Arn"
+        ]
+       }
+      },
+      {
+       "Action": [
+        "ecs:Poll",
+        "ecs:StartTelemetrySession"
+       ],
+       "Condition": {
+        "ArnEquals": {
+         "ecs:cluster": {
+          "Fn::GetAtt": [
+           "ECSWindowscluster14061F74",
+           "Arn"
+          ]
+         }
+        }
+       },
+       "Effect": "Allow",
+       "Resource": "*"
+      },
+      {
+       "Action": [
+        "ecs:DiscoverPollEndpoint",
+        "ecr:GetAuthorizationToken",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "ECSWindowsAutoScalingGroupInstanceRoleDefaultPolicyAEE83B95",
+    "Roles": [
+     {
+      "Ref": "ECSWindowsAutoScalingGroupInstanceRoleFB287046"
+     }
+    ]
+   }
+  },
+  "ECSWindowsAutoScalingGroupInstanceProfileD8019407": {
+   "Type": "AWS::IAM::InstanceProfile",
+   "Properties": {
+    "Roles": [
+     {
+      "Ref": "ECSWindowsAutoScalingGroupInstanceRoleFB287046"
+     }
+    ]
+   }
+  },
+  "ECSWindowsAutoScalingGroupLaunchConfigAD09CF33": {
+   "Type": "AWS::AutoScaling::LaunchConfiguration",
+   "Properties": {
+    "ImageId": {
+     "Ref": "SsmParameterValueawsserviceecsoptimizedamiwindowsserver2019englishfullrecommendedimageidC96584B6F00A464EAD1953AFF4B05118Parameter"
+    },
+    "InstanceType": "m5.large",
+    "IamInstanceProfile": {
+     "Ref": "ECSWindowsAutoScalingGroupInstanceProfileD8019407"
+    },
+    "SecurityGroups": [
+     {
+      "Fn::GetAtt": [
+       "ECSWindowsAutoScalingGroupInstanceSecurityGroupA3DBA17A",
+       "GroupId"
+      ]
+     },
+     {
+      "Fn::GetAtt": [
+       "ECSWindowssecuritygroupB4EE54DA",
+       "GroupId"
+      ]
+     }
+    ],
+    "UserData": {
+     "Fn::Base64": {
+      "Fn::Join": [
+       "",
+       [
+        "<powershell>aws ecr get-login-password --region ",
+        {
+         "Ref": "AWS::Region"
+        },
+        " | docker login --username AWS --password-stdin ",
+        {
+         "Ref": "AWS::AccountId"
+        },
+        ".dkr.ecr.",
+        {
+         "Ref": "AWS::Region"
+        },
+        ".amazonaws.com\ndocker pull ",
+        {
+         "Ref": "AWS::AccountId"
+        },
+        ".dkr.ecr.",
+        {
+         "Ref": "AWS::Region"
+        },
+        ".",
+        {
+         "Ref": "AWS::URLSuffix"
+        },
+        "/",
+        {
+         "Fn::Select": [
+          0,
+          {
+           "Fn::Split": [
+            ":",
+            {
+             "Fn::Select": [
+              1,
+              {
+               "Fn::Split": [
+                "/",
+                {
+                 "Fn::GetAtt": [
+                  "WindowsImageBuilderDockerImage8672CA3E",
+                  "ImageUri"
+                 ]
+                }
+               ]
+              }
+             ]
+            }
+           ]
+          }
+         ]
+        },
+        ":latest\nRemove-Item -Recurse C:\\ProgramData\\Amazon\\ECS\\Cache\nImport-Module ECSTools\n[Environment]::SetEnvironmentVariable(\"ECS_CLUSTER\", \"",
+        {
+         "Ref": "ECSWindowscluster14061F74"
+        },
+        "\", \"Machine\")\n[Environment]::SetEnvironmentVariable(\"ECS_ENABLE_AWSLOGS_EXECUTIONROLE_OVERRIDE\", \"true\", \"Machine\")\n[Environment]::SetEnvironmentVariable(\"ECS_AVAILABLE_LOGGING_DRIVERS\", '[\"json-file\",\"awslogs\"]', \"Machine\")\n[Environment]::SetEnvironmentVariable(\"ECS_ENABLE_TASK_IAM_ROLE\", \"true\", \"Machine\")\nInitialize-ECSAgent -Cluster '",
+        {
+         "Ref": "ECSWindowscluster14061F74"
+        },
+        "' -EnableTaskIAMRole</powershell>"
+       ]
+      ]
+     }
+    }
+   },
+   "DependsOn": [
+    "ECSWindowsAutoScalingGroupInstanceRoleDefaultPolicyAEE83B95",
+    "ECSWindowsAutoScalingGroupInstanceRoleFB287046"
+   ]
+  },
+  "ECSWindowsAutoScalingGroupASG864E3AAF": {
+   "Type": "AWS::AutoScaling::AutoScalingGroup",
+   "Properties": {
+    "MaxSize": "5",
+    "MinSize": "0",
+    "LaunchConfigurationName": {
+     "Ref": "ECSWindowsAutoScalingGroupLaunchConfigAD09CF33"
+    },
+    "NewInstancesProtectedFromScaleIn": true,
+    "Tags": [
+     {
+      "Key": "Name",
+      "PropagateAtLaunch": true,
+      "Value": "github-runners-test/ECS Windows/Auto Scaling Group"
+     }
+    ],
+    "VPCZoneIdentifier": [
+     {
+      "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
+     },
+     {
+      "Ref": "VpcPublicSubnet2Subnet691E08A3"
+     }
+    ]
+   },
+   "UpdatePolicy": {
+    "AutoScalingScheduledAction": {
+     "IgnoreUnmodifiedGroupSizeProperties": true
+    }
+   }
+  },
+  "ECSWindowsCapacityProvider8F8896A5": {
+   "Type": "AWS::ECS::CapacityProvider",
+   "Properties": {
+    "AutoScalingGroupProvider": {
+     "AutoScalingGroupArn": {
+      "Ref": "ECSWindowsAutoScalingGroupASG864E3AAF"
+     },
+     "ManagedScaling": {
+      "Status": "ENABLED",
+      "TargetCapacity": 100
+     },
+     "ManagedTerminationProtection": "ENABLED"
+    }
+   }
+  },
+  "ECSWindowslogs83D9D352": {
+   "Type": "AWS::Logs::LogGroup",
+   "Properties": {
+    "RetentionInDays": 30
+   },
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete"
+  },
+  "ECSWindowslogslogsfilterA25F0C55": {
+   "Type": "AWS::Logs::MetricFilter",
+   "Properties": {
+    "FilterPattern": "[..., marker = \"CDKGHA\", job = \"JOB\", done = \"DONE\", labels, status = \"Succeeded\" || status = \"SucceededWithIssues\" || status = \"Failed\" || status = \"Canceled\" || status = \"Skipped\" || status = \"Abandoned\"]",
+    "LogGroupName": {
+     "Ref": "ECSWindowslogs83D9D352"
+    },
+    "MetricTransformations": [
+     {
+      "Dimensions": [
+       {
+        "Key": "ProviderLabels",
+        "Value": "$labels"
+       },
+       {
+        "Key": "Status",
+        "Value": "$status"
+       }
+      ],
+      "MetricName": "JobCompleted",
+      "MetricNamespace": "GitHubRunners",
+      "MetricValue": "1",
+      "Unit": "Count"
+     }
+    ]
+   }
+  },
+  "ECSWindowstaskTaskRole17C8DA48": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    }
+   }
+  },
+  "ECSWindowstask73A31B6C": {
+   "Type": "AWS::ECS::TaskDefinition",
+   "Properties": {
+    "ContainerDefinitions": [
+     {
+      "Command": [
+       "powershell",
+       "-Command",
+       "cd \\actions ;\n        if ($Env:RUNNER_VERSION -eq \"latest\") { $RunnerFlags = \"\" } else { $RunnerFlags = \"--disableupdate\" } ; \n        ./config.cmd --unattended --url \"https://${Env:GITHUB_DOMAIN}/${Env:OWNER}/${Env:REPO}\" --token \"${Env:RUNNER_TOKEN}\" --ephemeral --work _work --labels \"${Env:RUNNER_LABEL}\" $RunnerFlags --name \"${Env:RUNNER_NAME}\" ; \n        ./run.cmd ; \n        $STATUS = Select-String -Path './_diag/*.log' -Pattern 'finish job request for job [0-9a-f\\-]+ with result: (.*)' | %{$_.Matches.Groups[1].Value} | Select-Object -Last 1 ; \n        if ($STATUS) { echo \"CDKGHA JOB DONE ${Env:RUNNER_LABEL} $STATUS\" }"
+      ],
+      "Cpu": 1024,
+      "Essential": true,
+      "Image": {
+       "Fn::Join": [
+        "",
+        [
+         {
+          "Ref": "AWS::AccountId"
+         },
+         ".dkr.ecr.",
+         {
+          "Ref": "AWS::Region"
+         },
+         ".",
+         {
+          "Ref": "AWS::URLSuffix"
+         },
+         "/",
+         {
+          "Fn::Select": [
+           0,
+           {
+            "Fn::Split": [
+             ":",
+             {
+              "Fn::Select": [
+               1,
+               {
+                "Fn::Split": [
+                 "/",
+                 {
+                  "Fn::GetAtt": [
+                   "WindowsImageBuilderDockerImage8672CA3E",
+                   "ImageUri"
+                  ]
+                 }
+                ]
+               }
+              ]
+             }
+            ]
+           }
+          ]
+         },
+         ":latest"
+        ]
+       ]
+      },
+      "LogConfiguration": {
+       "LogDriver": "awslogs",
+       "Options": {
+        "awslogs-group": {
+         "Ref": "ECSWindowslogs83D9D352"
+        },
+        "awslogs-stream-prefix": "runner",
+        "awslogs-region": {
+         "Ref": "AWS::Region"
+        }
+       }
+      },
+      "Memory": 3500,
+      "Name": "runner"
+     }
+    ],
+    "ExecutionRoleArn": {
+     "Fn::GetAtt": [
+      "ECSWindowstaskExecutionRoleF164B5BF",
+      "Arn"
+     ]
+    },
+    "Family": "githubrunnerstestECSWindowstask6B1D5861",
+    "NetworkMode": "bridge",
+    "RequiresCompatibilities": [
+     "EC2"
+    ],
+    "TaskRoleArn": {
+     "Fn::GetAtt": [
+      "ECSWindowstaskTaskRole17C8DA48",
+      "Arn"
+     ]
+    }
+   }
+  },
+  "ECSWindowstaskExecutionRoleF164B5BF": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    }
+   }
+  },
+  "ECSWindowstaskExecutionRoleDefaultPolicyA46C9687": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage"
+       ],
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::Join": [
+         "",
+         [
+          "arn:",
+          {
+           "Ref": "AWS::Partition"
+          },
+          ":ecr:",
+          {
+           "Ref": "AWS::Region"
+          },
+          ":",
+          {
+           "Ref": "AWS::AccountId"
+          },
+          ":repository/",
+          {
+           "Fn::Select": [
+            0,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Fn::Select": [
+                1,
+                {
+                 "Fn::Split": [
+                  "/",
+                  {
+                   "Fn::GetAtt": [
+                    "WindowsImageBuilderDockerImage8672CA3E",
+                    "ImageUri"
+                   ]
+                  }
+                 ]
+                }
+               ]
+              }
+             ]
+            }
+           ]
+          }
+         ]
+        ]
+       }
+      },
+      {
+       "Action": "ecr:GetAuthorizationToken",
+       "Effect": "Allow",
+       "Resource": "*"
+      },
+      {
+       "Action": [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+       ],
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::GetAtt": [
+         "ECSWindowslogs83D9D352",
+         "Arn"
+        ]
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "ECSWindowstaskExecutionRoleDefaultPolicyA46C9687",
+    "Roles": [
+     {
+      "Ref": "ECSWindowstaskExecutionRoleF164B5BF"
+     }
+    ]
+   }
+  },
   "LambdaImageDigestReaderE0842577": {
    "Type": "Custom::EcrImageDigest",
    "Properties": {
@@ -12098,6 +13792,441 @@
        }
       },
       {
+       "Action": "ecs:RunTask",
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::Join": [
+         "",
+         [
+          "arn:",
+          {
+           "Fn::Select": [
+            1,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Ref": "ECStask8F0DD550"
+              }
+             ]
+            }
+           ]
+          },
+          ":",
+          {
+           "Fn::Select": [
+            2,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Ref": "ECStask8F0DD550"
+              }
+             ]
+            }
+           ]
+          },
+          ":",
+          {
+           "Fn::Select": [
+            3,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Ref": "ECStask8F0DD550"
+              }
+             ]
+            }
+           ]
+          },
+          ":",
+          {
+           "Fn::Select": [
+            4,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Ref": "ECStask8F0DD550"
+              }
+             ]
+            }
+           ]
+          },
+          ":",
+          {
+           "Fn::Select": [
+            0,
+            {
+             "Fn::Split": [
+              "/",
+              {
+               "Fn::Select": [
+                5,
+                {
+                 "Fn::Split": [
+                  ":",
+                  {
+                   "Ref": "ECStask8F0DD550"
+                  }
+                 ]
+                }
+               ]
+              }
+             ]
+            }
+           ]
+          },
+          "/",
+          {
+           "Fn::Select": [
+            1,
+            {
+             "Fn::Split": [
+              "/",
+              {
+               "Fn::Select": [
+                5,
+                {
+                 "Fn::Split": [
+                  ":",
+                  {
+                   "Ref": "ECStask8F0DD550"
+                  }
+                 ]
+                }
+               ]
+              }
+             ]
+            }
+           ]
+          }
+         ]
+        ]
+       }
+      },
+      {
+       "Action": [
+        "ecs:StopTask",
+        "ecs:DescribeTasks"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
+      },
+      {
+       "Action": "iam:PassRole",
+       "Effect": "Allow",
+       "Resource": [
+        {
+         "Fn::GetAtt": [
+          "ECStaskTaskRoleFE831ECD",
+          "Arn"
+         ]
+        },
+        {
+         "Fn::GetAtt": [
+          "ECStaskExecutionRole1A6D19A5",
+          "Arn"
+         ]
+        }
+       ]
+      },
+      {
+       "Action": [
+        "events:PutTargets",
+        "events:PutRule",
+        "events:DescribeRule"
+       ],
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::Join": [
+         "",
+         [
+          "arn:",
+          {
+           "Ref": "AWS::Partition"
+          },
+          ":events:",
+          {
+           "Ref": "AWS::Region"
+          },
+          ":",
+          {
+           "Ref": "AWS::AccountId"
+          },
+          ":rule/StepFunctionsGetEventsForECSTaskRule"
+         ]
+        ]
+       }
+      },
+      {
+       "Action": "ecs:RunTask",
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::Join": [
+         "",
+         [
+          "arn:",
+          {
+           "Fn::Select": [
+            1,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Ref": "ECSARM64task27EB8443"
+              }
+             ]
+            }
+           ]
+          },
+          ":",
+          {
+           "Fn::Select": [
+            2,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Ref": "ECSARM64task27EB8443"
+              }
+             ]
+            }
+           ]
+          },
+          ":",
+          {
+           "Fn::Select": [
+            3,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Ref": "ECSARM64task27EB8443"
+              }
+             ]
+            }
+           ]
+          },
+          ":",
+          {
+           "Fn::Select": [
+            4,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Ref": "ECSARM64task27EB8443"
+              }
+             ]
+            }
+           ]
+          },
+          ":",
+          {
+           "Fn::Select": [
+            0,
+            {
+             "Fn::Split": [
+              "/",
+              {
+               "Fn::Select": [
+                5,
+                {
+                 "Fn::Split": [
+                  ":",
+                  {
+                   "Ref": "ECSARM64task27EB8443"
+                  }
+                 ]
+                }
+               ]
+              }
+             ]
+            }
+           ]
+          },
+          "/",
+          {
+           "Fn::Select": [
+            1,
+            {
+             "Fn::Split": [
+              "/",
+              {
+               "Fn::Select": [
+                5,
+                {
+                 "Fn::Split": [
+                  ":",
+                  {
+                   "Ref": "ECSARM64task27EB8443"
+                  }
+                 ]
+                }
+               ]
+              }
+             ]
+            }
+           ]
+          }
+         ]
+        ]
+       }
+      },
+      {
+       "Action": "iam:PassRole",
+       "Effect": "Allow",
+       "Resource": [
+        {
+         "Fn::GetAtt": [
+          "ECSARM64taskTaskRole23B1CB4E",
+          "Arn"
+         ]
+        },
+        {
+         "Fn::GetAtt": [
+          "ECSARM64taskExecutionRoleBF2AE76F",
+          "Arn"
+         ]
+        }
+       ]
+      },
+      {
+       "Action": "ecs:RunTask",
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::Join": [
+         "",
+         [
+          "arn:",
+          {
+           "Fn::Select": [
+            1,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Ref": "ECSWindowstask73A31B6C"
+              }
+             ]
+            }
+           ]
+          },
+          ":",
+          {
+           "Fn::Select": [
+            2,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Ref": "ECSWindowstask73A31B6C"
+              }
+             ]
+            }
+           ]
+          },
+          ":",
+          {
+           "Fn::Select": [
+            3,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Ref": "ECSWindowstask73A31B6C"
+              }
+             ]
+            }
+           ]
+          },
+          ":",
+          {
+           "Fn::Select": [
+            4,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Ref": "ECSWindowstask73A31B6C"
+              }
+             ]
+            }
+           ]
+          },
+          ":",
+          {
+           "Fn::Select": [
+            0,
+            {
+             "Fn::Split": [
+              "/",
+              {
+               "Fn::Select": [
+                5,
+                {
+                 "Fn::Split": [
+                  ":",
+                  {
+                   "Ref": "ECSWindowstask73A31B6C"
+                  }
+                 ]
+                }
+               ]
+              }
+             ]
+            }
+           ]
+          },
+          "/",
+          {
+           "Fn::Select": [
+            1,
+            {
+             "Fn::Split": [
+              "/",
+              {
+               "Fn::Select": [
+                5,
+                {
+                 "Fn::Split": [
+                  ":",
+                  {
+                   "Ref": "ECSWindowstask73A31B6C"
+                  }
+                 ]
+                }
+               ]
+              }
+             ]
+            }
+           ]
+          }
+         ]
+        ]
+       }
+      },
+      {
+       "Action": "iam:PassRole",
+       "Effect": "Allow",
+       "Resource": [
+        {
+         "Fn::GetAtt": [
+          "ECSWindowstaskTaskRole17C8DA48",
+          "Arn"
+         ]
+        },
+        {
+         "Fn::GetAtt": [
+          "ECSWindowstaskExecutionRoleF164B5BF",
+          "Arn"
+         ]
+        }
+       ]
+      },
+      {
        "Action": "lambda:InvokeFunction",
        "Effect": "Allow",
        "Resource": [
@@ -12265,14 +14394,6 @@
        }
       },
       {
-       "Action": [
-        "ecs:StopTask",
-        "ecs:DescribeTasks"
-       ],
-       "Effect": "Allow",
-       "Resource": "*"
-      },
-      {
        "Action": "iam:PassRole",
        "Effect": "Allow",
        "Resource": [
@@ -12289,34 +14410,6 @@
          ]
         }
        ]
-      },
-      {
-       "Action": [
-        "events:PutTargets",
-        "events:PutRule",
-        "events:DescribeRule"
-       ],
-       "Effect": "Allow",
-       "Resource": {
-        "Fn::Join": [
-         "",
-         [
-          "arn:",
-          {
-           "Ref": "AWS::Partition"
-          },
-          ":events:",
-          {
-           "Ref": "AWS::Region"
-          },
-          ":",
-          {
-           "Ref": "AWS::AccountId"
-          },
-          ":rule/StepFunctionsGetEventsForECSTaskRule"
-         ]
-        ]
-       }
       },
       {
        "Action": "ecs:RunTask",
@@ -12980,7 +15073,7 @@
          "Arn"
         ]
        },
-       "\"},\"Error Catcher\":{\"Type\":\"Parallel\",\"ResultPath\":\"$.result\",\"End\":true,\"Catch\":[{\"ErrorEquals\":[\"States.ALL\"],\"ResultPath\":\"$.error\",\"Next\":\"Delete Runner\"}],\"Branches\":[{\"StartAt\":\"Choose provider\",\"States\":{\"Choose provider\":{\"Type\":\"Choice\",\"Choices\":[{\"And\":[{\"Variable\":\"$.labels.codebuild-x64\",\"IsPresent\":true}],\"Next\":\"codebuild-x64\"},{\"And\":[{\"Variable\":\"$.labels.codebuild\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.arm64\",\"IsPresent\":true}],\"Next\":\"codebuild, linux, arm64\"},{\"And\":[{\"Variable\":\"$.labels.codebuild\",\"IsPresent\":true},{\"Variable\":\"$.labels.windows\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"codebuild, windows, x64\"},{\"And\":[{\"Variable\":\"$.labels.lambda\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"lambda, x64\"},{\"And\":[{\"Variable\":\"$.labels.lambda\",\"IsPresent\":true},{\"Variable\":\"$.labels.arm64\",\"IsPresent\":true}],\"Next\":\"lambda, arm64\"},{\"And\":[{\"Variable\":\"$.labels.fargate\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"fargate, linux, x64\"},{\"And\":[{\"Variable\":\"$.labels.fargate-spot\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"fargate-spot, linux, x64\"},{\"And\":[{\"Variable\":\"$.labels.fargate\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.arm64\",\"IsPresent\":true}],\"Next\":\"fargate, linux, arm64\"},{\"And\":[{\"Variable\":\"$.labels.fargate-spot\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.arm64\",\"IsPresent\":true}],\"Next\":\"fargate-spot, linux, arm64\"},{\"And\":[{\"Variable\":\"$.labels.fargate\",\"IsPresent\":true},{\"Variable\":\"$.labels.windows\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"fargate, windows, x64\"},{\"And\":[{\"Variable\":\"$.labels.ec2\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"ec2, linux, x64 data\"},{\"And\":[{\"Variable\":\"$.labels.ec2-spot\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"ec2-spot, linux, x64 data\"},{\"And\":[{\"Variable\":\"$.labels.ec2\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.arm64\",\"IsPresent\":true}],\"Next\":\"ec2, linux, arm64 data\"},{\"And\":[{\"Variable\":\"$.labels.ec2\",\"IsPresent\":true},{\"Variable\":\"$.labels.windows\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"ec2, windows, x64 data\"}],\"Default\":\"Unknown label\"},\"Unknown label\":{\"Type\":\"Succeed\"},\"codebuild-x64\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"CodeBuild.CodeBuildException\",\"CodeBuild.AccountLimitExceededException\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Type\":\"Task\",\"Resource\":\"arn:",
+       "\"},\"Error Catcher\":{\"Type\":\"Parallel\",\"ResultPath\":\"$.result\",\"End\":true,\"Catch\":[{\"ErrorEquals\":[\"States.ALL\"],\"ResultPath\":\"$.error\",\"Next\":\"Delete Runner\"}],\"Branches\":[{\"StartAt\":\"Choose provider\",\"States\":{\"Choose provider\":{\"Type\":\"Choice\",\"Choices\":[{\"And\":[{\"Variable\":\"$.labels.codebuild-x64\",\"IsPresent\":true}],\"Next\":\"codebuild-x64\"},{\"And\":[{\"Variable\":\"$.labels.codebuild\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.arm64\",\"IsPresent\":true}],\"Next\":\"codebuild, linux, arm64\"},{\"And\":[{\"Variable\":\"$.labels.codebuild\",\"IsPresent\":true},{\"Variable\":\"$.labels.windows\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"codebuild, windows, x64\"},{\"And\":[{\"Variable\":\"$.labels.ecs\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"ecs, linux, x64\"},{\"And\":[{\"Variable\":\"$.labels.ecs\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.arm64\",\"IsPresent\":true}],\"Next\":\"ecs, linux, arm64\"},{\"And\":[{\"Variable\":\"$.labels.ecs\",\"IsPresent\":true},{\"Variable\":\"$.labels.windows\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"ecs, windows, x64\"},{\"And\":[{\"Variable\":\"$.labels.lambda\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"lambda, x64\"},{\"And\":[{\"Variable\":\"$.labels.lambda\",\"IsPresent\":true},{\"Variable\":\"$.labels.arm64\",\"IsPresent\":true}],\"Next\":\"lambda, arm64\"},{\"And\":[{\"Variable\":\"$.labels.fargate\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"fargate, linux, x64\"},{\"And\":[{\"Variable\":\"$.labels.fargate-spot\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"fargate-spot, linux, x64\"},{\"And\":[{\"Variable\":\"$.labels.fargate\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.arm64\",\"IsPresent\":true}],\"Next\":\"fargate, linux, arm64\"},{\"And\":[{\"Variable\":\"$.labels.fargate-spot\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.arm64\",\"IsPresent\":true}],\"Next\":\"fargate-spot, linux, arm64\"},{\"And\":[{\"Variable\":\"$.labels.fargate\",\"IsPresent\":true},{\"Variable\":\"$.labels.windows\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"fargate, windows, x64\"},{\"And\":[{\"Variable\":\"$.labels.ec2\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"ec2, linux, x64 data\"},{\"And\":[{\"Variable\":\"$.labels.ec2-spot\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"ec2-spot, linux, x64 data\"},{\"And\":[{\"Variable\":\"$.labels.ec2\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.arm64\",\"IsPresent\":true}],\"Next\":\"ec2, linux, arm64 data\"},{\"And\":[{\"Variable\":\"$.labels.ec2\",\"IsPresent\":true},{\"Variable\":\"$.labels.windows\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"ec2, windows, x64 data\"}],\"Default\":\"Unknown label\"},\"Unknown label\":{\"Type\":\"Succeed\"},\"codebuild-x64\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"CodeBuild.CodeBuildException\",\"CodeBuild.AccountLimitExceededException\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Type\":\"Task\",\"Resource\":\"arn:",
        {
         "Ref": "AWS::Partition"
        },
@@ -13004,7 +15097,52 @@
        {
         "Ref": "CodeBuildWindowsCodeBuildC39F35C1"
        },
-       "\",\"EnvironmentVariablesOverride\":[{\"Name\":\"RUNNER_TOKEN\",\"Type\":\"PLAINTEXT\",\"Value.$\":\"$.runner.token\"},{\"Name\":\"RUNNER_NAME\",\"Type\":\"PLAINTEXT\",\"Value.$\":\"$$.Execution.Name\"},{\"Name\":\"RUNNER_LABEL\",\"Type\":\"PLAINTEXT\",\"Value\":\"codebuild,windows,x64\"},{\"Name\":\"GITHUB_DOMAIN\",\"Type\":\"PLAINTEXT\",\"Value.$\":\"$.runner.domain\"},{\"Name\":\"OWNER\",\"Type\":\"PLAINTEXT\",\"Value.$\":\"$.owner\"},{\"Name\":\"REPO\",\"Type\":\"PLAINTEXT\",\"Value.$\":\"$.repo\"}]}},\"lambda, x64\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2},{\"ErrorEquals\":[\"Lambda.LambdaException\",\"Lambda.Ec2ThrottledException\",\"Lambda.Ec2UnexpectedException\",\"Lambda.EniLimitReachedException\",\"Lambda.TooManyRequestsException\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Type\":\"Task\",\"Resource\":\"arn:",
+       "\",\"EnvironmentVariablesOverride\":[{\"Name\":\"RUNNER_TOKEN\",\"Type\":\"PLAINTEXT\",\"Value.$\":\"$.runner.token\"},{\"Name\":\"RUNNER_NAME\",\"Type\":\"PLAINTEXT\",\"Value.$\":\"$$.Execution.Name\"},{\"Name\":\"RUNNER_LABEL\",\"Type\":\"PLAINTEXT\",\"Value\":\"codebuild,windows,x64\"},{\"Name\":\"GITHUB_DOMAIN\",\"Type\":\"PLAINTEXT\",\"Value.$\":\"$.runner.domain\"},{\"Name\":\"OWNER\",\"Type\":\"PLAINTEXT\",\"Value.$\":\"$.owner\"},{\"Name\":\"REPO\",\"Type\":\"PLAINTEXT\",\"Value.$\":\"$.repo\"}]}},\"ecs, linux, x64\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Ecs.EcsException\",\"Ecs.LimitExceededException\",\"Ecs.UpdateInProgressException\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Type\":\"Task\",\"Resource\":\"arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":states:::ecs:runTask.sync\",\"Parameters\":{\"Cluster\":\"",
+       {
+        "Fn::GetAtt": [
+         "ECScluster20BC0B82",
+         "Arn"
+        ]
+       },
+       "\",\"TaskDefinition\":\"githubrunnerstestECStaskCE74CC84\",\"Overrides\":{\"ContainerOverrides\":[{\"Name\":\"runner\",\"Environment\":[{\"Name\":\"RUNNER_TOKEN\",\"Value.$\":\"$.runner.token\"},{\"Name\":\"RUNNER_NAME\",\"Value.$\":\"$$.Execution.Name\"},{\"Name\":\"RUNNER_LABEL\",\"Value\":\"ecs,linux,x64\"},{\"Name\":\"GITHUB_DOMAIN\",\"Value.$\":\"$.runner.domain\"},{\"Name\":\"OWNER\",\"Value.$\":\"$.owner\"},{\"Name\":\"REPO\",\"Value.$\":\"$.repo\"}]}]},\"PropagateTags\":\"TASK_DEFINITION\",\"CapacityProviderStrategy\":[{\"CapacityProvider\":\"",
+       {
+        "Ref": "ECSCapacityProviderABF1B146"
+       },
+       "\"}]}},\"ecs, linux, arm64\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Ecs.EcsException\",\"Ecs.LimitExceededException\",\"Ecs.UpdateInProgressException\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Type\":\"Task\",\"Resource\":\"arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":states:::ecs:runTask.sync\",\"Parameters\":{\"Cluster\":\"",
+       {
+        "Fn::GetAtt": [
+         "ECSARM64cluster4ECAA083",
+         "Arn"
+        ]
+       },
+       "\",\"TaskDefinition\":\"githubrunnerstestECSARM64taskE94E43A3\",\"Overrides\":{\"ContainerOverrides\":[{\"Name\":\"runner\",\"Environment\":[{\"Name\":\"RUNNER_TOKEN\",\"Value.$\":\"$.runner.token\"},{\"Name\":\"RUNNER_NAME\",\"Value.$\":\"$$.Execution.Name\"},{\"Name\":\"RUNNER_LABEL\",\"Value\":\"ecs,linux,arm64\"},{\"Name\":\"GITHUB_DOMAIN\",\"Value.$\":\"$.runner.domain\"},{\"Name\":\"OWNER\",\"Value.$\":\"$.owner\"},{\"Name\":\"REPO\",\"Value.$\":\"$.repo\"}]}]},\"PropagateTags\":\"TASK_DEFINITION\",\"CapacityProviderStrategy\":[{\"CapacityProvider\":\"",
+       {
+        "Ref": "ECSARM64CapacityProvider8627FEF9"
+       },
+       "\"}]}},\"ecs, windows, x64\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Ecs.EcsException\",\"Ecs.LimitExceededException\",\"Ecs.UpdateInProgressException\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Type\":\"Task\",\"Resource\":\"arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":states:::ecs:runTask.sync\",\"Parameters\":{\"Cluster\":\"",
+       {
+        "Fn::GetAtt": [
+         "ECSWindowscluster14061F74",
+         "Arn"
+        ]
+       },
+       "\",\"TaskDefinition\":\"githubrunnerstestECSWindowstask6B1D5861\",\"Overrides\":{\"ContainerOverrides\":[{\"Name\":\"runner\",\"Environment\":[{\"Name\":\"RUNNER_TOKEN\",\"Value.$\":\"$.runner.token\"},{\"Name\":\"RUNNER_NAME\",\"Value.$\":\"$$.Execution.Name\"},{\"Name\":\"RUNNER_LABEL\",\"Value\":\"ecs,windows,x64\"},{\"Name\":\"GITHUB_DOMAIN\",\"Value.$\":\"$.runner.domain\"},{\"Name\":\"OWNER\",\"Value.$\":\"$.owner\"},{\"Name\":\"REPO\",\"Value.$\":\"$.repo\"}]}]},\"PropagateTags\":\"TASK_DEFINITION\",\"CapacityProviderStrategy\":[{\"CapacityProvider\":\"",
+       {
+        "Ref": "ECSWindowsCapacityProvider8F8896A5"
+       },
+       "\"}]}},\"lambda, x64\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2},{\"ErrorEquals\":[\"Lambda.LambdaException\",\"Lambda.Ec2ThrottledException\",\"Lambda.Ec2UnexpectedException\",\"Lambda.EniLimitReachedException\",\"Lambda.TooManyRequestsException\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Type\":\"Task\",\"Resource\":\"arn:",
        {
         "Ref": "AWS::Partition"
        },
@@ -14335,6 +16473,303 @@
       }
      },
      {
+      "type": "EcsRunnerProvider",
+      "labels": [
+       "ecs",
+       "linux",
+       "x64"
+      ],
+      "vpcArn": {
+       "Fn::Join": [
+        "",
+        [
+         "arn:",
+         {
+          "Ref": "AWS::Partition"
+         },
+         ":ec2:",
+         {
+          "Ref": "AWS::Region"
+         },
+         ":",
+         {
+          "Ref": "AWS::AccountId"
+         },
+         ":vpc/",
+         {
+          "Ref": "Vpc8378EB38"
+         }
+        ]
+       ]
+      },
+      "securityGroups": [
+       {
+        "Fn::GetAtt": [
+         "ECSsecuritygroup76605212",
+         "GroupId"
+        ]
+       }
+      ],
+      "roleArn": {
+       "Fn::GetAtt": [
+        "ECStaskTaskRoleFE831ECD",
+        "Arn"
+       ]
+      },
+      "logGroup": {
+       "Ref": "ECSlogs71446134"
+      },
+      "image": {
+       "imageRepository": {
+        "Fn::Join": [
+         "",
+         [
+          {
+           "Fn::Select": [
+            4,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Ref": "CodeBuildImageBuilderB8638EC8"
+              }
+             ]
+            }
+           ]
+          },
+          ".dkr.ecr.",
+          {
+           "Fn::Select": [
+            3,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Ref": "CodeBuildImageBuilderB8638EC8"
+              }
+             ]
+            }
+           ]
+          },
+          ".",
+          {
+           "Ref": "AWS::URLSuffix"
+          },
+          "/",
+          {
+           "Fn::GetAtt": [
+            "CodeBuildImageBuilderB8638EC8",
+            "Name"
+           ]
+          }
+         ]
+        ]
+       },
+       "imageTag": "latest",
+       "imageBuilderLogGroup": {
+        "Ref": "CodeBuildImageBuilderLogsE4CADFCC"
+       }
+      }
+     },
+     {
+      "type": "EcsRunnerProvider",
+      "labels": [
+       "ecs",
+       "linux",
+       "arm64"
+      ],
+      "vpcArn": {
+       "Fn::Join": [
+        "",
+        [
+         "arn:",
+         {
+          "Ref": "AWS::Partition"
+         },
+         ":ec2:",
+         {
+          "Ref": "AWS::Region"
+         },
+         ":",
+         {
+          "Ref": "AWS::AccountId"
+         },
+         ":vpc/",
+         {
+          "Ref": "Vpc8378EB38"
+         }
+        ]
+       ]
+      },
+      "securityGroups": [
+       {
+        "Fn::GetAtt": [
+         "ECSARM64securitygroup281D94B2",
+         "GroupId"
+        ]
+       }
+      ],
+      "roleArn": {
+       "Fn::GetAtt": [
+        "ECSARM64taskTaskRole23B1CB4E",
+        "Arn"
+       ]
+      },
+      "logGroup": {
+       "Ref": "ECSARM64logs1A2F1E00"
+      },
+      "image": {
+       "imageRepository": {
+        "Fn::Join": [
+         "",
+         [
+          {
+           "Fn::Select": [
+            4,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Ref": "CodeBuildImageBuilderarmBuilder755EB37D"
+              }
+             ]
+            }
+           ]
+          },
+          ".dkr.ecr.",
+          {
+           "Fn::Select": [
+            3,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Ref": "CodeBuildImageBuilderarmBuilder755EB37D"
+              }
+             ]
+            }
+           ]
+          },
+          ".",
+          {
+           "Ref": "AWS::URLSuffix"
+          },
+          "/",
+          {
+           "Fn::GetAtt": [
+            "CodeBuildImageBuilderarmBuilder755EB37D",
+            "Name"
+           ]
+          }
+         ]
+        ]
+       },
+       "imageTag": "latest",
+       "imageBuilderLogGroup": {
+        "Ref": "CodeBuildImageBuilderarmLogs5A60CB81"
+       }
+      }
+     },
+     {
+      "type": "EcsRunnerProvider",
+      "labels": [
+       "ecs",
+       "windows",
+       "x64"
+      ],
+      "vpcArn": {
+       "Fn::Join": [
+        "",
+        [
+         "arn:",
+         {
+          "Ref": "AWS::Partition"
+         },
+         ":ec2:",
+         {
+          "Ref": "AWS::Region"
+         },
+         ":",
+         {
+          "Ref": "AWS::AccountId"
+         },
+         ":vpc/",
+         {
+          "Ref": "Vpc8378EB38"
+         }
+        ]
+       ]
+      },
+      "securityGroups": [
+       {
+        "Fn::GetAtt": [
+         "ECSWindowssecuritygroupB4EE54DA",
+         "GroupId"
+        ]
+       }
+      ],
+      "roleArn": {
+       "Fn::GetAtt": [
+        "ECSWindowstaskTaskRole17C8DA48",
+        "Arn"
+       ]
+      },
+      "logGroup": {
+       "Ref": "ECSWindowslogs83D9D352"
+      },
+      "image": {
+       "imageRepository": {
+        "Fn::Join": [
+         "",
+         [
+          {
+           "Ref": "AWS::AccountId"
+          },
+          ".dkr.ecr.",
+          {
+           "Ref": "AWS::Region"
+          },
+          ".",
+          {
+           "Ref": "AWS::URLSuffix"
+          },
+          "/",
+          {
+           "Fn::Select": [
+            0,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Fn::Select": [
+                1,
+                {
+                 "Fn::Split": [
+                  "/",
+                  {
+                   "Fn::GetAtt": [
+                    "WindowsImageBuilderDockerImage8672CA3E",
+                    "ImageUri"
+                   ]
+                  }
+                 ]
+                }
+               ]
+              }
+             ]
+            }
+           ]
+          }
+         ]
+        ]
+       },
+       "imageTag": "latest",
+       "imageBuilderLogGroup": {
+        "Ref": "WindowsImageBuilderDockerLogE660E23E"
+       }
+      }
+     },
+     {
       "type": "LambdaRunnerProvider",
       "labels": [
        "lambda",
@@ -15140,6 +17575,18 @@
   "SsmParameterValueawsservicecanonicalubuntuserverfocalstablecurrentarm64hvmebsgp2amiidC96584B6F00A464EAD1953AFF4B05118Parameter": {
    "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
    "Default": "/aws/service/canonical/ubuntu/server/focal/stable/current/arm64/hvm/ebs-gp2/ami-id"
+  },
+  "SsmParameterValueawsserviceecsoptimizedamiamazonlinux2recommendedimageidC96584B6F00A464EAD1953AFF4B05118Parameter": {
+   "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
+   "Default": "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id"
+  },
+  "SsmParameterValueawsserviceecsoptimizedamiamazonlinux2arm64recommendedimageidC96584B6F00A464EAD1953AFF4B05118Parameter": {
+   "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
+   "Default": "/aws/service/ecs/optimized-ami/amazon-linux-2/arm64/recommended/image_id"
+  },
+  "SsmParameterValueawsserviceecsoptimizedamiwindowsserver2019englishfullrecommendedimageidC96584B6F00A464EAD1953AFF4B05118Parameter": {
+   "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
+   "Default": "/aws/service/ecs/optimized-ami/windows_server/2019/english/full/recommended/image_id"
   },
   "BootstrapVersion": {
    "Type": "AWS::SSM::Parameter::Value<String>",

--- a/test/default.integ.snapshot/manifest.json
+++ b/test/default.integ.snapshot/manifest.json
@@ -23,7 +23,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/84e2ff4297b23e3e6424bc089be97d55ed8b808a8c163f687a1313ffe1303781.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/4d1b7dc9601c9e6b463cbbe4b0c5a7b0f32c382075796248d49a12aaa2091eef.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [
@@ -1411,6 +1411,312 @@
           {
             "type": "aws:cdk:logicalId",
             "data": "awsimagebuilderversionerdcc036c8876b451ea2c1552f9e06e9e1LogRetentionA8337CBD"
+          }
+        ],
+        "/github-runners-test/ECS/security group/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSsecuritygroup76605212"
+          }
+        ],
+        "/github-runners-test/ECS/cluster/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECScluster20BC0B82"
+          }
+        ],
+        "/github-runners-test/ECS/cluster/cluster": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECScluster9E223943"
+          }
+        ],
+        "/github-runners-test/ECS/Auto Scaling Group/InstanceSecurityGroup/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSAutoScalingGroupInstanceSecurityGroup87D56BFE"
+          }
+        ],
+        "/github-runners-test/ECS/Auto Scaling Group/InstanceRole/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSAutoScalingGroupInstanceRoleCA234A7C"
+          }
+        ],
+        "/github-runners-test/ECS/Auto Scaling Group/InstanceRole/DefaultPolicy/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSAutoScalingGroupInstanceRoleDefaultPolicy86A5959D"
+          }
+        ],
+        "/github-runners-test/ECS/Auto Scaling Group/InstanceProfile": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSAutoScalingGroupInstanceProfile288AC654"
+          }
+        ],
+        "/github-runners-test/ECS/Auto Scaling Group/LaunchConfig": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSAutoScalingGroupLaunchConfigC22C3413"
+          }
+        ],
+        "/github-runners-test/ECS/Auto Scaling Group/ASG": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSAutoScalingGroupASG88763D9A"
+          }
+        ],
+        "/github-runners-test/ECS/Capacity Provider/Capacity Provider": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSCapacityProviderABF1B146"
+          }
+        ],
+        "/github-runners-test/ECS/logs/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSlogs71446134"
+          }
+        ],
+        "/github-runners-test/ECS/logs/logs filter/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSlogslogsfilterC744F425"
+          }
+        ],
+        "/github-runners-test/ECS/task/TaskRole/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECStaskTaskRoleFE831ECD"
+          }
+        ],
+        "/github-runners-test/ECS/task/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECStask8F0DD550"
+          }
+        ],
+        "/github-runners-test/ECS/task/ExecutionRole/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECStaskExecutionRole1A6D19A5"
+          }
+        ],
+        "/github-runners-test/ECS/task/ExecutionRole/DefaultPolicy/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECStaskExecutionRoleDefaultPolicy564C1271"
+          }
+        ],
+        "/github-runners-test/SsmParameterValue:--aws--service--ecs--optimized-ami--amazon-linux-2--recommended--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118.Parameter": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "SsmParameterValueawsserviceecsoptimizedamiamazonlinux2recommendedimageidC96584B6F00A464EAD1953AFF4B05118Parameter"
+          }
+        ],
+        "/github-runners-test/ECS ARM64/security group/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSARM64securitygroup281D94B2"
+          }
+        ],
+        "/github-runners-test/ECS ARM64/cluster/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSARM64cluster4ECAA083"
+          }
+        ],
+        "/github-runners-test/ECS ARM64/cluster/cluster": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSARM64cluster43E75409"
+          }
+        ],
+        "/github-runners-test/ECS ARM64/Auto Scaling Group/InstanceSecurityGroup/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSARM64AutoScalingGroupInstanceSecurityGroupB68B781E"
+          }
+        ],
+        "/github-runners-test/ECS ARM64/Auto Scaling Group/InstanceRole/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSARM64AutoScalingGroupInstanceRole01030665"
+          }
+        ],
+        "/github-runners-test/ECS ARM64/Auto Scaling Group/InstanceRole/DefaultPolicy/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSARM64AutoScalingGroupInstanceRoleDefaultPolicyD0E29275"
+          }
+        ],
+        "/github-runners-test/ECS ARM64/Auto Scaling Group/InstanceProfile": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSARM64AutoScalingGroupInstanceProfile768645E6"
+          }
+        ],
+        "/github-runners-test/ECS ARM64/Auto Scaling Group/LaunchConfig": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSARM64AutoScalingGroupLaunchConfig9B8B62ED"
+          }
+        ],
+        "/github-runners-test/ECS ARM64/Auto Scaling Group/ASG": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSARM64AutoScalingGroupASGA19FC118"
+          }
+        ],
+        "/github-runners-test/ECS ARM64/Capacity Provider/Capacity Provider": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSARM64CapacityProvider8627FEF9"
+          }
+        ],
+        "/github-runners-test/ECS ARM64/logs/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSARM64logs1A2F1E00"
+          }
+        ],
+        "/github-runners-test/ECS ARM64/logs/logs filter/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSARM64logslogsfilter6914CFA1"
+          }
+        ],
+        "/github-runners-test/ECS ARM64/task/TaskRole/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSARM64taskTaskRole23B1CB4E"
+          }
+        ],
+        "/github-runners-test/ECS ARM64/task/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSARM64task27EB8443"
+          }
+        ],
+        "/github-runners-test/ECS ARM64/task/ExecutionRole/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSARM64taskExecutionRoleBF2AE76F"
+          }
+        ],
+        "/github-runners-test/ECS ARM64/task/ExecutionRole/DefaultPolicy/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSARM64taskExecutionRoleDefaultPolicy17294239"
+          }
+        ],
+        "/github-runners-test/SsmParameterValue:--aws--service--ecs--optimized-ami--amazon-linux-2--arm64--recommended--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118.Parameter": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "SsmParameterValueawsserviceecsoptimizedamiamazonlinux2arm64recommendedimageidC96584B6F00A464EAD1953AFF4B05118Parameter"
+          }
+        ],
+        "/github-runners-test/ECS Windows/security group/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSWindowssecuritygroupB4EE54DA"
+          }
+        ],
+        "/github-runners-test/ECS Windows/cluster/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSWindowscluster14061F74"
+          }
+        ],
+        "/github-runners-test/ECS Windows/cluster/cluster": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSWindowscluster49B54894"
+          }
+        ],
+        "/github-runners-test/ECS Windows/Auto Scaling Group/InstanceSecurityGroup/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSWindowsAutoScalingGroupInstanceSecurityGroupA3DBA17A"
+          }
+        ],
+        "/github-runners-test/ECS Windows/Auto Scaling Group/InstanceRole/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSWindowsAutoScalingGroupInstanceRoleFB287046"
+          }
+        ],
+        "/github-runners-test/ECS Windows/Auto Scaling Group/InstanceRole/DefaultPolicy/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSWindowsAutoScalingGroupInstanceRoleDefaultPolicyAEE83B95"
+          }
+        ],
+        "/github-runners-test/ECS Windows/Auto Scaling Group/InstanceProfile": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSWindowsAutoScalingGroupInstanceProfileD8019407"
+          }
+        ],
+        "/github-runners-test/ECS Windows/Auto Scaling Group/LaunchConfig": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSWindowsAutoScalingGroupLaunchConfigAD09CF33"
+          }
+        ],
+        "/github-runners-test/ECS Windows/Auto Scaling Group/ASG": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSWindowsAutoScalingGroupASG864E3AAF"
+          }
+        ],
+        "/github-runners-test/ECS Windows/Capacity Provider/Capacity Provider": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSWindowsCapacityProvider8F8896A5"
+          }
+        ],
+        "/github-runners-test/ECS Windows/logs/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSWindowslogs83D9D352"
+          }
+        ],
+        "/github-runners-test/ECS Windows/logs/logs filter/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSWindowslogslogsfilterA25F0C55"
+          }
+        ],
+        "/github-runners-test/ECS Windows/task/TaskRole/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSWindowstaskTaskRole17C8DA48"
+          }
+        ],
+        "/github-runners-test/ECS Windows/task/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSWindowstask73A31B6C"
+          }
+        ],
+        "/github-runners-test/ECS Windows/task/ExecutionRole/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSWindowstaskExecutionRoleF164B5BF"
+          }
+        ],
+        "/github-runners-test/ECS Windows/task/ExecutionRole/DefaultPolicy/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ECSWindowstaskExecutionRoleDefaultPolicyA46C9687"
+          }
+        ],
+        "/github-runners-test/SsmParameterValue:--aws--service--ecs--optimized-ami--windows_server--2019--english--full--recommended--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118.Parameter": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "SsmParameterValueawsserviceecsoptimizedamiwindowsserver2019englishfullrecommendedimageidC96584B6F00A464EAD1953AFF4B05118Parameter"
           }
         ],
         "/github-runners-test/Lambda/Image Digest Reader/Resource/Default": [

--- a/test/default.integ.snapshot/tree.json
+++ b/test/default.integ.snapshot/tree.json
@@ -10823,6 +10823,2567 @@
               "version": "2.50.0"
             }
           },
+          "ECS": {
+            "id": "ECS",
+            "path": "github-runners-test/ECS",
+            "children": {
+              "security group": {
+                "id": "security group",
+                "path": "github-runners-test/ECS/security group",
+                "children": {
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "github-runners-test/ECS/security group/Resource",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::EC2::SecurityGroup",
+                      "aws:cdk:cloudformation:props": {
+                        "groupDescription": "github-runners-test/ECS/security group",
+                        "securityGroupEgress": [
+                          {
+                            "cidrIp": "0.0.0.0/0",
+                            "description": "Allow all outbound traffic by default",
+                            "ipProtocol": "-1"
+                          }
+                        ],
+                        "vpcId": {
+                          "Ref": "Vpc8378EB38"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_ec2.CfnSecurityGroup",
+                      "version": "2.50.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_ec2.SecurityGroup",
+                  "version": "2.50.0"
+                }
+              },
+              "cluster": {
+                "id": "cluster",
+                "path": "github-runners-test/ECS/cluster",
+                "children": {
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "github-runners-test/ECS/cluster/Resource",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::ECS::Cluster",
+                      "aws:cdk:cloudformation:props": {}
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_ecs.CfnCluster",
+                      "version": "2.50.0"
+                    }
+                  },
+                  "cluster": {
+                    "id": "cluster",
+                    "path": "github-runners-test/ECS/cluster/cluster",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::ECS::ClusterCapacityProviderAssociations",
+                      "aws:cdk:cloudformation:props": {
+                        "capacityProviders": [
+                          {
+                            "Ref": "ECSCapacityProviderABF1B146"
+                          }
+                        ],
+                        "cluster": {
+                          "Ref": "ECScluster20BC0B82"
+                        },
+                        "defaultCapacityProviderStrategy": []
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_ecs.CfnClusterCapacityProviderAssociations",
+                      "version": "2.50.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_ecs.Cluster",
+                  "version": "2.50.0"
+                }
+              },
+              "Auto Scaling Group": {
+                "id": "Auto Scaling Group",
+                "path": "github-runners-test/ECS/Auto Scaling Group",
+                "children": {
+                  "InstanceSecurityGroup": {
+                    "id": "InstanceSecurityGroup",
+                    "path": "github-runners-test/ECS/Auto Scaling Group/InstanceSecurityGroup",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "github-runners-test/ECS/Auto Scaling Group/InstanceSecurityGroup/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::EC2::SecurityGroup",
+                          "aws:cdk:cloudformation:props": {
+                            "groupDescription": "github-runners-test/ECS/Auto Scaling Group/InstanceSecurityGroup",
+                            "securityGroupEgress": [
+                              {
+                                "cidrIp": "0.0.0.0/0",
+                                "description": "Allow all outbound traffic by default",
+                                "ipProtocol": "-1"
+                              }
+                            ],
+                            "tags": [
+                              {
+                                "key": "Name",
+                                "value": "github-runners-test/ECS/Auto Scaling Group"
+                              }
+                            ],
+                            "vpcId": {
+                              "Ref": "Vpc8378EB38"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_ec2.CfnSecurityGroup",
+                          "version": "2.50.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_ec2.SecurityGroup",
+                      "version": "2.50.0"
+                    }
+                  },
+                  "InstanceRole": {
+                    "id": "InstanceRole",
+                    "path": "github-runners-test/ECS/Auto Scaling Group/InstanceRole",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "github-runners-test/ECS/Auto Scaling Group/InstanceRole/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::IAM::Role",
+                          "aws:cdk:cloudformation:props": {
+                            "assumeRolePolicyDocument": {
+                              "Statement": [
+                                {
+                                  "Action": "sts:AssumeRole",
+                                  "Effect": "Allow",
+                                  "Principal": {
+                                    "Service": {
+                                      "Fn::Join": [
+                                        "",
+                                        [
+                                          "ec2.",
+                                          {
+                                            "Ref": "AWS::URLSuffix"
+                                          }
+                                        ]
+                                      ]
+                                    }
+                                  }
+                                }
+                              ],
+                              "Version": "2012-10-17"
+                            },
+                            "managedPolicyArns": [
+                              {
+                                "Fn::Join": [
+                                  "",
+                                  [
+                                    "arn:",
+                                    {
+                                      "Ref": "AWS::Partition"
+                                    },
+                                    ":iam::aws:policy/AmazonSSMManagedInstanceCore"
+                                  ]
+                                ]
+                              }
+                            ],
+                            "tags": [
+                              {
+                                "key": "Name",
+                                "value": "github-runners-test/ECS/Auto Scaling Group"
+                              }
+                            ]
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_iam.CfnRole",
+                          "version": "2.50.0"
+                        }
+                      },
+                      "DefaultPolicy": {
+                        "id": "DefaultPolicy",
+                        "path": "github-runners-test/ECS/Auto Scaling Group/InstanceRole/DefaultPolicy",
+                        "children": {
+                          "Resource": {
+                            "id": "Resource",
+                            "path": "github-runners-test/ECS/Auto Scaling Group/InstanceRole/DefaultPolicy/Resource",
+                            "attributes": {
+                              "aws:cdk:cloudformation:type": "AWS::IAM::Policy",
+                              "aws:cdk:cloudformation:props": {
+                                "policyDocument": {
+                                  "Statement": [
+                                    {
+                                      "Action": [
+                                        "ecr:BatchCheckLayerAvailability",
+                                        "ecr:GetDownloadUrlForLayer",
+                                        "ecr:BatchGetImage"
+                                      ],
+                                      "Effect": "Allow",
+                                      "Resource": {
+                                        "Ref": "CodeBuildImageBuilderB8638EC8"
+                                      }
+                                    },
+                                    {
+                                      "Action": "ecr:GetAuthorizationToken",
+                                      "Effect": "Allow",
+                                      "Resource": "*"
+                                    },
+                                    {
+                                      "Action": [
+                                        "ecs:DeregisterContainerInstance",
+                                        "ecs:RegisterContainerInstance",
+                                        "ecs:Submit*"
+                                      ],
+                                      "Effect": "Allow",
+                                      "Resource": {
+                                        "Fn::GetAtt": [
+                                          "ECScluster20BC0B82",
+                                          "Arn"
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "Action": [
+                                        "ecs:Poll",
+                                        "ecs:StartTelemetrySession"
+                                      ],
+                                      "Condition": {
+                                        "ArnEquals": {
+                                          "ecs:cluster": {
+                                            "Fn::GetAtt": [
+                                              "ECScluster20BC0B82",
+                                              "Arn"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "Effect": "Allow",
+                                      "Resource": "*"
+                                    },
+                                    {
+                                      "Action": [
+                                        "ecs:DiscoverPollEndpoint",
+                                        "ecr:GetAuthorizationToken",
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                      ],
+                                      "Effect": "Allow",
+                                      "Resource": "*"
+                                    }
+                                  ],
+                                  "Version": "2012-10-17"
+                                },
+                                "policyName": "ECSAutoScalingGroupInstanceRoleDefaultPolicy86A5959D",
+                                "roles": [
+                                  {
+                                    "Ref": "ECSAutoScalingGroupInstanceRoleCA234A7C"
+                                  }
+                                ]
+                              }
+                            },
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
+                              "version": "2.50.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_iam.Policy",
+                          "version": "2.50.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_iam.Role",
+                      "version": "2.50.0"
+                    }
+                  },
+                  "InstanceProfile": {
+                    "id": "InstanceProfile",
+                    "path": "github-runners-test/ECS/Auto Scaling Group/InstanceProfile",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::IAM::InstanceProfile",
+                      "aws:cdk:cloudformation:props": {
+                        "roles": [
+                          {
+                            "Ref": "ECSAutoScalingGroupInstanceRoleCA234A7C"
+                          }
+                        ]
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_iam.CfnInstanceProfile",
+                      "version": "2.50.0"
+                    }
+                  },
+                  "LaunchConfig": {
+                    "id": "LaunchConfig",
+                    "path": "github-runners-test/ECS/Auto Scaling Group/LaunchConfig",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::AutoScaling::LaunchConfiguration",
+                      "aws:cdk:cloudformation:props": {
+                        "imageId": {
+                          "Ref": "SsmParameterValueawsserviceecsoptimizedamiamazonlinux2recommendedimageidC96584B6F00A464EAD1953AFF4B05118Parameter"
+                        },
+                        "instanceType": "m5.large",
+                        "iamInstanceProfile": {
+                          "Ref": "ECSAutoScalingGroupInstanceProfile288AC654"
+                        },
+                        "securityGroups": [
+                          {
+                            "Fn::GetAtt": [
+                              "ECSAutoScalingGroupInstanceSecurityGroup87D56BFE",
+                              "GroupId"
+                            ]
+                          },
+                          {
+                            "Fn::GetAtt": [
+                              "ECSsecuritygroup76605212",
+                              "GroupId"
+                            ]
+                          }
+                        ],
+                        "userData": {
+                          "Fn::Base64": {
+                            "Fn::Join": [
+                              "",
+                              [
+                                "#!/bin/bash\naws ecr get-login-password --region ",
+                                {
+                                  "Ref": "AWS::Region"
+                                },
+                                " | docker login --username AWS --password-stdin ",
+                                {
+                                  "Ref": "AWS::AccountId"
+                                },
+                                ".dkr.ecr.",
+                                {
+                                  "Ref": "AWS::Region"
+                                },
+                                ".amazonaws.com\ndocker pull ",
+                                {
+                                  "Fn::Select": [
+                                    4,
+                                    {
+                                      "Fn::Split": [
+                                        ":",
+                                        {
+                                          "Ref": "CodeBuildImageBuilderB8638EC8"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                ".dkr.ecr.",
+                                {
+                                  "Fn::Select": [
+                                    3,
+                                    {
+                                      "Fn::Split": [
+                                        ":",
+                                        {
+                                          "Ref": "CodeBuildImageBuilderB8638EC8"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                ".",
+                                {
+                                  "Ref": "AWS::URLSuffix"
+                                },
+                                "/",
+                                {
+                                  "Fn::GetAtt": [
+                                    "CodeBuildImageBuilderB8638EC8",
+                                    "Name"
+                                  ]
+                                },
+                                ":latest\necho ECS_CLUSTER=",
+                                {
+                                  "Ref": "ECScluster20BC0B82"
+                                },
+                                " >> /etc/ecs/ecs.config\nsudo iptables --insert FORWARD 1 --in-interface docker+ --destination 169.254.169.254/32 --jump DROP\nsudo service iptables save\necho ECS_AWSVPC_BLOCK_IMDS=true >> /etc/ecs/ecs.config"
+                              ]
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_autoscaling.CfnLaunchConfiguration",
+                      "version": "2.50.0"
+                    }
+                  },
+                  "ASG": {
+                    "id": "ASG",
+                    "path": "github-runners-test/ECS/Auto Scaling Group/ASG",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::AutoScaling::AutoScalingGroup",
+                      "aws:cdk:cloudformation:props": {
+                        "maxSize": "5",
+                        "minSize": "0",
+                        "launchConfigurationName": {
+                          "Ref": "ECSAutoScalingGroupLaunchConfigC22C3413"
+                        },
+                        "newInstancesProtectedFromScaleIn": true,
+                        "tags": [
+                          {
+                            "key": "Name",
+                            "value": "github-runners-test/ECS/Auto Scaling Group",
+                            "propagateAtLaunch": true
+                          }
+                        ],
+                        "vpcZoneIdentifier": [
+                          {
+                            "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
+                          },
+                          {
+                            "Ref": "VpcPublicSubnet2Subnet691E08A3"
+                          }
+                        ]
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_autoscaling.CfnAutoScalingGroup",
+                      "version": "2.50.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_autoscaling.AutoScalingGroup",
+                  "version": "2.50.0"
+                }
+              },
+              "Capacity Provider": {
+                "id": "Capacity Provider",
+                "path": "github-runners-test/ECS/Capacity Provider",
+                "children": {
+                  "Capacity Provider": {
+                    "id": "Capacity Provider",
+                    "path": "github-runners-test/ECS/Capacity Provider/Capacity Provider",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::ECS::CapacityProvider",
+                      "aws:cdk:cloudformation:props": {
+                        "autoScalingGroupProvider": {
+                          "autoScalingGroupArn": {
+                            "Ref": "ECSAutoScalingGroupASG88763D9A"
+                          },
+                          "managedScaling": {
+                            "status": "ENABLED",
+                            "targetCapacity": 100
+                          },
+                          "managedTerminationProtection": "ENABLED"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_ecs.CfnCapacityProvider",
+                      "version": "2.50.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_ecs.AsgCapacityProvider",
+                  "version": "2.50.0"
+                }
+              },
+              "logs": {
+                "id": "logs",
+                "path": "github-runners-test/ECS/logs",
+                "children": {
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "github-runners-test/ECS/logs/Resource",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::Logs::LogGroup",
+                      "aws:cdk:cloudformation:props": {
+                        "retentionInDays": 30
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_logs.CfnLogGroup",
+                      "version": "2.50.0"
+                    }
+                  },
+                  "logs filter": {
+                    "id": "logs filter",
+                    "path": "github-runners-test/ECS/logs/logs filter",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "github-runners-test/ECS/logs/logs filter/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::Logs::MetricFilter",
+                          "aws:cdk:cloudformation:props": {
+                            "filterPattern": "[..., marker = \"CDKGHA\", job = \"JOB\", done = \"DONE\", labels, status = \"Succeeded\" || status = \"SucceededWithIssues\" || status = \"Failed\" || status = \"Canceled\" || status = \"Skipped\" || status = \"Abandoned\"]",
+                            "logGroupName": {
+                              "Ref": "ECSlogs71446134"
+                            },
+                            "metricTransformations": [
+                              {
+                                "metricNamespace": "GitHubRunners",
+                                "metricName": "JobCompleted",
+                                "metricValue": "1",
+                                "dimensions": [
+                                  {
+                                    "key": "ProviderLabels",
+                                    "value": "$labels"
+                                  },
+                                  {
+                                    "key": "Status",
+                                    "value": "$status"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_logs.CfnMetricFilter",
+                          "version": "2.50.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_logs.MetricFilter",
+                      "version": "2.50.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_logs.LogGroup",
+                  "version": "2.50.0"
+                }
+              },
+              "task": {
+                "id": "task",
+                "path": "github-runners-test/ECS/task",
+                "children": {
+                  "TaskRole": {
+                    "id": "TaskRole",
+                    "path": "github-runners-test/ECS/task/TaskRole",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "github-runners-test/ECS/task/TaskRole/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::IAM::Role",
+                          "aws:cdk:cloudformation:props": {
+                            "assumeRolePolicyDocument": {
+                              "Statement": [
+                                {
+                                  "Action": "sts:AssumeRole",
+                                  "Effect": "Allow",
+                                  "Principal": {
+                                    "Service": "ecs-tasks.amazonaws.com"
+                                  }
+                                }
+                              ],
+                              "Version": "2012-10-17"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_iam.CfnRole",
+                          "version": "2.50.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_iam.Role",
+                      "version": "2.50.0"
+                    }
+                  },
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "github-runners-test/ECS/task/Resource",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::ECS::TaskDefinition",
+                      "aws:cdk:cloudformation:props": {
+                        "containerDefinitions": [
+                          {
+                            "command": [
+                              "sh",
+                              "-c",
+                              "cd /home/runner &&\n        if [ \"$RUNNER_VERSION\" = \"latest\" ]; then RUNNER_FLAGS=\"\"; else RUNNER_FLAGS=\"--disableupdate\"; fi &&\n        ./config.sh --unattended --url \"https://$GITHUB_DOMAIN/$OWNER/$REPO\" --token \"$RUNNER_TOKEN\" --ephemeral --work _work --labels \"$RUNNER_LABEL\" $RUNNER_FLAGS --name \"$RUNNER_NAME\" && \n        ./run.sh &&\n        STATUS=$(grep -Phors \"finish job request for job [0-9a-f\\-]+ with result: \\K.*\" _diag/ | tail -n1) &&\n        [ -n \"$STATUS\" ] && echo CDKGHA JOB DONE \"$RUNNER_LABEL\" \"$STATUS\""
+                            ],
+                            "cpu": 1024,
+                            "essential": true,
+                            "image": {
+                              "Fn::Join": [
+                                "",
+                                [
+                                  {
+                                    "Fn::Select": [
+                                      4,
+                                      {
+                                        "Fn::Split": [
+                                          ":",
+                                          {
+                                            "Ref": "CodeBuildImageBuilderB8638EC8"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  ".dkr.ecr.",
+                                  {
+                                    "Fn::Select": [
+                                      3,
+                                      {
+                                        "Fn::Split": [
+                                          ":",
+                                          {
+                                            "Ref": "CodeBuildImageBuilderB8638EC8"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  ".",
+                                  {
+                                    "Ref": "AWS::URLSuffix"
+                                  },
+                                  "/",
+                                  {
+                                    "Fn::GetAtt": [
+                                      "CodeBuildImageBuilderB8638EC8",
+                                      "Name"
+                                    ]
+                                  },
+                                  ":latest"
+                                ]
+                              ]
+                            },
+                            "memory": 3500,
+                            "name": "runner",
+                            "user": "runner",
+                            "logConfiguration": {
+                              "logDriver": "awslogs",
+                              "options": {
+                                "awslogs-group": {
+                                  "Ref": "ECSlogs71446134"
+                                },
+                                "awslogs-stream-prefix": "runner",
+                                "awslogs-region": {
+                                  "Ref": "AWS::Region"
+                                }
+                              }
+                            }
+                          }
+                        ],
+                        "executionRoleArn": {
+                          "Fn::GetAtt": [
+                            "ECStaskExecutionRole1A6D19A5",
+                            "Arn"
+                          ]
+                        },
+                        "family": "githubrunnerstestECStaskCE74CC84",
+                        "networkMode": "bridge",
+                        "requiresCompatibilities": [
+                          "EC2"
+                        ],
+                        "taskRoleArn": {
+                          "Fn::GetAtt": [
+                            "ECStaskTaskRoleFE831ECD",
+                            "Arn"
+                          ]
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_ecs.CfnTaskDefinition",
+                      "version": "2.50.0"
+                    }
+                  },
+                  "runner": {
+                    "id": "runner",
+                    "path": "github-runners-test/ECS/task/runner",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_ecs.ContainerDefinition",
+                      "version": "2.50.0"
+                    }
+                  },
+                  "ExecutionRole": {
+                    "id": "ExecutionRole",
+                    "path": "github-runners-test/ECS/task/ExecutionRole",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "github-runners-test/ECS/task/ExecutionRole/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::IAM::Role",
+                          "aws:cdk:cloudformation:props": {
+                            "assumeRolePolicyDocument": {
+                              "Statement": [
+                                {
+                                  "Action": "sts:AssumeRole",
+                                  "Effect": "Allow",
+                                  "Principal": {
+                                    "Service": "ecs-tasks.amazonaws.com"
+                                  }
+                                }
+                              ],
+                              "Version": "2012-10-17"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_iam.CfnRole",
+                          "version": "2.50.0"
+                        }
+                      },
+                      "DefaultPolicy": {
+                        "id": "DefaultPolicy",
+                        "path": "github-runners-test/ECS/task/ExecutionRole/DefaultPolicy",
+                        "children": {
+                          "Resource": {
+                            "id": "Resource",
+                            "path": "github-runners-test/ECS/task/ExecutionRole/DefaultPolicy/Resource",
+                            "attributes": {
+                              "aws:cdk:cloudformation:type": "AWS::IAM::Policy",
+                              "aws:cdk:cloudformation:props": {
+                                "policyDocument": {
+                                  "Statement": [
+                                    {
+                                      "Action": [
+                                        "ecr:BatchCheckLayerAvailability",
+                                        "ecr:GetDownloadUrlForLayer",
+                                        "ecr:BatchGetImage"
+                                      ],
+                                      "Effect": "Allow",
+                                      "Resource": {
+                                        "Ref": "CodeBuildImageBuilderB8638EC8"
+                                      }
+                                    },
+                                    {
+                                      "Action": "ecr:GetAuthorizationToken",
+                                      "Effect": "Allow",
+                                      "Resource": "*"
+                                    },
+                                    {
+                                      "Action": [
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                      ],
+                                      "Effect": "Allow",
+                                      "Resource": {
+                                        "Fn::GetAtt": [
+                                          "ECSlogs71446134",
+                                          "Arn"
+                                        ]
+                                      }
+                                    }
+                                  ],
+                                  "Version": "2012-10-17"
+                                },
+                                "policyName": "ECStaskExecutionRoleDefaultPolicy564C1271",
+                                "roles": [
+                                  {
+                                    "Ref": "ECStaskExecutionRole1A6D19A5"
+                                  }
+                                ]
+                              }
+                            },
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
+                              "version": "2.50.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_iam.Policy",
+                          "version": "2.50.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_iam.Role",
+                      "version": "2.50.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_ecs.Ec2TaskDefinition",
+                  "version": "2.50.0"
+                }
+              },
+              "ecs, linux, x64": {
+                "id": "ecs, linux, x64",
+                "path": "github-runners-test/ECS/ecs, linux, x64",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_stepfunctions_tasks.EcsRunTask",
+                  "version": "2.50.0"
+                }
+              }
+            },
+            "constructInfo": {
+              "fqn": "constructs.Construct",
+              "version": "10.0.5"
+            }
+          },
+          "SsmParameterValue:--aws--service--ecs--optimized-ami--amazon-linux-2--recommended--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118.Parameter": {
+            "id": "SsmParameterValue:--aws--service--ecs--optimized-ami--amazon-linux-2--recommended--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118.Parameter",
+            "path": "github-runners-test/SsmParameterValue:--aws--service--ecs--optimized-ami--amazon-linux-2--recommended--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118.Parameter",
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.CfnParameter",
+              "version": "2.50.0"
+            }
+          },
+          "SsmParameterValue:--aws--service--ecs--optimized-ami--amazon-linux-2--recommended--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118": {
+            "id": "SsmParameterValue:--aws--service--ecs--optimized-ami--amazon-linux-2--recommended--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118",
+            "path": "github-runners-test/SsmParameterValue:--aws--service--ecs--optimized-ami--amazon-linux-2--recommended--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118",
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.Resource",
+              "version": "2.50.0"
+            }
+          },
+          "ECS ARM64": {
+            "id": "ECS ARM64",
+            "path": "github-runners-test/ECS ARM64",
+            "children": {
+              "security group": {
+                "id": "security group",
+                "path": "github-runners-test/ECS ARM64/security group",
+                "children": {
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "github-runners-test/ECS ARM64/security group/Resource",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::EC2::SecurityGroup",
+                      "aws:cdk:cloudformation:props": {
+                        "groupDescription": "github-runners-test/ECS ARM64/security group",
+                        "securityGroupEgress": [
+                          {
+                            "cidrIp": "0.0.0.0/0",
+                            "description": "Allow all outbound traffic by default",
+                            "ipProtocol": "-1"
+                          }
+                        ],
+                        "vpcId": {
+                          "Ref": "Vpc8378EB38"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_ec2.CfnSecurityGroup",
+                      "version": "2.50.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_ec2.SecurityGroup",
+                  "version": "2.50.0"
+                }
+              },
+              "cluster": {
+                "id": "cluster",
+                "path": "github-runners-test/ECS ARM64/cluster",
+                "children": {
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "github-runners-test/ECS ARM64/cluster/Resource",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::ECS::Cluster",
+                      "aws:cdk:cloudformation:props": {}
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_ecs.CfnCluster",
+                      "version": "2.50.0"
+                    }
+                  },
+                  "cluster": {
+                    "id": "cluster",
+                    "path": "github-runners-test/ECS ARM64/cluster/cluster",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::ECS::ClusterCapacityProviderAssociations",
+                      "aws:cdk:cloudformation:props": {
+                        "capacityProviders": [
+                          {
+                            "Ref": "ECSARM64CapacityProvider8627FEF9"
+                          }
+                        ],
+                        "cluster": {
+                          "Ref": "ECSARM64cluster4ECAA083"
+                        },
+                        "defaultCapacityProviderStrategy": []
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_ecs.CfnClusterCapacityProviderAssociations",
+                      "version": "2.50.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_ecs.Cluster",
+                  "version": "2.50.0"
+                }
+              },
+              "Auto Scaling Group": {
+                "id": "Auto Scaling Group",
+                "path": "github-runners-test/ECS ARM64/Auto Scaling Group",
+                "children": {
+                  "InstanceSecurityGroup": {
+                    "id": "InstanceSecurityGroup",
+                    "path": "github-runners-test/ECS ARM64/Auto Scaling Group/InstanceSecurityGroup",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "github-runners-test/ECS ARM64/Auto Scaling Group/InstanceSecurityGroup/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::EC2::SecurityGroup",
+                          "aws:cdk:cloudformation:props": {
+                            "groupDescription": "github-runners-test/ECS ARM64/Auto Scaling Group/InstanceSecurityGroup",
+                            "securityGroupEgress": [
+                              {
+                                "cidrIp": "0.0.0.0/0",
+                                "description": "Allow all outbound traffic by default",
+                                "ipProtocol": "-1"
+                              }
+                            ],
+                            "tags": [
+                              {
+                                "key": "Name",
+                                "value": "github-runners-test/ECS ARM64/Auto Scaling Group"
+                              }
+                            ],
+                            "vpcId": {
+                              "Ref": "Vpc8378EB38"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_ec2.CfnSecurityGroup",
+                          "version": "2.50.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_ec2.SecurityGroup",
+                      "version": "2.50.0"
+                    }
+                  },
+                  "InstanceRole": {
+                    "id": "InstanceRole",
+                    "path": "github-runners-test/ECS ARM64/Auto Scaling Group/InstanceRole",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "github-runners-test/ECS ARM64/Auto Scaling Group/InstanceRole/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::IAM::Role",
+                          "aws:cdk:cloudformation:props": {
+                            "assumeRolePolicyDocument": {
+                              "Statement": [
+                                {
+                                  "Action": "sts:AssumeRole",
+                                  "Effect": "Allow",
+                                  "Principal": {
+                                    "Service": {
+                                      "Fn::Join": [
+                                        "",
+                                        [
+                                          "ec2.",
+                                          {
+                                            "Ref": "AWS::URLSuffix"
+                                          }
+                                        ]
+                                      ]
+                                    }
+                                  }
+                                }
+                              ],
+                              "Version": "2012-10-17"
+                            },
+                            "managedPolicyArns": [
+                              {
+                                "Fn::Join": [
+                                  "",
+                                  [
+                                    "arn:",
+                                    {
+                                      "Ref": "AWS::Partition"
+                                    },
+                                    ":iam::aws:policy/AmazonSSMManagedInstanceCore"
+                                  ]
+                                ]
+                              }
+                            ],
+                            "tags": [
+                              {
+                                "key": "Name",
+                                "value": "github-runners-test/ECS ARM64/Auto Scaling Group"
+                              }
+                            ]
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_iam.CfnRole",
+                          "version": "2.50.0"
+                        }
+                      },
+                      "DefaultPolicy": {
+                        "id": "DefaultPolicy",
+                        "path": "github-runners-test/ECS ARM64/Auto Scaling Group/InstanceRole/DefaultPolicy",
+                        "children": {
+                          "Resource": {
+                            "id": "Resource",
+                            "path": "github-runners-test/ECS ARM64/Auto Scaling Group/InstanceRole/DefaultPolicy/Resource",
+                            "attributes": {
+                              "aws:cdk:cloudformation:type": "AWS::IAM::Policy",
+                              "aws:cdk:cloudformation:props": {
+                                "policyDocument": {
+                                  "Statement": [
+                                    {
+                                      "Action": [
+                                        "ecr:BatchCheckLayerAvailability",
+                                        "ecr:GetDownloadUrlForLayer",
+                                        "ecr:BatchGetImage"
+                                      ],
+                                      "Effect": "Allow",
+                                      "Resource": {
+                                        "Ref": "CodeBuildImageBuilderarmBuilder755EB37D"
+                                      }
+                                    },
+                                    {
+                                      "Action": "ecr:GetAuthorizationToken",
+                                      "Effect": "Allow",
+                                      "Resource": "*"
+                                    },
+                                    {
+                                      "Action": [
+                                        "ecs:DeregisterContainerInstance",
+                                        "ecs:RegisterContainerInstance",
+                                        "ecs:Submit*"
+                                      ],
+                                      "Effect": "Allow",
+                                      "Resource": {
+                                        "Fn::GetAtt": [
+                                          "ECSARM64cluster4ECAA083",
+                                          "Arn"
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "Action": [
+                                        "ecs:Poll",
+                                        "ecs:StartTelemetrySession"
+                                      ],
+                                      "Condition": {
+                                        "ArnEquals": {
+                                          "ecs:cluster": {
+                                            "Fn::GetAtt": [
+                                              "ECSARM64cluster4ECAA083",
+                                              "Arn"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "Effect": "Allow",
+                                      "Resource": "*"
+                                    },
+                                    {
+                                      "Action": [
+                                        "ecs:DiscoverPollEndpoint",
+                                        "ecr:GetAuthorizationToken",
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                      ],
+                                      "Effect": "Allow",
+                                      "Resource": "*"
+                                    }
+                                  ],
+                                  "Version": "2012-10-17"
+                                },
+                                "policyName": "ECSARM64AutoScalingGroupInstanceRoleDefaultPolicyD0E29275",
+                                "roles": [
+                                  {
+                                    "Ref": "ECSARM64AutoScalingGroupInstanceRole01030665"
+                                  }
+                                ]
+                              }
+                            },
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
+                              "version": "2.50.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_iam.Policy",
+                          "version": "2.50.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_iam.Role",
+                      "version": "2.50.0"
+                    }
+                  },
+                  "InstanceProfile": {
+                    "id": "InstanceProfile",
+                    "path": "github-runners-test/ECS ARM64/Auto Scaling Group/InstanceProfile",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::IAM::InstanceProfile",
+                      "aws:cdk:cloudformation:props": {
+                        "roles": [
+                          {
+                            "Ref": "ECSARM64AutoScalingGroupInstanceRole01030665"
+                          }
+                        ]
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_iam.CfnInstanceProfile",
+                      "version": "2.50.0"
+                    }
+                  },
+                  "LaunchConfig": {
+                    "id": "LaunchConfig",
+                    "path": "github-runners-test/ECS ARM64/Auto Scaling Group/LaunchConfig",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::AutoScaling::LaunchConfiguration",
+                      "aws:cdk:cloudformation:props": {
+                        "imageId": {
+                          "Ref": "SsmParameterValueawsserviceecsoptimizedamiamazonlinux2arm64recommendedimageidC96584B6F00A464EAD1953AFF4B05118Parameter"
+                        },
+                        "instanceType": "m6g.large",
+                        "iamInstanceProfile": {
+                          "Ref": "ECSARM64AutoScalingGroupInstanceProfile768645E6"
+                        },
+                        "securityGroups": [
+                          {
+                            "Fn::GetAtt": [
+                              "ECSARM64AutoScalingGroupInstanceSecurityGroupB68B781E",
+                              "GroupId"
+                            ]
+                          },
+                          {
+                            "Fn::GetAtt": [
+                              "ECSARM64securitygroup281D94B2",
+                              "GroupId"
+                            ]
+                          }
+                        ],
+                        "userData": {
+                          "Fn::Base64": {
+                            "Fn::Join": [
+                              "",
+                              [
+                                "#!/bin/bash\naws ecr get-login-password --region ",
+                                {
+                                  "Ref": "AWS::Region"
+                                },
+                                " | docker login --username AWS --password-stdin ",
+                                {
+                                  "Ref": "AWS::AccountId"
+                                },
+                                ".dkr.ecr.",
+                                {
+                                  "Ref": "AWS::Region"
+                                },
+                                ".amazonaws.com\ndocker pull ",
+                                {
+                                  "Fn::Select": [
+                                    4,
+                                    {
+                                      "Fn::Split": [
+                                        ":",
+                                        {
+                                          "Ref": "CodeBuildImageBuilderarmBuilder755EB37D"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                ".dkr.ecr.",
+                                {
+                                  "Fn::Select": [
+                                    3,
+                                    {
+                                      "Fn::Split": [
+                                        ":",
+                                        {
+                                          "Ref": "CodeBuildImageBuilderarmBuilder755EB37D"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                ".",
+                                {
+                                  "Ref": "AWS::URLSuffix"
+                                },
+                                "/",
+                                {
+                                  "Fn::GetAtt": [
+                                    "CodeBuildImageBuilderarmBuilder755EB37D",
+                                    "Name"
+                                  ]
+                                },
+                                ":latest\necho ECS_CLUSTER=",
+                                {
+                                  "Ref": "ECSARM64cluster4ECAA083"
+                                },
+                                " >> /etc/ecs/ecs.config\nsudo iptables --insert FORWARD 1 --in-interface docker+ --destination 169.254.169.254/32 --jump DROP\nsudo service iptables save\necho ECS_AWSVPC_BLOCK_IMDS=true >> /etc/ecs/ecs.config"
+                              ]
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_autoscaling.CfnLaunchConfiguration",
+                      "version": "2.50.0"
+                    }
+                  },
+                  "ASG": {
+                    "id": "ASG",
+                    "path": "github-runners-test/ECS ARM64/Auto Scaling Group/ASG",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::AutoScaling::AutoScalingGroup",
+                      "aws:cdk:cloudformation:props": {
+                        "maxSize": "5",
+                        "minSize": "0",
+                        "launchConfigurationName": {
+                          "Ref": "ECSARM64AutoScalingGroupLaunchConfig9B8B62ED"
+                        },
+                        "newInstancesProtectedFromScaleIn": true,
+                        "tags": [
+                          {
+                            "key": "Name",
+                            "value": "github-runners-test/ECS ARM64/Auto Scaling Group",
+                            "propagateAtLaunch": true
+                          }
+                        ],
+                        "vpcZoneIdentifier": [
+                          {
+                            "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
+                          },
+                          {
+                            "Ref": "VpcPublicSubnet2Subnet691E08A3"
+                          }
+                        ]
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_autoscaling.CfnAutoScalingGroup",
+                      "version": "2.50.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_autoscaling.AutoScalingGroup",
+                  "version": "2.50.0"
+                }
+              },
+              "Capacity Provider": {
+                "id": "Capacity Provider",
+                "path": "github-runners-test/ECS ARM64/Capacity Provider",
+                "children": {
+                  "Capacity Provider": {
+                    "id": "Capacity Provider",
+                    "path": "github-runners-test/ECS ARM64/Capacity Provider/Capacity Provider",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::ECS::CapacityProvider",
+                      "aws:cdk:cloudformation:props": {
+                        "autoScalingGroupProvider": {
+                          "autoScalingGroupArn": {
+                            "Ref": "ECSARM64AutoScalingGroupASGA19FC118"
+                          },
+                          "managedScaling": {
+                            "status": "ENABLED",
+                            "targetCapacity": 100
+                          },
+                          "managedTerminationProtection": "ENABLED"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_ecs.CfnCapacityProvider",
+                      "version": "2.50.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_ecs.AsgCapacityProvider",
+                  "version": "2.50.0"
+                }
+              },
+              "logs": {
+                "id": "logs",
+                "path": "github-runners-test/ECS ARM64/logs",
+                "children": {
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "github-runners-test/ECS ARM64/logs/Resource",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::Logs::LogGroup",
+                      "aws:cdk:cloudformation:props": {
+                        "retentionInDays": 30
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_logs.CfnLogGroup",
+                      "version": "2.50.0"
+                    }
+                  },
+                  "logs filter": {
+                    "id": "logs filter",
+                    "path": "github-runners-test/ECS ARM64/logs/logs filter",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "github-runners-test/ECS ARM64/logs/logs filter/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::Logs::MetricFilter",
+                          "aws:cdk:cloudformation:props": {
+                            "filterPattern": "[..., marker = \"CDKGHA\", job = \"JOB\", done = \"DONE\", labels, status = \"Succeeded\" || status = \"SucceededWithIssues\" || status = \"Failed\" || status = \"Canceled\" || status = \"Skipped\" || status = \"Abandoned\"]",
+                            "logGroupName": {
+                              "Ref": "ECSARM64logs1A2F1E00"
+                            },
+                            "metricTransformations": [
+                              {
+                                "metricNamespace": "GitHubRunners",
+                                "metricName": "JobCompleted",
+                                "metricValue": "1",
+                                "dimensions": [
+                                  {
+                                    "key": "ProviderLabels",
+                                    "value": "$labels"
+                                  },
+                                  {
+                                    "key": "Status",
+                                    "value": "$status"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_logs.CfnMetricFilter",
+                          "version": "2.50.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_logs.MetricFilter",
+                      "version": "2.50.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_logs.LogGroup",
+                  "version": "2.50.0"
+                }
+              },
+              "task": {
+                "id": "task",
+                "path": "github-runners-test/ECS ARM64/task",
+                "children": {
+                  "TaskRole": {
+                    "id": "TaskRole",
+                    "path": "github-runners-test/ECS ARM64/task/TaskRole",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "github-runners-test/ECS ARM64/task/TaskRole/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::IAM::Role",
+                          "aws:cdk:cloudformation:props": {
+                            "assumeRolePolicyDocument": {
+                              "Statement": [
+                                {
+                                  "Action": "sts:AssumeRole",
+                                  "Effect": "Allow",
+                                  "Principal": {
+                                    "Service": "ecs-tasks.amazonaws.com"
+                                  }
+                                }
+                              ],
+                              "Version": "2012-10-17"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_iam.CfnRole",
+                          "version": "2.50.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_iam.Role",
+                      "version": "2.50.0"
+                    }
+                  },
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "github-runners-test/ECS ARM64/task/Resource",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::ECS::TaskDefinition",
+                      "aws:cdk:cloudformation:props": {
+                        "containerDefinitions": [
+                          {
+                            "command": [
+                              "sh",
+                              "-c",
+                              "cd /home/runner &&\n        if [ \"$RUNNER_VERSION\" = \"latest\" ]; then RUNNER_FLAGS=\"\"; else RUNNER_FLAGS=\"--disableupdate\"; fi &&\n        ./config.sh --unattended --url \"https://$GITHUB_DOMAIN/$OWNER/$REPO\" --token \"$RUNNER_TOKEN\" --ephemeral --work _work --labels \"$RUNNER_LABEL\" $RUNNER_FLAGS --name \"$RUNNER_NAME\" && \n        ./run.sh &&\n        STATUS=$(grep -Phors \"finish job request for job [0-9a-f\\-]+ with result: \\K.*\" _diag/ | tail -n1) &&\n        [ -n \"$STATUS\" ] && echo CDKGHA JOB DONE \"$RUNNER_LABEL\" \"$STATUS\""
+                            ],
+                            "cpu": 1024,
+                            "essential": true,
+                            "image": {
+                              "Fn::Join": [
+                                "",
+                                [
+                                  {
+                                    "Fn::Select": [
+                                      4,
+                                      {
+                                        "Fn::Split": [
+                                          ":",
+                                          {
+                                            "Ref": "CodeBuildImageBuilderarmBuilder755EB37D"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  ".dkr.ecr.",
+                                  {
+                                    "Fn::Select": [
+                                      3,
+                                      {
+                                        "Fn::Split": [
+                                          ":",
+                                          {
+                                            "Ref": "CodeBuildImageBuilderarmBuilder755EB37D"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  ".",
+                                  {
+                                    "Ref": "AWS::URLSuffix"
+                                  },
+                                  "/",
+                                  {
+                                    "Fn::GetAtt": [
+                                      "CodeBuildImageBuilderarmBuilder755EB37D",
+                                      "Name"
+                                    ]
+                                  },
+                                  ":latest"
+                                ]
+                              ]
+                            },
+                            "memory": 3500,
+                            "name": "runner",
+                            "user": "runner",
+                            "logConfiguration": {
+                              "logDriver": "awslogs",
+                              "options": {
+                                "awslogs-group": {
+                                  "Ref": "ECSARM64logs1A2F1E00"
+                                },
+                                "awslogs-stream-prefix": "runner",
+                                "awslogs-region": {
+                                  "Ref": "AWS::Region"
+                                }
+                              }
+                            }
+                          }
+                        ],
+                        "executionRoleArn": {
+                          "Fn::GetAtt": [
+                            "ECSARM64taskExecutionRoleBF2AE76F",
+                            "Arn"
+                          ]
+                        },
+                        "family": "githubrunnerstestECSARM64taskE94E43A3",
+                        "networkMode": "bridge",
+                        "requiresCompatibilities": [
+                          "EC2"
+                        ],
+                        "taskRoleArn": {
+                          "Fn::GetAtt": [
+                            "ECSARM64taskTaskRole23B1CB4E",
+                            "Arn"
+                          ]
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_ecs.CfnTaskDefinition",
+                      "version": "2.50.0"
+                    }
+                  },
+                  "runner": {
+                    "id": "runner",
+                    "path": "github-runners-test/ECS ARM64/task/runner",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_ecs.ContainerDefinition",
+                      "version": "2.50.0"
+                    }
+                  },
+                  "ExecutionRole": {
+                    "id": "ExecutionRole",
+                    "path": "github-runners-test/ECS ARM64/task/ExecutionRole",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "github-runners-test/ECS ARM64/task/ExecutionRole/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::IAM::Role",
+                          "aws:cdk:cloudformation:props": {
+                            "assumeRolePolicyDocument": {
+                              "Statement": [
+                                {
+                                  "Action": "sts:AssumeRole",
+                                  "Effect": "Allow",
+                                  "Principal": {
+                                    "Service": "ecs-tasks.amazonaws.com"
+                                  }
+                                }
+                              ],
+                              "Version": "2012-10-17"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_iam.CfnRole",
+                          "version": "2.50.0"
+                        }
+                      },
+                      "DefaultPolicy": {
+                        "id": "DefaultPolicy",
+                        "path": "github-runners-test/ECS ARM64/task/ExecutionRole/DefaultPolicy",
+                        "children": {
+                          "Resource": {
+                            "id": "Resource",
+                            "path": "github-runners-test/ECS ARM64/task/ExecutionRole/DefaultPolicy/Resource",
+                            "attributes": {
+                              "aws:cdk:cloudformation:type": "AWS::IAM::Policy",
+                              "aws:cdk:cloudformation:props": {
+                                "policyDocument": {
+                                  "Statement": [
+                                    {
+                                      "Action": [
+                                        "ecr:BatchCheckLayerAvailability",
+                                        "ecr:GetDownloadUrlForLayer",
+                                        "ecr:BatchGetImage"
+                                      ],
+                                      "Effect": "Allow",
+                                      "Resource": {
+                                        "Ref": "CodeBuildImageBuilderarmBuilder755EB37D"
+                                      }
+                                    },
+                                    {
+                                      "Action": "ecr:GetAuthorizationToken",
+                                      "Effect": "Allow",
+                                      "Resource": "*"
+                                    },
+                                    {
+                                      "Action": [
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                      ],
+                                      "Effect": "Allow",
+                                      "Resource": {
+                                        "Fn::GetAtt": [
+                                          "ECSARM64logs1A2F1E00",
+                                          "Arn"
+                                        ]
+                                      }
+                                    }
+                                  ],
+                                  "Version": "2012-10-17"
+                                },
+                                "policyName": "ECSARM64taskExecutionRoleDefaultPolicy17294239",
+                                "roles": [
+                                  {
+                                    "Ref": "ECSARM64taskExecutionRoleBF2AE76F"
+                                  }
+                                ]
+                              }
+                            },
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
+                              "version": "2.50.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_iam.Policy",
+                          "version": "2.50.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_iam.Role",
+                      "version": "2.50.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_ecs.Ec2TaskDefinition",
+                  "version": "2.50.0"
+                }
+              },
+              "ecs, linux, arm64": {
+                "id": "ecs, linux, arm64",
+                "path": "github-runners-test/ECS ARM64/ecs, linux, arm64",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_stepfunctions_tasks.EcsRunTask",
+                  "version": "2.50.0"
+                }
+              }
+            },
+            "constructInfo": {
+              "fqn": "constructs.Construct",
+              "version": "10.0.5"
+            }
+          },
+          "SsmParameterValue:--aws--service--ecs--optimized-ami--amazon-linux-2--arm64--recommended--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118.Parameter": {
+            "id": "SsmParameterValue:--aws--service--ecs--optimized-ami--amazon-linux-2--arm64--recommended--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118.Parameter",
+            "path": "github-runners-test/SsmParameterValue:--aws--service--ecs--optimized-ami--amazon-linux-2--arm64--recommended--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118.Parameter",
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.CfnParameter",
+              "version": "2.50.0"
+            }
+          },
+          "SsmParameterValue:--aws--service--ecs--optimized-ami--amazon-linux-2--arm64--recommended--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118": {
+            "id": "SsmParameterValue:--aws--service--ecs--optimized-ami--amazon-linux-2--arm64--recommended--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118",
+            "path": "github-runners-test/SsmParameterValue:--aws--service--ecs--optimized-ami--amazon-linux-2--arm64--recommended--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118",
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.Resource",
+              "version": "2.50.0"
+            }
+          },
+          "ECS Windows": {
+            "id": "ECS Windows",
+            "path": "github-runners-test/ECS Windows",
+            "children": {
+              "security group": {
+                "id": "security group",
+                "path": "github-runners-test/ECS Windows/security group",
+                "children": {
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "github-runners-test/ECS Windows/security group/Resource",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::EC2::SecurityGroup",
+                      "aws:cdk:cloudformation:props": {
+                        "groupDescription": "github-runners-test/ECS Windows/security group",
+                        "securityGroupEgress": [
+                          {
+                            "cidrIp": "0.0.0.0/0",
+                            "description": "Allow all outbound traffic by default",
+                            "ipProtocol": "-1"
+                          }
+                        ],
+                        "vpcId": {
+                          "Ref": "Vpc8378EB38"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_ec2.CfnSecurityGroup",
+                      "version": "2.50.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_ec2.SecurityGroup",
+                  "version": "2.50.0"
+                }
+              },
+              "cluster": {
+                "id": "cluster",
+                "path": "github-runners-test/ECS Windows/cluster",
+                "children": {
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "github-runners-test/ECS Windows/cluster/Resource",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::ECS::Cluster",
+                      "aws:cdk:cloudformation:props": {}
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_ecs.CfnCluster",
+                      "version": "2.50.0"
+                    }
+                  },
+                  "cluster": {
+                    "id": "cluster",
+                    "path": "github-runners-test/ECS Windows/cluster/cluster",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::ECS::ClusterCapacityProviderAssociations",
+                      "aws:cdk:cloudformation:props": {
+                        "capacityProviders": [
+                          {
+                            "Ref": "ECSWindowsCapacityProvider8F8896A5"
+                          }
+                        ],
+                        "cluster": {
+                          "Ref": "ECSWindowscluster14061F74"
+                        },
+                        "defaultCapacityProviderStrategy": []
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_ecs.CfnClusterCapacityProviderAssociations",
+                      "version": "2.50.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_ecs.Cluster",
+                  "version": "2.50.0"
+                }
+              },
+              "Auto Scaling Group": {
+                "id": "Auto Scaling Group",
+                "path": "github-runners-test/ECS Windows/Auto Scaling Group",
+                "children": {
+                  "InstanceSecurityGroup": {
+                    "id": "InstanceSecurityGroup",
+                    "path": "github-runners-test/ECS Windows/Auto Scaling Group/InstanceSecurityGroup",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "github-runners-test/ECS Windows/Auto Scaling Group/InstanceSecurityGroup/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::EC2::SecurityGroup",
+                          "aws:cdk:cloudformation:props": {
+                            "groupDescription": "github-runners-test/ECS Windows/Auto Scaling Group/InstanceSecurityGroup",
+                            "securityGroupEgress": [
+                              {
+                                "cidrIp": "0.0.0.0/0",
+                                "description": "Allow all outbound traffic by default",
+                                "ipProtocol": "-1"
+                              }
+                            ],
+                            "tags": [
+                              {
+                                "key": "Name",
+                                "value": "github-runners-test/ECS Windows/Auto Scaling Group"
+                              }
+                            ],
+                            "vpcId": {
+                              "Ref": "Vpc8378EB38"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_ec2.CfnSecurityGroup",
+                          "version": "2.50.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_ec2.SecurityGroup",
+                      "version": "2.50.0"
+                    }
+                  },
+                  "InstanceRole": {
+                    "id": "InstanceRole",
+                    "path": "github-runners-test/ECS Windows/Auto Scaling Group/InstanceRole",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "github-runners-test/ECS Windows/Auto Scaling Group/InstanceRole/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::IAM::Role",
+                          "aws:cdk:cloudformation:props": {
+                            "assumeRolePolicyDocument": {
+                              "Statement": [
+                                {
+                                  "Action": "sts:AssumeRole",
+                                  "Effect": "Allow",
+                                  "Principal": {
+                                    "Service": {
+                                      "Fn::Join": [
+                                        "",
+                                        [
+                                          "ec2.",
+                                          {
+                                            "Ref": "AWS::URLSuffix"
+                                          }
+                                        ]
+                                      ]
+                                    }
+                                  }
+                                }
+                              ],
+                              "Version": "2012-10-17"
+                            },
+                            "managedPolicyArns": [
+                              {
+                                "Fn::Join": [
+                                  "",
+                                  [
+                                    "arn:",
+                                    {
+                                      "Ref": "AWS::Partition"
+                                    },
+                                    ":iam::aws:policy/AmazonSSMManagedInstanceCore"
+                                  ]
+                                ]
+                              }
+                            ],
+                            "tags": [
+                              {
+                                "key": "Name",
+                                "value": "github-runners-test/ECS Windows/Auto Scaling Group"
+                              }
+                            ]
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_iam.CfnRole",
+                          "version": "2.50.0"
+                        }
+                      },
+                      "DefaultPolicy": {
+                        "id": "DefaultPolicy",
+                        "path": "github-runners-test/ECS Windows/Auto Scaling Group/InstanceRole/DefaultPolicy",
+                        "children": {
+                          "Resource": {
+                            "id": "Resource",
+                            "path": "github-runners-test/ECS Windows/Auto Scaling Group/InstanceRole/DefaultPolicy/Resource",
+                            "attributes": {
+                              "aws:cdk:cloudformation:type": "AWS::IAM::Policy",
+                              "aws:cdk:cloudformation:props": {
+                                "policyDocument": {
+                                  "Statement": [
+                                    {
+                                      "Action": [
+                                        "ecr:BatchCheckLayerAvailability",
+                                        "ecr:GetDownloadUrlForLayer",
+                                        "ecr:BatchGetImage"
+                                      ],
+                                      "Effect": "Allow",
+                                      "Resource": {
+                                        "Fn::Join": [
+                                          "",
+                                          [
+                                            "arn:",
+                                            {
+                                              "Ref": "AWS::Partition"
+                                            },
+                                            ":ecr:",
+                                            {
+                                              "Ref": "AWS::Region"
+                                            },
+                                            ":",
+                                            {
+                                              "Ref": "AWS::AccountId"
+                                            },
+                                            ":repository/",
+                                            {
+                                              "Fn::Select": [
+                                                0,
+                                                {
+                                                  "Fn::Split": [
+                                                    ":",
+                                                    {
+                                                      "Fn::Select": [
+                                                        1,
+                                                        {
+                                                          "Fn::Split": [
+                                                            "/",
+                                                            {
+                                                              "Fn::GetAtt": [
+                                                                "WindowsImageBuilderDockerImage8672CA3E",
+                                                                "ImageUri"
+                                                              ]
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "Action": "ecr:GetAuthorizationToken",
+                                      "Effect": "Allow",
+                                      "Resource": "*"
+                                    },
+                                    {
+                                      "Action": [
+                                        "ecs:DeregisterContainerInstance",
+                                        "ecs:RegisterContainerInstance",
+                                        "ecs:Submit*"
+                                      ],
+                                      "Effect": "Allow",
+                                      "Resource": {
+                                        "Fn::GetAtt": [
+                                          "ECSWindowscluster14061F74",
+                                          "Arn"
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "Action": [
+                                        "ecs:Poll",
+                                        "ecs:StartTelemetrySession"
+                                      ],
+                                      "Condition": {
+                                        "ArnEquals": {
+                                          "ecs:cluster": {
+                                            "Fn::GetAtt": [
+                                              "ECSWindowscluster14061F74",
+                                              "Arn"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "Effect": "Allow",
+                                      "Resource": "*"
+                                    },
+                                    {
+                                      "Action": [
+                                        "ecs:DiscoverPollEndpoint",
+                                        "ecr:GetAuthorizationToken",
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                      ],
+                                      "Effect": "Allow",
+                                      "Resource": "*"
+                                    }
+                                  ],
+                                  "Version": "2012-10-17"
+                                },
+                                "policyName": "ECSWindowsAutoScalingGroupInstanceRoleDefaultPolicyAEE83B95",
+                                "roles": [
+                                  {
+                                    "Ref": "ECSWindowsAutoScalingGroupInstanceRoleFB287046"
+                                  }
+                                ]
+                              }
+                            },
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
+                              "version": "2.50.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_iam.Policy",
+                          "version": "2.50.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_iam.Role",
+                      "version": "2.50.0"
+                    }
+                  },
+                  "InstanceProfile": {
+                    "id": "InstanceProfile",
+                    "path": "github-runners-test/ECS Windows/Auto Scaling Group/InstanceProfile",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::IAM::InstanceProfile",
+                      "aws:cdk:cloudformation:props": {
+                        "roles": [
+                          {
+                            "Ref": "ECSWindowsAutoScalingGroupInstanceRoleFB287046"
+                          }
+                        ]
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_iam.CfnInstanceProfile",
+                      "version": "2.50.0"
+                    }
+                  },
+                  "LaunchConfig": {
+                    "id": "LaunchConfig",
+                    "path": "github-runners-test/ECS Windows/Auto Scaling Group/LaunchConfig",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::AutoScaling::LaunchConfiguration",
+                      "aws:cdk:cloudformation:props": {
+                        "imageId": {
+                          "Ref": "SsmParameterValueawsserviceecsoptimizedamiwindowsserver2019englishfullrecommendedimageidC96584B6F00A464EAD1953AFF4B05118Parameter"
+                        },
+                        "instanceType": "m5.large",
+                        "iamInstanceProfile": {
+                          "Ref": "ECSWindowsAutoScalingGroupInstanceProfileD8019407"
+                        },
+                        "securityGroups": [
+                          {
+                            "Fn::GetAtt": [
+                              "ECSWindowsAutoScalingGroupInstanceSecurityGroupA3DBA17A",
+                              "GroupId"
+                            ]
+                          },
+                          {
+                            "Fn::GetAtt": [
+                              "ECSWindowssecuritygroupB4EE54DA",
+                              "GroupId"
+                            ]
+                          }
+                        ],
+                        "userData": {
+                          "Fn::Base64": {
+                            "Fn::Join": [
+                              "",
+                              [
+                                "<powershell>aws ecr get-login-password --region ",
+                                {
+                                  "Ref": "AWS::Region"
+                                },
+                                " | docker login --username AWS --password-stdin ",
+                                {
+                                  "Ref": "AWS::AccountId"
+                                },
+                                ".dkr.ecr.",
+                                {
+                                  "Ref": "AWS::Region"
+                                },
+                                ".amazonaws.com\ndocker pull ",
+                                {
+                                  "Ref": "AWS::AccountId"
+                                },
+                                ".dkr.ecr.",
+                                {
+                                  "Ref": "AWS::Region"
+                                },
+                                ".",
+                                {
+                                  "Ref": "AWS::URLSuffix"
+                                },
+                                "/",
+                                {
+                                  "Fn::Select": [
+                                    0,
+                                    {
+                                      "Fn::Split": [
+                                        ":",
+                                        {
+                                          "Fn::Select": [
+                                            1,
+                                            {
+                                              "Fn::Split": [
+                                                "/",
+                                                {
+                                                  "Fn::GetAtt": [
+                                                    "WindowsImageBuilderDockerImage8672CA3E",
+                                                    "ImageUri"
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                ":latest\nRemove-Item -Recurse C:\\ProgramData\\Amazon\\ECS\\Cache\nImport-Module ECSTools\n[Environment]::SetEnvironmentVariable(\"ECS_CLUSTER\", \"",
+                                {
+                                  "Ref": "ECSWindowscluster14061F74"
+                                },
+                                "\", \"Machine\")\n[Environment]::SetEnvironmentVariable(\"ECS_ENABLE_AWSLOGS_EXECUTIONROLE_OVERRIDE\", \"true\", \"Machine\")\n[Environment]::SetEnvironmentVariable(\"ECS_AVAILABLE_LOGGING_DRIVERS\", '[\"json-file\",\"awslogs\"]', \"Machine\")\n[Environment]::SetEnvironmentVariable(\"ECS_ENABLE_TASK_IAM_ROLE\", \"true\", \"Machine\")\nInitialize-ECSAgent -Cluster '",
+                                {
+                                  "Ref": "ECSWindowscluster14061F74"
+                                },
+                                "' -EnableTaskIAMRole</powershell>"
+                              ]
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_autoscaling.CfnLaunchConfiguration",
+                      "version": "2.50.0"
+                    }
+                  },
+                  "ASG": {
+                    "id": "ASG",
+                    "path": "github-runners-test/ECS Windows/Auto Scaling Group/ASG",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::AutoScaling::AutoScalingGroup",
+                      "aws:cdk:cloudformation:props": {
+                        "maxSize": "5",
+                        "minSize": "0",
+                        "launchConfigurationName": {
+                          "Ref": "ECSWindowsAutoScalingGroupLaunchConfigAD09CF33"
+                        },
+                        "newInstancesProtectedFromScaleIn": true,
+                        "tags": [
+                          {
+                            "key": "Name",
+                            "value": "github-runners-test/ECS Windows/Auto Scaling Group",
+                            "propagateAtLaunch": true
+                          }
+                        ],
+                        "vpcZoneIdentifier": [
+                          {
+                            "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
+                          },
+                          {
+                            "Ref": "VpcPublicSubnet2Subnet691E08A3"
+                          }
+                        ]
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_autoscaling.CfnAutoScalingGroup",
+                      "version": "2.50.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_autoscaling.AutoScalingGroup",
+                  "version": "2.50.0"
+                }
+              },
+              "Capacity Provider": {
+                "id": "Capacity Provider",
+                "path": "github-runners-test/ECS Windows/Capacity Provider",
+                "children": {
+                  "Capacity Provider": {
+                    "id": "Capacity Provider",
+                    "path": "github-runners-test/ECS Windows/Capacity Provider/Capacity Provider",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::ECS::CapacityProvider",
+                      "aws:cdk:cloudformation:props": {
+                        "autoScalingGroupProvider": {
+                          "autoScalingGroupArn": {
+                            "Ref": "ECSWindowsAutoScalingGroupASG864E3AAF"
+                          },
+                          "managedScaling": {
+                            "status": "ENABLED",
+                            "targetCapacity": 100
+                          },
+                          "managedTerminationProtection": "ENABLED"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_ecs.CfnCapacityProvider",
+                      "version": "2.50.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_ecs.AsgCapacityProvider",
+                  "version": "2.50.0"
+                }
+              },
+              "logs": {
+                "id": "logs",
+                "path": "github-runners-test/ECS Windows/logs",
+                "children": {
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "github-runners-test/ECS Windows/logs/Resource",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::Logs::LogGroup",
+                      "aws:cdk:cloudformation:props": {
+                        "retentionInDays": 30
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_logs.CfnLogGroup",
+                      "version": "2.50.0"
+                    }
+                  },
+                  "logs filter": {
+                    "id": "logs filter",
+                    "path": "github-runners-test/ECS Windows/logs/logs filter",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "github-runners-test/ECS Windows/logs/logs filter/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::Logs::MetricFilter",
+                          "aws:cdk:cloudformation:props": {
+                            "filterPattern": "[..., marker = \"CDKGHA\", job = \"JOB\", done = \"DONE\", labels, status = \"Succeeded\" || status = \"SucceededWithIssues\" || status = \"Failed\" || status = \"Canceled\" || status = \"Skipped\" || status = \"Abandoned\"]",
+                            "logGroupName": {
+                              "Ref": "ECSWindowslogs83D9D352"
+                            },
+                            "metricTransformations": [
+                              {
+                                "metricNamespace": "GitHubRunners",
+                                "metricName": "JobCompleted",
+                                "metricValue": "1",
+                                "dimensions": [
+                                  {
+                                    "key": "ProviderLabels",
+                                    "value": "$labels"
+                                  },
+                                  {
+                                    "key": "Status",
+                                    "value": "$status"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_logs.CfnMetricFilter",
+                          "version": "2.50.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_logs.MetricFilter",
+                      "version": "2.50.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_logs.LogGroup",
+                  "version": "2.50.0"
+                }
+              },
+              "task": {
+                "id": "task",
+                "path": "github-runners-test/ECS Windows/task",
+                "children": {
+                  "TaskRole": {
+                    "id": "TaskRole",
+                    "path": "github-runners-test/ECS Windows/task/TaskRole",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "github-runners-test/ECS Windows/task/TaskRole/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::IAM::Role",
+                          "aws:cdk:cloudformation:props": {
+                            "assumeRolePolicyDocument": {
+                              "Statement": [
+                                {
+                                  "Action": "sts:AssumeRole",
+                                  "Effect": "Allow",
+                                  "Principal": {
+                                    "Service": "ecs-tasks.amazonaws.com"
+                                  }
+                                }
+                              ],
+                              "Version": "2012-10-17"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_iam.CfnRole",
+                          "version": "2.50.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_iam.Role",
+                      "version": "2.50.0"
+                    }
+                  },
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "github-runners-test/ECS Windows/task/Resource",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::ECS::TaskDefinition",
+                      "aws:cdk:cloudformation:props": {
+                        "containerDefinitions": [
+                          {
+                            "command": [
+                              "powershell",
+                              "-Command",
+                              "cd \\actions ;\n        if ($Env:RUNNER_VERSION -eq \"latest\") { $RunnerFlags = \"\" } else { $RunnerFlags = \"--disableupdate\" } ; \n        ./config.cmd --unattended --url \"https://${Env:GITHUB_DOMAIN}/${Env:OWNER}/${Env:REPO}\" --token \"${Env:RUNNER_TOKEN}\" --ephemeral --work _work --labels \"${Env:RUNNER_LABEL}\" $RunnerFlags --name \"${Env:RUNNER_NAME}\" ; \n        ./run.cmd ; \n        $STATUS = Select-String -Path './_diag/*.log' -Pattern 'finish job request for job [0-9a-f\\-]+ with result: (.*)' | %{$_.Matches.Groups[1].Value} | Select-Object -Last 1 ; \n        if ($STATUS) { echo \"CDKGHA JOB DONE ${Env:RUNNER_LABEL} $STATUS\" }"
+                            ],
+                            "cpu": 1024,
+                            "essential": true,
+                            "image": {
+                              "Fn::Join": [
+                                "",
+                                [
+                                  {
+                                    "Ref": "AWS::AccountId"
+                                  },
+                                  ".dkr.ecr.",
+                                  {
+                                    "Ref": "AWS::Region"
+                                  },
+                                  ".",
+                                  {
+                                    "Ref": "AWS::URLSuffix"
+                                  },
+                                  "/",
+                                  {
+                                    "Fn::Select": [
+                                      0,
+                                      {
+                                        "Fn::Split": [
+                                          ":",
+                                          {
+                                            "Fn::Select": [
+                                              1,
+                                              {
+                                                "Fn::Split": [
+                                                  "/",
+                                                  {
+                                                    "Fn::GetAtt": [
+                                                      "WindowsImageBuilderDockerImage8672CA3E",
+                                                      "ImageUri"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  ":latest"
+                                ]
+                              ]
+                            },
+                            "memory": 3500,
+                            "name": "runner",
+                            "logConfiguration": {
+                              "logDriver": "awslogs",
+                              "options": {
+                                "awslogs-group": {
+                                  "Ref": "ECSWindowslogs83D9D352"
+                                },
+                                "awslogs-stream-prefix": "runner",
+                                "awslogs-region": {
+                                  "Ref": "AWS::Region"
+                                }
+                              }
+                            }
+                          }
+                        ],
+                        "executionRoleArn": {
+                          "Fn::GetAtt": [
+                            "ECSWindowstaskExecutionRoleF164B5BF",
+                            "Arn"
+                          ]
+                        },
+                        "family": "githubrunnerstestECSWindowstask6B1D5861",
+                        "networkMode": "bridge",
+                        "requiresCompatibilities": [
+                          "EC2"
+                        ],
+                        "taskRoleArn": {
+                          "Fn::GetAtt": [
+                            "ECSWindowstaskTaskRole17C8DA48",
+                            "Arn"
+                          ]
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_ecs.CfnTaskDefinition",
+                      "version": "2.50.0"
+                    }
+                  },
+                  "runner": {
+                    "id": "runner",
+                    "path": "github-runners-test/ECS Windows/task/runner",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_ecs.ContainerDefinition",
+                      "version": "2.50.0"
+                    }
+                  },
+                  "ExecutionRole": {
+                    "id": "ExecutionRole",
+                    "path": "github-runners-test/ECS Windows/task/ExecutionRole",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "github-runners-test/ECS Windows/task/ExecutionRole/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::IAM::Role",
+                          "aws:cdk:cloudformation:props": {
+                            "assumeRolePolicyDocument": {
+                              "Statement": [
+                                {
+                                  "Action": "sts:AssumeRole",
+                                  "Effect": "Allow",
+                                  "Principal": {
+                                    "Service": "ecs-tasks.amazonaws.com"
+                                  }
+                                }
+                              ],
+                              "Version": "2012-10-17"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_iam.CfnRole",
+                          "version": "2.50.0"
+                        }
+                      },
+                      "DefaultPolicy": {
+                        "id": "DefaultPolicy",
+                        "path": "github-runners-test/ECS Windows/task/ExecutionRole/DefaultPolicy",
+                        "children": {
+                          "Resource": {
+                            "id": "Resource",
+                            "path": "github-runners-test/ECS Windows/task/ExecutionRole/DefaultPolicy/Resource",
+                            "attributes": {
+                              "aws:cdk:cloudformation:type": "AWS::IAM::Policy",
+                              "aws:cdk:cloudformation:props": {
+                                "policyDocument": {
+                                  "Statement": [
+                                    {
+                                      "Action": [
+                                        "ecr:BatchCheckLayerAvailability",
+                                        "ecr:GetDownloadUrlForLayer",
+                                        "ecr:BatchGetImage"
+                                      ],
+                                      "Effect": "Allow",
+                                      "Resource": {
+                                        "Fn::Join": [
+                                          "",
+                                          [
+                                            "arn:",
+                                            {
+                                              "Ref": "AWS::Partition"
+                                            },
+                                            ":ecr:",
+                                            {
+                                              "Ref": "AWS::Region"
+                                            },
+                                            ":",
+                                            {
+                                              "Ref": "AWS::AccountId"
+                                            },
+                                            ":repository/",
+                                            {
+                                              "Fn::Select": [
+                                                0,
+                                                {
+                                                  "Fn::Split": [
+                                                    ":",
+                                                    {
+                                                      "Fn::Select": [
+                                                        1,
+                                                        {
+                                                          "Fn::Split": [
+                                                            "/",
+                                                            {
+                                                              "Fn::GetAtt": [
+                                                                "WindowsImageBuilderDockerImage8672CA3E",
+                                                                "ImageUri"
+                                                              ]
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "Action": "ecr:GetAuthorizationToken",
+                                      "Effect": "Allow",
+                                      "Resource": "*"
+                                    },
+                                    {
+                                      "Action": [
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                      ],
+                                      "Effect": "Allow",
+                                      "Resource": {
+                                        "Fn::GetAtt": [
+                                          "ECSWindowslogs83D9D352",
+                                          "Arn"
+                                        ]
+                                      }
+                                    }
+                                  ],
+                                  "Version": "2012-10-17"
+                                },
+                                "policyName": "ECSWindowstaskExecutionRoleDefaultPolicyA46C9687",
+                                "roles": [
+                                  {
+                                    "Ref": "ECSWindowstaskExecutionRoleF164B5BF"
+                                  }
+                                ]
+                              }
+                            },
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
+                              "version": "2.50.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_iam.Policy",
+                          "version": "2.50.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_iam.Role",
+                      "version": "2.50.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_ecs.Ec2TaskDefinition",
+                  "version": "2.50.0"
+                }
+              },
+              "ecs, windows, x64": {
+                "id": "ecs, windows, x64",
+                "path": "github-runners-test/ECS Windows/ecs, windows, x64",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_stepfunctions_tasks.EcsRunTask",
+                  "version": "2.50.0"
+                }
+              }
+            },
+            "constructInfo": {
+              "fqn": "constructs.Construct",
+              "version": "10.0.5"
+            }
+          },
+          "SsmParameterValue:--aws--service--ecs--optimized-ami--windows_server--2019--english--full--recommended--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118.Parameter": {
+            "id": "SsmParameterValue:--aws--service--ecs--optimized-ami--windows_server--2019--english--full--recommended--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118.Parameter",
+            "path": "github-runners-test/SsmParameterValue:--aws--service--ecs--optimized-ami--windows_server--2019--english--full--recommended--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118.Parameter",
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.CfnParameter",
+              "version": "2.50.0"
+            }
+          },
+          "SsmParameterValue:--aws--service--ecs--optimized-ami--windows_server--2019--english--full--recommended--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118": {
+            "id": "SsmParameterValue:--aws--service--ecs--optimized-ami--windows_server--2019--english--full--recommended--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118",
+            "path": "github-runners-test/SsmParameterValue:--aws--service--ecs--optimized-ami--windows_server--2019--english--full--recommended--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118",
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.Resource",
+              "version": "2.50.0"
+            }
+          },
           "Lambda": {
             "id": "Lambda",
             "path": "github-runners-test/Lambda",
@@ -15833,6 +18394,441 @@
                                       }
                                     },
                                     {
+                                      "Action": "ecs:RunTask",
+                                      "Effect": "Allow",
+                                      "Resource": {
+                                        "Fn::Join": [
+                                          "",
+                                          [
+                                            "arn:",
+                                            {
+                                              "Fn::Select": [
+                                                1,
+                                                {
+                                                  "Fn::Split": [
+                                                    ":",
+                                                    {
+                                                      "Ref": "ECStask8F0DD550"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            ":",
+                                            {
+                                              "Fn::Select": [
+                                                2,
+                                                {
+                                                  "Fn::Split": [
+                                                    ":",
+                                                    {
+                                                      "Ref": "ECStask8F0DD550"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            ":",
+                                            {
+                                              "Fn::Select": [
+                                                3,
+                                                {
+                                                  "Fn::Split": [
+                                                    ":",
+                                                    {
+                                                      "Ref": "ECStask8F0DD550"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            ":",
+                                            {
+                                              "Fn::Select": [
+                                                4,
+                                                {
+                                                  "Fn::Split": [
+                                                    ":",
+                                                    {
+                                                      "Ref": "ECStask8F0DD550"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            ":",
+                                            {
+                                              "Fn::Select": [
+                                                0,
+                                                {
+                                                  "Fn::Split": [
+                                                    "/",
+                                                    {
+                                                      "Fn::Select": [
+                                                        5,
+                                                        {
+                                                          "Fn::Split": [
+                                                            ":",
+                                                            {
+                                                              "Ref": "ECStask8F0DD550"
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "/",
+                                            {
+                                              "Fn::Select": [
+                                                1,
+                                                {
+                                                  "Fn::Split": [
+                                                    "/",
+                                                    {
+                                                      "Fn::Select": [
+                                                        5,
+                                                        {
+                                                          "Fn::Split": [
+                                                            ":",
+                                                            {
+                                                              "Ref": "ECStask8F0DD550"
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "Action": [
+                                        "ecs:StopTask",
+                                        "ecs:DescribeTasks"
+                                      ],
+                                      "Effect": "Allow",
+                                      "Resource": "*"
+                                    },
+                                    {
+                                      "Action": "iam:PassRole",
+                                      "Effect": "Allow",
+                                      "Resource": [
+                                        {
+                                          "Fn::GetAtt": [
+                                            "ECStaskTaskRoleFE831ECD",
+                                            "Arn"
+                                          ]
+                                        },
+                                        {
+                                          "Fn::GetAtt": [
+                                            "ECStaskExecutionRole1A6D19A5",
+                                            "Arn"
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Action": [
+                                        "events:PutTargets",
+                                        "events:PutRule",
+                                        "events:DescribeRule"
+                                      ],
+                                      "Effect": "Allow",
+                                      "Resource": {
+                                        "Fn::Join": [
+                                          "",
+                                          [
+                                            "arn:",
+                                            {
+                                              "Ref": "AWS::Partition"
+                                            },
+                                            ":events:",
+                                            {
+                                              "Ref": "AWS::Region"
+                                            },
+                                            ":",
+                                            {
+                                              "Ref": "AWS::AccountId"
+                                            },
+                                            ":rule/StepFunctionsGetEventsForECSTaskRule"
+                                          ]
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "Action": "ecs:RunTask",
+                                      "Effect": "Allow",
+                                      "Resource": {
+                                        "Fn::Join": [
+                                          "",
+                                          [
+                                            "arn:",
+                                            {
+                                              "Fn::Select": [
+                                                1,
+                                                {
+                                                  "Fn::Split": [
+                                                    ":",
+                                                    {
+                                                      "Ref": "ECSARM64task27EB8443"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            ":",
+                                            {
+                                              "Fn::Select": [
+                                                2,
+                                                {
+                                                  "Fn::Split": [
+                                                    ":",
+                                                    {
+                                                      "Ref": "ECSARM64task27EB8443"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            ":",
+                                            {
+                                              "Fn::Select": [
+                                                3,
+                                                {
+                                                  "Fn::Split": [
+                                                    ":",
+                                                    {
+                                                      "Ref": "ECSARM64task27EB8443"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            ":",
+                                            {
+                                              "Fn::Select": [
+                                                4,
+                                                {
+                                                  "Fn::Split": [
+                                                    ":",
+                                                    {
+                                                      "Ref": "ECSARM64task27EB8443"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            ":",
+                                            {
+                                              "Fn::Select": [
+                                                0,
+                                                {
+                                                  "Fn::Split": [
+                                                    "/",
+                                                    {
+                                                      "Fn::Select": [
+                                                        5,
+                                                        {
+                                                          "Fn::Split": [
+                                                            ":",
+                                                            {
+                                                              "Ref": "ECSARM64task27EB8443"
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "/",
+                                            {
+                                              "Fn::Select": [
+                                                1,
+                                                {
+                                                  "Fn::Split": [
+                                                    "/",
+                                                    {
+                                                      "Fn::Select": [
+                                                        5,
+                                                        {
+                                                          "Fn::Split": [
+                                                            ":",
+                                                            {
+                                                              "Ref": "ECSARM64task27EB8443"
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "Action": "iam:PassRole",
+                                      "Effect": "Allow",
+                                      "Resource": [
+                                        {
+                                          "Fn::GetAtt": [
+                                            "ECSARM64taskTaskRole23B1CB4E",
+                                            "Arn"
+                                          ]
+                                        },
+                                        {
+                                          "Fn::GetAtt": [
+                                            "ECSARM64taskExecutionRoleBF2AE76F",
+                                            "Arn"
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Action": "ecs:RunTask",
+                                      "Effect": "Allow",
+                                      "Resource": {
+                                        "Fn::Join": [
+                                          "",
+                                          [
+                                            "arn:",
+                                            {
+                                              "Fn::Select": [
+                                                1,
+                                                {
+                                                  "Fn::Split": [
+                                                    ":",
+                                                    {
+                                                      "Ref": "ECSWindowstask73A31B6C"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            ":",
+                                            {
+                                              "Fn::Select": [
+                                                2,
+                                                {
+                                                  "Fn::Split": [
+                                                    ":",
+                                                    {
+                                                      "Ref": "ECSWindowstask73A31B6C"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            ":",
+                                            {
+                                              "Fn::Select": [
+                                                3,
+                                                {
+                                                  "Fn::Split": [
+                                                    ":",
+                                                    {
+                                                      "Ref": "ECSWindowstask73A31B6C"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            ":",
+                                            {
+                                              "Fn::Select": [
+                                                4,
+                                                {
+                                                  "Fn::Split": [
+                                                    ":",
+                                                    {
+                                                      "Ref": "ECSWindowstask73A31B6C"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            ":",
+                                            {
+                                              "Fn::Select": [
+                                                0,
+                                                {
+                                                  "Fn::Split": [
+                                                    "/",
+                                                    {
+                                                      "Fn::Select": [
+                                                        5,
+                                                        {
+                                                          "Fn::Split": [
+                                                            ":",
+                                                            {
+                                                              "Ref": "ECSWindowstask73A31B6C"
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "/",
+                                            {
+                                              "Fn::Select": [
+                                                1,
+                                                {
+                                                  "Fn::Split": [
+                                                    "/",
+                                                    {
+                                                      "Fn::Select": [
+                                                        5,
+                                                        {
+                                                          "Fn::Split": [
+                                                            ":",
+                                                            {
+                                                              "Ref": "ECSWindowstask73A31B6C"
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "Action": "iam:PassRole",
+                                      "Effect": "Allow",
+                                      "Resource": [
+                                        {
+                                          "Fn::GetAtt": [
+                                            "ECSWindowstaskTaskRole17C8DA48",
+                                            "Arn"
+                                          ]
+                                        },
+                                        {
+                                          "Fn::GetAtt": [
+                                            "ECSWindowstaskExecutionRoleF164B5BF",
+                                            "Arn"
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
                                       "Action": "lambda:InvokeFunction",
                                       "Effect": "Allow",
                                       "Resource": [
@@ -16000,14 +18996,6 @@
                                       }
                                     },
                                     {
-                                      "Action": [
-                                        "ecs:StopTask",
-                                        "ecs:DescribeTasks"
-                                      ],
-                                      "Effect": "Allow",
-                                      "Resource": "*"
-                                    },
-                                    {
                                       "Action": "iam:PassRole",
                                       "Effect": "Allow",
                                       "Resource": [
@@ -16024,34 +19012,6 @@
                                           ]
                                         }
                                       ]
-                                    },
-                                    {
-                                      "Action": [
-                                        "events:PutTargets",
-                                        "events:PutRule",
-                                        "events:DescribeRule"
-                                      ],
-                                      "Effect": "Allow",
-                                      "Resource": {
-                                        "Fn::Join": [
-                                          "",
-                                          [
-                                            "arn:",
-                                            {
-                                              "Ref": "AWS::Partition"
-                                            },
-                                            ":events:",
-                                            {
-                                              "Ref": "AWS::Region"
-                                            },
-                                            ":",
-                                            {
-                                              "Ref": "AWS::AccountId"
-                                            },
-                                            ":rule/StepFunctionsGetEventsForECSTaskRule"
-                                          ]
-                                        ]
-                                      }
                                     },
                                     {
                                       "Action": "ecs:RunTask",
@@ -16735,7 +19695,7 @@
                                   "Arn"
                                 ]
                               },
-                              "\"},\"Error Catcher\":{\"Type\":\"Parallel\",\"ResultPath\":\"$.result\",\"End\":true,\"Catch\":[{\"ErrorEquals\":[\"States.ALL\"],\"ResultPath\":\"$.error\",\"Next\":\"Delete Runner\"}],\"Branches\":[{\"StartAt\":\"Choose provider\",\"States\":{\"Choose provider\":{\"Type\":\"Choice\",\"Choices\":[{\"And\":[{\"Variable\":\"$.labels.codebuild-x64\",\"IsPresent\":true}],\"Next\":\"codebuild-x64\"},{\"And\":[{\"Variable\":\"$.labels.codebuild\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.arm64\",\"IsPresent\":true}],\"Next\":\"codebuild, linux, arm64\"},{\"And\":[{\"Variable\":\"$.labels.codebuild\",\"IsPresent\":true},{\"Variable\":\"$.labels.windows\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"codebuild, windows, x64\"},{\"And\":[{\"Variable\":\"$.labels.lambda\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"lambda, x64\"},{\"And\":[{\"Variable\":\"$.labels.lambda\",\"IsPresent\":true},{\"Variable\":\"$.labels.arm64\",\"IsPresent\":true}],\"Next\":\"lambda, arm64\"},{\"And\":[{\"Variable\":\"$.labels.fargate\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"fargate, linux, x64\"},{\"And\":[{\"Variable\":\"$.labels.fargate-spot\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"fargate-spot, linux, x64\"},{\"And\":[{\"Variable\":\"$.labels.fargate\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.arm64\",\"IsPresent\":true}],\"Next\":\"fargate, linux, arm64\"},{\"And\":[{\"Variable\":\"$.labels.fargate-spot\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.arm64\",\"IsPresent\":true}],\"Next\":\"fargate-spot, linux, arm64\"},{\"And\":[{\"Variable\":\"$.labels.fargate\",\"IsPresent\":true},{\"Variable\":\"$.labels.windows\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"fargate, windows, x64\"},{\"And\":[{\"Variable\":\"$.labels.ec2\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"ec2, linux, x64 data\"},{\"And\":[{\"Variable\":\"$.labels.ec2-spot\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"ec2-spot, linux, x64 data\"},{\"And\":[{\"Variable\":\"$.labels.ec2\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.arm64\",\"IsPresent\":true}],\"Next\":\"ec2, linux, arm64 data\"},{\"And\":[{\"Variable\":\"$.labels.ec2\",\"IsPresent\":true},{\"Variable\":\"$.labels.windows\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"ec2, windows, x64 data\"}],\"Default\":\"Unknown label\"},\"Unknown label\":{\"Type\":\"Succeed\"},\"codebuild-x64\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"CodeBuild.CodeBuildException\",\"CodeBuild.AccountLimitExceededException\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Type\":\"Task\",\"Resource\":\"arn:",
+                              "\"},\"Error Catcher\":{\"Type\":\"Parallel\",\"ResultPath\":\"$.result\",\"End\":true,\"Catch\":[{\"ErrorEquals\":[\"States.ALL\"],\"ResultPath\":\"$.error\",\"Next\":\"Delete Runner\"}],\"Branches\":[{\"StartAt\":\"Choose provider\",\"States\":{\"Choose provider\":{\"Type\":\"Choice\",\"Choices\":[{\"And\":[{\"Variable\":\"$.labels.codebuild-x64\",\"IsPresent\":true}],\"Next\":\"codebuild-x64\"},{\"And\":[{\"Variable\":\"$.labels.codebuild\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.arm64\",\"IsPresent\":true}],\"Next\":\"codebuild, linux, arm64\"},{\"And\":[{\"Variable\":\"$.labels.codebuild\",\"IsPresent\":true},{\"Variable\":\"$.labels.windows\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"codebuild, windows, x64\"},{\"And\":[{\"Variable\":\"$.labels.ecs\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"ecs, linux, x64\"},{\"And\":[{\"Variable\":\"$.labels.ecs\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.arm64\",\"IsPresent\":true}],\"Next\":\"ecs, linux, arm64\"},{\"And\":[{\"Variable\":\"$.labels.ecs\",\"IsPresent\":true},{\"Variable\":\"$.labels.windows\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"ecs, windows, x64\"},{\"And\":[{\"Variable\":\"$.labels.lambda\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"lambda, x64\"},{\"And\":[{\"Variable\":\"$.labels.lambda\",\"IsPresent\":true},{\"Variable\":\"$.labels.arm64\",\"IsPresent\":true}],\"Next\":\"lambda, arm64\"},{\"And\":[{\"Variable\":\"$.labels.fargate\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"fargate, linux, x64\"},{\"And\":[{\"Variable\":\"$.labels.fargate-spot\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"fargate-spot, linux, x64\"},{\"And\":[{\"Variable\":\"$.labels.fargate\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.arm64\",\"IsPresent\":true}],\"Next\":\"fargate, linux, arm64\"},{\"And\":[{\"Variable\":\"$.labels.fargate-spot\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.arm64\",\"IsPresent\":true}],\"Next\":\"fargate-spot, linux, arm64\"},{\"And\":[{\"Variable\":\"$.labels.fargate\",\"IsPresent\":true},{\"Variable\":\"$.labels.windows\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"fargate, windows, x64\"},{\"And\":[{\"Variable\":\"$.labels.ec2\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"ec2, linux, x64 data\"},{\"And\":[{\"Variable\":\"$.labels.ec2-spot\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"ec2-spot, linux, x64 data\"},{\"And\":[{\"Variable\":\"$.labels.ec2\",\"IsPresent\":true},{\"Variable\":\"$.labels.linux\",\"IsPresent\":true},{\"Variable\":\"$.labels.arm64\",\"IsPresent\":true}],\"Next\":\"ec2, linux, arm64 data\"},{\"And\":[{\"Variable\":\"$.labels.ec2\",\"IsPresent\":true},{\"Variable\":\"$.labels.windows\",\"IsPresent\":true},{\"Variable\":\"$.labels.x64\",\"IsPresent\":true}],\"Next\":\"ec2, windows, x64 data\"}],\"Default\":\"Unknown label\"},\"Unknown label\":{\"Type\":\"Succeed\"},\"codebuild-x64\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"CodeBuild.CodeBuildException\",\"CodeBuild.AccountLimitExceededException\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Type\":\"Task\",\"Resource\":\"arn:",
                               {
                                 "Ref": "AWS::Partition"
                               },
@@ -16759,7 +19719,52 @@
                               {
                                 "Ref": "CodeBuildWindowsCodeBuildC39F35C1"
                               },
-                              "\",\"EnvironmentVariablesOverride\":[{\"Name\":\"RUNNER_TOKEN\",\"Type\":\"PLAINTEXT\",\"Value.$\":\"$.runner.token\"},{\"Name\":\"RUNNER_NAME\",\"Type\":\"PLAINTEXT\",\"Value.$\":\"$$.Execution.Name\"},{\"Name\":\"RUNNER_LABEL\",\"Type\":\"PLAINTEXT\",\"Value\":\"codebuild,windows,x64\"},{\"Name\":\"GITHUB_DOMAIN\",\"Type\":\"PLAINTEXT\",\"Value.$\":\"$.runner.domain\"},{\"Name\":\"OWNER\",\"Type\":\"PLAINTEXT\",\"Value.$\":\"$.owner\"},{\"Name\":\"REPO\",\"Type\":\"PLAINTEXT\",\"Value.$\":\"$.repo\"}]}},\"lambda, x64\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2},{\"ErrorEquals\":[\"Lambda.LambdaException\",\"Lambda.Ec2ThrottledException\",\"Lambda.Ec2UnexpectedException\",\"Lambda.EniLimitReachedException\",\"Lambda.TooManyRequestsException\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Type\":\"Task\",\"Resource\":\"arn:",
+                              "\",\"EnvironmentVariablesOverride\":[{\"Name\":\"RUNNER_TOKEN\",\"Type\":\"PLAINTEXT\",\"Value.$\":\"$.runner.token\"},{\"Name\":\"RUNNER_NAME\",\"Type\":\"PLAINTEXT\",\"Value.$\":\"$$.Execution.Name\"},{\"Name\":\"RUNNER_LABEL\",\"Type\":\"PLAINTEXT\",\"Value\":\"codebuild,windows,x64\"},{\"Name\":\"GITHUB_DOMAIN\",\"Type\":\"PLAINTEXT\",\"Value.$\":\"$.runner.domain\"},{\"Name\":\"OWNER\",\"Type\":\"PLAINTEXT\",\"Value.$\":\"$.owner\"},{\"Name\":\"REPO\",\"Type\":\"PLAINTEXT\",\"Value.$\":\"$.repo\"}]}},\"ecs, linux, x64\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Ecs.EcsException\",\"Ecs.LimitExceededException\",\"Ecs.UpdateInProgressException\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Type\":\"Task\",\"Resource\":\"arn:",
+                              {
+                                "Ref": "AWS::Partition"
+                              },
+                              ":states:::ecs:runTask.sync\",\"Parameters\":{\"Cluster\":\"",
+                              {
+                                "Fn::GetAtt": [
+                                  "ECScluster20BC0B82",
+                                  "Arn"
+                                ]
+                              },
+                              "\",\"TaskDefinition\":\"githubrunnerstestECStaskCE74CC84\",\"Overrides\":{\"ContainerOverrides\":[{\"Name\":\"runner\",\"Environment\":[{\"Name\":\"RUNNER_TOKEN\",\"Value.$\":\"$.runner.token\"},{\"Name\":\"RUNNER_NAME\",\"Value.$\":\"$$.Execution.Name\"},{\"Name\":\"RUNNER_LABEL\",\"Value\":\"ecs,linux,x64\"},{\"Name\":\"GITHUB_DOMAIN\",\"Value.$\":\"$.runner.domain\"},{\"Name\":\"OWNER\",\"Value.$\":\"$.owner\"},{\"Name\":\"REPO\",\"Value.$\":\"$.repo\"}]}]},\"PropagateTags\":\"TASK_DEFINITION\",\"CapacityProviderStrategy\":[{\"CapacityProvider\":\"",
+                              {
+                                "Ref": "ECSCapacityProviderABF1B146"
+                              },
+                              "\"}]}},\"ecs, linux, arm64\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Ecs.EcsException\",\"Ecs.LimitExceededException\",\"Ecs.UpdateInProgressException\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Type\":\"Task\",\"Resource\":\"arn:",
+                              {
+                                "Ref": "AWS::Partition"
+                              },
+                              ":states:::ecs:runTask.sync\",\"Parameters\":{\"Cluster\":\"",
+                              {
+                                "Fn::GetAtt": [
+                                  "ECSARM64cluster4ECAA083",
+                                  "Arn"
+                                ]
+                              },
+                              "\",\"TaskDefinition\":\"githubrunnerstestECSARM64taskE94E43A3\",\"Overrides\":{\"ContainerOverrides\":[{\"Name\":\"runner\",\"Environment\":[{\"Name\":\"RUNNER_TOKEN\",\"Value.$\":\"$.runner.token\"},{\"Name\":\"RUNNER_NAME\",\"Value.$\":\"$$.Execution.Name\"},{\"Name\":\"RUNNER_LABEL\",\"Value\":\"ecs,linux,arm64\"},{\"Name\":\"GITHUB_DOMAIN\",\"Value.$\":\"$.runner.domain\"},{\"Name\":\"OWNER\",\"Value.$\":\"$.owner\"},{\"Name\":\"REPO\",\"Value.$\":\"$.repo\"}]}]},\"PropagateTags\":\"TASK_DEFINITION\",\"CapacityProviderStrategy\":[{\"CapacityProvider\":\"",
+                              {
+                                "Ref": "ECSARM64CapacityProvider8627FEF9"
+                              },
+                              "\"}]}},\"ecs, windows, x64\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Ecs.EcsException\",\"Ecs.LimitExceededException\",\"Ecs.UpdateInProgressException\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Type\":\"Task\",\"Resource\":\"arn:",
+                              {
+                                "Ref": "AWS::Partition"
+                              },
+                              ":states:::ecs:runTask.sync\",\"Parameters\":{\"Cluster\":\"",
+                              {
+                                "Fn::GetAtt": [
+                                  "ECSWindowscluster14061F74",
+                                  "Arn"
+                                ]
+                              },
+                              "\",\"TaskDefinition\":\"githubrunnerstestECSWindowstask6B1D5861\",\"Overrides\":{\"ContainerOverrides\":[{\"Name\":\"runner\",\"Environment\":[{\"Name\":\"RUNNER_TOKEN\",\"Value.$\":\"$.runner.token\"},{\"Name\":\"RUNNER_NAME\",\"Value.$\":\"$$.Execution.Name\"},{\"Name\":\"RUNNER_LABEL\",\"Value\":\"ecs,windows,x64\"},{\"Name\":\"GITHUB_DOMAIN\",\"Value.$\":\"$.runner.domain\"},{\"Name\":\"OWNER\",\"Value.$\":\"$.owner\"},{\"Name\":\"REPO\",\"Value.$\":\"$.repo\"}]}]},\"PropagateTags\":\"TASK_DEFINITION\",\"CapacityProviderStrategy\":[{\"CapacityProvider\":\"",
+                              {
+                                "Ref": "ECSWindowsCapacityProvider8F8896A5"
+                              },
+                              "\"}]}},\"lambda, x64\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2},{\"ErrorEquals\":[\"Lambda.LambdaException\",\"Lambda.Ec2ThrottledException\",\"Lambda.Ec2UnexpectedException\",\"Lambda.EniLimitReachedException\",\"Lambda.TooManyRequestsException\"],\"IntervalSeconds\":60,\"MaxAttempts\":10,\"BackoffRate\":1.3}],\"Type\":\"Task\",\"Resource\":\"arn:",
                               {
                                 "Ref": "AWS::Partition"
                               },

--- a/test/default.integ.ts
+++ b/test/default.integ.ts
@@ -16,6 +16,7 @@ import {
   Os,
   RunnerImageComponent,
 } from '../src';
+import { EcsRunnerProvider } from '../src/providers/ecs';
 
 const app = new cdk.App();
 const stack = new cdk.Stack(app, 'github-runners-test');
@@ -135,6 +136,21 @@ new GitHubRunners(stack, 'runners', {
       labels: ['codebuild', 'windows', 'x64'],
       computeType: codebuild.ComputeType.MEDIUM,
       imageBuilder: windowsImageBuilder,
+    }),
+    new EcsRunnerProvider(stack, 'ECS', {
+      labels: ['ecs', 'linux', 'x64'],
+      imageBuilder: codeBuildImageBuilder, // codebuild has dind
+      vpc,
+    }),
+    new EcsRunnerProvider(stack, 'ECS ARM64', {
+      labels: ['ecs', 'linux', 'arm64'],
+      imageBuilder: codeBuildArm64ImageBuilder, // codebuild has dind
+      vpc,
+    }),
+    new EcsRunnerProvider(stack, 'ECS Windows', {
+      labels: ['ecs', 'windows', 'x64'],
+      imageBuilder: windowsImageBuilder,
+      vpc,
     }),
     new LambdaRunnerProvider(stack, 'Lambda', {
       labels: ['lambda', 'x64'],


### PR DESCRIPTION
EC2 backed ECS runner provider gives the user more control over the underlaying resources. The number of EC2 instances that can run runner containers and their auto-scaling can be adjusted. By default it scales down to zero, but `minInstances` can be set to a higher number to get faster runner start times.

Default auto-scaling behavior leaves instances around for 15 minutes after the last job finished.

Fixes #191
Related #260