### PR TITLE
fix: Require IMDSv2 in the AWS Image Builder and ECS instances

### DIFF
--- a/src/providers/ecs.ts
+++ b/src/providers/ecs.ts
@@ -419,7 +419,10 @@ export class EcsRunnerProvider extends BaseProvider implements IRunnerProvider {
     }
 
     if (this.image.os.is(Os.WINDOWS)) {
-      return ecs.EcsOptimizedImage.windows(ecs.WindowsOptimizedVersion.SERVER_2019);
+      // ancient AMI from 2019 with no IMSDv2 support 🤦‍♂️ -- return ecs.EcsOptimizedImage.windows(ecs.WindowsOptimizedVersion.SERVER_2019);
+      return ec2.MachineImage.fromSsmParameter('/aws/service/ami-windows-latest/Windows_Server-2019-English-Full-ECS_Optimized/image_id', {
+        os: ec2.OperatingSystemType.WINDOWS,
+      });
     }
 
     throw new Error(`Unable to find AMI for ECS instances for ${this.image.os.name}/${this.image.architecture.name}`);

--- a/src/providers/ecs.ts
+++ b/src/providers/ecs.ts
@@ -338,6 +338,7 @@ export class EcsRunnerProvider extends BaseProvider implements IRunnerProvider {
           },
         ] : undefined,
         spotPrice: props?.spotMaxPrice,
+        requireImdsv2: true,
       }),
       spotInstanceDraining: false, // waste of money to restart jobs as the restarted job won't have a token
     });

--- a/src/providers/image-builders/aws-image-builder/builder.ts
+++ b/src/providers/image-builders/aws-image-builder/builder.ts
@@ -532,7 +532,9 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
       return this.boundAmi;
     }
 
-    const launchTemplate = new ec2.LaunchTemplate(this, 'Launch template');
+    const launchTemplate = new ec2.LaunchTemplate(this, 'Launch template', {
+      requireImdsv2: true,
+    });
 
     const stackName = cdk.Stack.of(this).stackName;
     const builderName = this.node.path;

--- a/src/providers/image-builders/aws-image-builder/builder.ts
+++ b/src/providers/image-builders/aws-image-builder/builder.ts
@@ -452,6 +452,9 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
       subnetId: this.vpc?.selectSubnets(this.subnetSelection).subnetIds[0],
       securityGroupIds: this.securityGroups?.map(sg => sg.securityGroupId),
       instanceTypes: [this.instanceType.toString()],
+      instanceMetadataOptions: {
+        httpTokens: 'required',
+      },
       instanceProfileName: new iam.CfnInstanceProfile(this, 'Instance Profile', {
         roles: [
           this.role.roleName,

--- a/src/providers/image-builders/aws-image-builder/deprecated/ami.ts
+++ b/src/providers/image-builders/aws-image-builder/deprecated/ami.ts
@@ -254,7 +254,9 @@ export class AmiBuilder extends ImageBuilderBase {
       return this.boundAmi;
     }
 
-    const launchTemplate = new ec2.LaunchTemplate(this, 'Launch template');
+    const launchTemplate = new ec2.LaunchTemplate(this, 'Launch template', {
+      requireImdsv2: true,
+    });
 
     const stackName = cdk.Stack.of(this).stackName;
     const builderName = this.node.path;

--- a/src/providers/image-builders/aws-image-builder/deprecated/common.ts
+++ b/src/providers/image-builders/aws-image-builder/deprecated/common.ts
@@ -110,6 +110,9 @@ export abstract class ImageBuilderBase extends Construct implements IRunnerImage
       subnetId: this.subnetId,
       securityGroupIds: this.securityGroups.map(sg => sg.securityGroupId),
       instanceTypes: [this.instanceType.toString()],
+      instanceMetadataOptions: {
+        httpTokens: 'required',
+      },
       instanceProfileName: new iam.CfnInstanceProfile(this, 'Instance Profile', {
         roles: [
           role.roleName,

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -183,7 +183,7 @@
         }
       }
     },
-    "7d08eb5bcf45836d6ce1e0bdb72021da83a237afbe06781a523bb3429bbb1c52": {
+    "d94641c84bbe137207d7e179fb369c348e57e55714ff97c5e090786d06185173": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -191,7 +191,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "7d08eb5bcf45836d6ce1e0bdb72021da83a237afbe06781a523bb3429bbb1c52.json",
+          "objectKey": "d94641c84bbe137207d7e179fb369c348e57e55714ff97c5e090786d06185173.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -183,7 +183,7 @@
         }
       }
     },
-    "d94641c84bbe137207d7e179fb369c348e57e55714ff97c5e090786d06185173": {
+    "d683e78c33c4de0163529ce1ae47b62cbdea581ddc99af53dff5e914efc37944": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -191,7 +191,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "d94641c84bbe137207d7e179fb369c348e57e55714ff97c5e090786d06185173.json",
+          "objectKey": "d683e78c33c4de0163529ce1ae47b62cbdea581ddc99af53dff5e914efc37944.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -2824,6 +2824,9 @@
      "Ref": "WindowsImageBuilderInstanceProfileBFCCEC08"
     },
     "Name": "github-runners-test-WindowsImageBuilder-18C0E1B2",
+    "InstanceMetadataOptions": {
+     "HttpTokens": "required"
+    },
     "InstanceTypes": [
      "m5.large"
     ],
@@ -3112,6 +3115,9 @@
    "Type": "AWS::EC2::LaunchTemplate",
    "Properties": {
     "LaunchTemplateData": {
+     "MetadataOptions": {
+      "HttpTokens": "required"
+     },
      "TagSpecifications": [
       {
        "ResourceType": "instance",
@@ -3868,6 +3874,9 @@
      "Ref": "AMILinuxBuilderInstanceProfile3CA638BE"
     },
     "Name": "github-runners-test-AMILinuxBuilder-67243E6D",
+    "InstanceMetadataOptions": {
+     "HttpTokens": "required"
+    },
     "InstanceTypes": [
      "m5.large"
     ],
@@ -6008,6 +6017,9 @@
    "Type": "AWS::EC2::LaunchTemplate",
    "Properties": {
     "LaunchTemplateData": {
+     "MetadataOptions": {
+      "HttpTokens": "required"
+     },
      "TagSpecifications": [
       {
        "ResourceType": "instance",
@@ -6764,6 +6776,9 @@
      "Ref": "AMILinuxarm64BuilderInstanceProfileCE3B6B09"
     },
     "Name": "github-runners-test-AMILinuxarm64Builder-3F449283",
+    "InstanceMetadataOptions": {
+     "HttpTokens": "required"
+    },
     "InstanceTypes": [
      "m6g.large"
     ],
@@ -7054,6 +7069,9 @@
    "Type": "AWS::EC2::LaunchTemplate",
    "Properties": {
     "LaunchTemplateData": {
+     "MetadataOptions": {
+      "HttpTokens": "required"
+     },
      "TagSpecifications": [
       {
        "ResourceType": "instance",
@@ -7807,6 +7825,9 @@
      "Ref": "WindowsEC2BuilderInstanceProfileA8DBA763"
     },
     "Name": "github-runners-test-WindowsEC2Builder-5FAF8285",
+    "InstanceMetadataOptions": {
+     "HttpTokens": "required"
+    },
     "InstanceTypes": [
      "m5.large"
     ],
@@ -9278,6 +9299,9 @@
     "IamInstanceProfile": {
      "Ref": "ECSAutoScalingGroupInstanceProfile288AC654"
     },
+    "MetadataOptions": {
+     "HttpTokens": "required"
+    },
     "SecurityGroups": [
      {
       "Fn::GetAtt": [
@@ -9828,6 +9852,9 @@
     "InstanceType": "m6g.large",
     "IamInstanceProfile": {
      "Ref": "ECSARM64AutoScalingGroupInstanceProfile768645E6"
+    },
+    "MetadataOptions": {
+     "HttpTokens": "required"
     },
     "SecurityGroups": [
      {
@@ -10422,6 +10449,9 @@
     "InstanceType": "m5.large",
     "IamInstanceProfile": {
      "Ref": "ECSWindowsAutoScalingGroupInstanceProfileD8019407"
+    },
+    "MetadataOptions": {
+     "HttpTokens": "required"
     },
     "SecurityGroups": [
      {

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -10444,7 +10444,7 @@
    "Type": "AWS::AutoScaling::LaunchConfiguration",
    "Properties": {
     "ImageId": {
-     "Ref": "SsmParameterValueawsserviceecsoptimizedamiwindowsserver2019englishfullrecommendedimageidC96584B6F00A464EAD1953AFF4B05118Parameter"
+     "Ref": "SsmParameterValueawsserviceamiwindowslatestWindowsServer2019EnglishFullECSOptimizedimageidC96584B6F00A464EAD1953AFF4B05118Parameter"
     },
     "InstanceType": "m5.large",
     "IamInstanceProfile": {
@@ -17643,9 +17643,9 @@
    "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
    "Default": "/aws/service/ecs/optimized-ami/amazon-linux-2/arm64/recommended/image_id"
   },
-  "SsmParameterValueawsserviceecsoptimizedamiwindowsserver2019englishfullrecommendedimageidC96584B6F00A464EAD1953AFF4B05118Parameter": {
+  "SsmParameterValueawsserviceamiwindowslatestWindowsServer2019EnglishFullECSOptimizedimageidC96584B6F00A464EAD1953AFF4B05118Parameter": {
    "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
-   "Default": "/aws/service/ecs/optimized-ami/windows_server/2019/english/full/recommended/image_id"
+   "Default": "/aws/service/ami-windows-latest/Windows_Server-2019-English-Full-ECS_Optimized/image_id"
   },
   "BootstrapVersion": {
    "Type": "AWS::SSM::Parameter::Value<String>",

--- a/test/default.integ.snapshot/manifest.json
+++ b/test/default.integ.snapshot/manifest.json
@@ -23,7 +23,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/d94641c84bbe137207d7e179fb369c348e57e55714ff97c5e090786d06185173.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/d683e78c33c4de0163529ce1ae47b62cbdea581ddc99af53dff5e914efc37944.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [
@@ -1713,10 +1713,10 @@
             "data": "ECSWindowstaskExecutionRoleDefaultPolicyA46C9687"
           }
         ],
-        "/github-runners-test/SsmParameterValue:--aws--service--ecs--optimized-ami--windows_server--2019--english--full--recommended--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118.Parameter": [
+        "/github-runners-test/SsmParameterValue:--aws--service--ami-windows-latest--Windows_Server-2019-English-Full-ECS_Optimized--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118.Parameter": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "SsmParameterValueawsserviceecsoptimizedamiwindowsserver2019englishfullrecommendedimageidC96584B6F00A464EAD1953AFF4B05118Parameter"
+            "data": "SsmParameterValueawsserviceamiwindowslatestWindowsServer2019EnglishFullECSOptimizedimageidC96584B6F00A464EAD1953AFF4B05118Parameter"
           }
         ],
         "/github-runners-test/Lambda/Image Digest Reader/Resource/Default": [

--- a/test/default.integ.snapshot/manifest.json
+++ b/test/default.integ.snapshot/manifest.json
@@ -23,7 +23,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/7d08eb5bcf45836d6ce1e0bdb72021da83a237afbe06781a523bb3429bbb1c52.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/d94641c84bbe137207d7e179fb369c348e57e55714ff97c5e090786d06185173.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/default.integ.snapshot/tree.json
+++ b/test/default.integ.snapshot/tree.json
@@ -3418,6 +3418,9 @@
                       "Ref": "WindowsImageBuilderInstanceProfileBFCCEC08"
                     },
                     "name": "github-runners-test-WindowsImageBuilder-18C0E1B2",
+                    "instanceMetadataOptions": {
+                      "httpTokens": "required"
+                    },
                     "instanceTypes": [
                       "m5.large"
                     ],
@@ -3860,7 +3863,10 @@
                                 }
                               ]
                             }
-                          ]
+                          ],
+                          "metadataOptions": {
+                            "httpTokens": "required"
+                          }
                         },
                         "tagSpecifications": [
                           {
@@ -4511,6 +4517,9 @@
                       "Ref": "AMILinuxBuilderInstanceProfile3CA638BE"
                     },
                     "name": "github-runners-test-AMILinuxBuilder-67243E6D",
+                    "instanceMetadataOptions": {
+                      "httpTokens": "required"
+                    },
                     "instanceTypes": [
                       "m5.large"
                     ],
@@ -7231,7 +7240,10 @@
                                 }
                               ]
                             }
-                          ]
+                          ],
+                          "metadataOptions": {
+                            "httpTokens": "required"
+                          }
                         },
                         "tagSpecifications": [
                           {
@@ -7882,6 +7894,9 @@
                       "Ref": "AMILinuxarm64BuilderInstanceProfileCE3B6B09"
                     },
                     "name": "github-runners-test-AMILinuxarm64Builder-3F449283",
+                    "instanceMetadataOptions": {
+                      "httpTokens": "required"
+                    },
                     "instanceTypes": [
                       "m6g.large"
                     ],
@@ -8336,7 +8351,10 @@
                                 }
                               ]
                             }
-                          ]
+                          ],
+                          "metadataOptions": {
+                            "httpTokens": "required"
+                          }
                         },
                         "tagSpecifications": [
                           {
@@ -8987,6 +9005,9 @@
                       "Ref": "WindowsEC2BuilderInstanceProfileA8DBA763"
                     },
                     "name": "github-runners-test-WindowsEC2Builder-5FAF8285",
+                    "instanceMetadataOptions": {
+                      "httpTokens": "required"
+                    },
                     "instanceTypes": [
                       "m5.large"
                     ],
@@ -11137,6 +11158,9 @@
                         "iamInstanceProfile": {
                           "Ref": "ECSAutoScalingGroupInstanceProfile288AC654"
                         },
+                        "metadataOptions": {
+                          "httpTokens": "required"
+                        },
                         "securityGroups": [
                           {
                             "Fn::GetAtt": [
@@ -11976,6 +12000,9 @@
                         "instanceType": "m6g.large",
                         "iamInstanceProfile": {
                           "Ref": "ECSARM64AutoScalingGroupInstanceProfile768645E6"
+                        },
+                        "metadataOptions": {
+                          "httpTokens": "required"
                         },
                         "securityGroups": [
                           {
@@ -12859,6 +12886,9 @@
                         "instanceType": "m5.large",
                         "iamInstanceProfile": {
                           "Ref": "ECSWindowsAutoScalingGroupInstanceProfileD8019407"
+                        },
+                        "metadataOptions": {
+                          "httpTokens": "required"
                         },
                         "securityGroups": [
                           {

--- a/test/default.integ.snapshot/tree.json
+++ b/test/default.integ.snapshot/tree.json
@@ -12881,7 +12881,7 @@
                       "aws:cdk:cloudformation:type": "AWS::AutoScaling::LaunchConfiguration",
                       "aws:cdk:cloudformation:props": {
                         "imageId": {
-                          "Ref": "SsmParameterValueawsserviceecsoptimizedamiwindowsserver2019englishfullrecommendedimageidC96584B6F00A464EAD1953AFF4B05118Parameter"
+                          "Ref": "SsmParameterValueawsserviceamiwindowslatestWindowsServer2019EnglishFullECSOptimizedimageidC96584B6F00A464EAD1953AFF4B05118Parameter"
                         },
                         "instanceType": "m5.large",
                         "iamInstanceProfile": {
@@ -13427,17 +13427,17 @@
               "version": "10.0.5"
             }
           },
-          "SsmParameterValue:--aws--service--ecs--optimized-ami--windows_server--2019--english--full--recommended--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118.Parameter": {
-            "id": "SsmParameterValue:--aws--service--ecs--optimized-ami--windows_server--2019--english--full--recommended--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118.Parameter",
-            "path": "github-runners-test/SsmParameterValue:--aws--service--ecs--optimized-ami--windows_server--2019--english--full--recommended--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118.Parameter",
+          "SsmParameterValue:--aws--service--ami-windows-latest--Windows_Server-2019-English-Full-ECS_Optimized--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118.Parameter": {
+            "id": "SsmParameterValue:--aws--service--ami-windows-latest--Windows_Server-2019-English-Full-ECS_Optimized--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118.Parameter",
+            "path": "github-runners-test/SsmParameterValue:--aws--service--ami-windows-latest--Windows_Server-2019-English-Full-ECS_Optimized--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118.Parameter",
             "constructInfo": {
               "fqn": "aws-cdk-lib.CfnParameter",
               "version": "2.50.0"
             }
           },
-          "SsmParameterValue:--aws--service--ecs--optimized-ami--windows_server--2019--english--full--recommended--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118": {
-            "id": "SsmParameterValue:--aws--service--ecs--optimized-ami--windows_server--2019--english--full--recommended--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118",
-            "path": "github-runners-test/SsmParameterValue:--aws--service--ecs--optimized-ami--windows_server--2019--english--full--recommended--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118",
+          "SsmParameterValue:--aws--service--ami-windows-latest--Windows_Server-2019-English-Full-ECS_Optimized--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118": {
+            "id": "SsmParameterValue:--aws--service--ami-windows-latest--Windows_Server-2019-English-Full-ECS_Optimized--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118",
+            "path": "github-runners-test/SsmParameterValue:--aws--service--ami-windows-latest--Windows_Server-2019-English-Full-ECS_Optimized--image_id:C96584B6-F00A-464E-AD19-53AFF4B05118",
             "constructInfo": {
               "fqn": "aws-cdk-lib.Resource",
               "version": "2.50.0"


### PR DESCRIPTION
[AWS recommends using IMDSv2](https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/); there's even a [migration guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-metadata-transition-to-version-2.html). Sadly, AIUI due to backwards compatibility concerns, it isn't the default _yet_.

`$WORK` requires the use of IMDSv2 for all our EC2 instances … and our use of cdk-github-runners is triggering all sorts of security monitoring alarms.

Any chance we can require the use of IMDSv2 in them? It _should_ be harmless **and** the [normal EC2 provider already requires it](https://github.com/CloudSnorkel/cdk-github-runners/blob/0c46eee82028ab318ec26d0fb1c0a515fd500667/src/providers/ec2.ts#L404).

n.b. we're still migrating from the newly deprecated AMI builders, so I've updated the `LaunchTemplate` there too.