### PR TITLE
fix: Remove double `set -ex` in deprecated builders

### DIFF
--- a/API.md
+++ b/API.md
@@ -26,7 +26,6 @@ builder.addComponent(new ImageBuilderComponent(scope, id, {
   displayName: 'p7zip',
   description: 'Install some more packages',
   commands: [
-    'set -ex',
     'apt-get install p7zip',
   ],
 }));
@@ -3295,7 +3294,6 @@ new ImageBuilderComponent(this, 'AWS CLI', {
   displayName: 'AWS CLI',
   description: 'Install latest version of AWS CLI',
   commands: [
-    '$ErrorActionPreference = \'Stop\'',
     'Start-Process msiexec.exe -Wait -ArgumentList \'/i https://awscli.amazonaws.com/AWSCLIV2.msi /qn\'',
   ],
 }

--- a/src/providers/image-builders/aws-image-builder/builder.ts
+++ b/src/providers/image-builders/aws-image-builder/builder.ts
@@ -96,7 +96,6 @@ export interface ImageBuilderComponentProperties {
  *   displayName: 'AWS CLI',
  *   description: 'Install latest version of AWS CLI',
  *   commands: [
- *     '$ErrorActionPreference = \'Stop\'',
  *     'Start-Process msiexec.exe -Wait -ArgumentList \'/i https://awscli.amazonaws.com/AWSCLIV2.msi /qn\'',
  *   ],
  * }

--- a/src/providers/image-builders/aws-image-builder/deprecated/ami.ts
+++ b/src/providers/image-builders/aws-image-builder/deprecated/ami.ts
@@ -138,7 +138,6 @@ export interface AmiBuilderProps {
  *   displayName: 'p7zip',
  *   description: 'Install some more packages',
  *   commands: [
- *     'set -ex',
  *     'apt-get install p7zip',
  *   ],
  * }));

--- a/src/providers/image-builders/aws-image-builder/deprecated/linux-components.ts
+++ b/src/providers/image-builders/aws-image-builder/deprecated/linux-components.ts
@@ -24,7 +24,6 @@ export class LinuxUbuntuComponents {
       displayName: 'Required packages',
       description: 'Install packages required for GitHub Runner and upgrade all packages',
       commands: [
-        'set -ex',
         'apt-get update',
         'DEBIAN_FRONTEND=noninteractive apt-get upgrade -y',
         'DEBIAN_FRONTEND=noninteractive apt-get install -y curl sudo jq bash zip unzip iptables software-properties-common ca-certificates',
@@ -41,7 +40,6 @@ export class LinuxUbuntuComponents {
       displayName: 'GitHub Runner user',
       description: 'Install latest version of AWS CLI',
       commands: [
-        'set -ex',
         'addgroup runner',
         'adduser --system --disabled-password --home /home/runner --ingroup runner runner',
         'usermod -aG sudo runner',
@@ -65,7 +63,6 @@ export class LinuxUbuntuComponents {
       displayName: 'AWS CLI',
       description: 'Install latest version of AWS CLI',
       commands: [
-        'set -ex',
         `curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${archUrl}.zip" -o awscliv2.zip`,
         'unzip -q awscliv2.zip',
         './aws/install',
@@ -80,7 +77,6 @@ export class LinuxUbuntuComponents {
       displayName: 'GitHub CLI',
       description: 'Install latest version of gh',
       commands: [
-        'set -ex',
         'curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg',
         'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] ' +
         '  https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null',
@@ -96,7 +92,6 @@ export class LinuxUbuntuComponents {
       displayName: 'Git',
       description: 'Install latest version of git',
       commands: [
-        'set -ex',
         'add-apt-repository ppa:git-core/ppa',
         'apt-get update',
         'DEBIAN_FRONTEND=noninteractive apt-get install -y git',
@@ -126,7 +121,6 @@ export class LinuxUbuntuComponents {
       displayName: 'GitHub Actions Runner',
       description: 'Install latest version of GitHub Actions Runner',
       commands: [
-        'set -ex',
         versionCommand,
         `curl -fsSLO "https://github.com/actions/runner/releases/download/v\${RUNNER_VERSION}/actions-runner-linux-${archUrl}-\${RUNNER_VERSION}.tar.gz"`,
         `tar xzf "actions-runner-linux-${archUrl}-\${RUNNER_VERSION}.tar.gz"`,
@@ -143,7 +137,6 @@ export class LinuxUbuntuComponents {
       displayName: 'Docker',
       description: 'Install latest version of Docker',
       commands: [
-        'set -ex',
         'curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker.gpg',
         'echo ' +
         '  "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu ' +
@@ -162,7 +155,6 @@ export class LinuxUbuntuComponents {
       displayName: 'Extra certificates',
       description: 'Install self-signed certificates to provide access to GitHub Enterprise Server',
       commands: [
-        'set -ex',
         'cp certs/certs.pem /usr/local/share/ca-certificates/github-enterprise-server.crt',
         'update-ca-certificates',
       ],

--- a/src/providers/image-builders/aws-image-builder/deprecated/windows-components.ts
+++ b/src/providers/image-builders/aws-image-builder/deprecated/windows-components.ts
@@ -15,7 +15,6 @@ export class WindowsComponents {
       displayName: 'CloudWatch agent',
       description: 'Install latest version of CloudWatch agent for sending logs to CloudWatch',
       commands: [
-        '$ErrorActionPreference = \'Stop\'',
         'Start-Process msiexec.exe -Wait -ArgumentList \'/i https://s3.amazonaws.com/amazoncloudwatch-agent/windows/amd64/latest/amazon-cloudwatch-agent.msi /qn\'',
       ],
     });
@@ -27,7 +26,6 @@ export class WindowsComponents {
       displayName: 'AWS CLI',
       description: 'Install latest version of AWS CLI',
       commands: [
-        '$ErrorActionPreference = \'Stop\'',
         'Start-Process msiexec.exe -Wait -ArgumentList \'/i https://awscli.amazonaws.com/AWSCLIV2.msi /qn\'',
       ],
     });
@@ -39,12 +37,9 @@ export class WindowsComponents {
       displayName: 'GitHub CLI',
       description: 'Install latest version of gh',
       commands: [
-        '$ErrorActionPreference = \'Stop\'',
-        '$ProgressPreference = \'SilentlyContinue\'',
         'cmd /c curl -w "%{redirect_url}" -fsS https://github.com/cli/cli/releases/latest > $Env:TEMP\\latest-gh',
         '$LatestUrl = Get-Content $Env:TEMP\\latest-gh',
         '$GH_VERSION = ($LatestUrl -Split \'/\')[-1].substring(1)',
-        '$ProgressPreference = \'SilentlyContinue\'',
         'Invoke-WebRequest -UseBasicParsing -Uri "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_windows_amd64.msi" -OutFile gh.msi',
         'Start-Process msiexec.exe -Wait -ArgumentList \'/i gh.msi /qn\'',
         'del gh.msi',
@@ -58,8 +53,6 @@ export class WindowsComponents {
       displayName: 'Git',
       description: 'Install latest version of git',
       commands: [
-        '$ErrorActionPreference = \'Stop\'',
-        '$ProgressPreference = \'SilentlyContinue\'',
         'cmd /c curl -w "%{redirect_url}" -fsS https://github.com/git-for-windows/git/releases/latest > $Env:TEMP\\latest-git',
         '$LatestUrl = Get-Content $Env:TEMP\\latest-git',
         '$GIT_VERSION = ($LatestUrl -Split \'/\')[-1].substring(1)',
@@ -89,10 +82,7 @@ export class WindowsComponents {
       platform: 'Windows',
       displayName: 'GitHub Actions Runner',
       description: 'Install latest version of GitHub Actions Runner',
-      commands: [
-        '$ErrorActionPreference = \'Stop\'',
-        '$ProgressPreference = \'SilentlyContinue\'',
-      ].concat(runnerCommands, [
+      commands: runnerCommands.concat([
         'Invoke-WebRequest -UseBasicParsing -Uri "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-win-x64-${RUNNER_VERSION}.zip" -OutFile actions.zip',
         'Expand-Archive actions.zip -DestinationPath C:\\actions',
         'del actions.zip',
@@ -107,8 +97,6 @@ export class WindowsComponents {
       displayName: 'Docker',
       description: 'Install latest version of Docker',
       commands: [
-        '$ErrorActionPreference = \'Stop\'',
-        '$ProgressPreference = \'SilentlyContinue\'',
         'Invoke-WebRequest -UseBasicParsing -Uri https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe -OutFile docker-setup.exe',
         'Start-Process \'docker-setup.exe\' -Wait -ArgumentList \'/install --quiet --accept-license\'',
         'del docker-setup.exe',
@@ -127,7 +115,6 @@ export class WindowsComponents {
       displayName: 'Extra certificates',
       description: 'Install self-signed certificates to provide access to GitHub Enterprise Server',
       commands: [
-        '$ErrorActionPreference = \'Stop\'',
         'Import-Certificate -FilePath certs\\certs.pem -CertStoreLocation Cert:\\LocalMachine\\Root',
       ],
       assets: [


### PR DESCRIPTION
Fixes #282