### PR TITLE
fix: Windows runner Docker image builds

### DIFF
--- a/src/providers/image-builders/aws-image-builder/builder.ts
+++ b/src/providers/image-builders/aws-image-builder/builder.ts
@@ -452,6 +452,8 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
       instanceTypes: [this.instanceType.toString()],
       instanceMetadataOptions: {
         httpTokens: 'required',
+        // Container builds require a minimum of two hops.
+        httpPutResponseHopLimit: 2,
       },
       instanceProfileName: new iam.CfnInstanceProfile(this, 'Instance Profile', {
         roles: [

--- a/src/providers/image-builders/aws-image-builder/deprecated/common.ts
+++ b/src/providers/image-builders/aws-image-builder/deprecated/common.ts
@@ -112,6 +112,8 @@ export abstract class ImageBuilderBase extends Construct implements IRunnerImage
       instanceTypes: [this.instanceType.toString()],
       instanceMetadataOptions: {
         httpTokens: 'required',
+        // Container builds require a minimum of two hops.
+        httpPutResponseHopLimit: 2,
       },
       instanceProfileName: new iam.CfnInstanceProfile(this, 'Instance Profile', {
         roles: [

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -196,7 +196,7 @@
         }
       }
     },
-    "9c0a45e0ef8b2912f4dd15c456ecba5f59c5820aeb8df601ab86623734525d13": {
+    "86ad6ffb80ab09572bf2277a0c1b69d1180bc0ccbb845cfc43276240977bd169": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -204,7 +204,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "9c0a45e0ef8b2912f4dd15c456ecba5f59c5820aeb8df601ab86623734525d13.json",
+          "objectKey": "86ad6ffb80ab09572bf2277a0c1b69d1180bc0ccbb845cfc43276240977bd169.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -2900,6 +2900,7 @@
     },
     "Name": "github-runners-test-WindowsImageBuilder-18C0E1B2",
     "InstanceMetadataOptions": {
+     "HttpPutResponseHopLimit": 2,
      "HttpTokens": "required"
     },
     "InstanceTypes": [
@@ -3953,6 +3954,7 @@
     },
     "Name": "github-runners-test-AMILinuxBuilder-67243E6D",
     "InstanceMetadataOptions": {
+     "HttpPutResponseHopLimit": 2,
      "HttpTokens": "required"
     },
     "InstanceTypes": [
@@ -6933,6 +6935,7 @@
     },
     "Name": "github-runners-test-AMILinuxarm64Builder-3F449283",
     "InstanceMetadataOptions": {
+     "HttpPutResponseHopLimit": 2,
      "HttpTokens": "required"
     },
     "InstanceTypes": [
@@ -7985,6 +7988,7 @@
     },
     "Name": "github-runners-test-WindowsEC2Builder-5FAF8285",
     "InstanceMetadataOptions": {
+     "HttpPutResponseHopLimit": 2,
      "HttpTokens": "required"
     },
     "InstanceTypes": [

--- a/test/default.integ.snapshot/manifest.json
+++ b/test/default.integ.snapshot/manifest.json
@@ -23,7 +23,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/9c0a45e0ef8b2912f4dd15c456ecba5f59c5820aeb8df601ab86623734525d13.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/86ad6ffb80ab09572bf2277a0c1b69d1180bc0ccbb845cfc43276240977bd169.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/default.integ.snapshot/tree.json
+++ b/test/default.integ.snapshot/tree.json
@@ -3545,7 +3545,8 @@
                     },
                     "name": "github-runners-test-WindowsImageBuilder-18C0E1B2",
                     "instanceMetadataOptions": {
-                      "httpTokens": "required"
+                      "httpTokens": "required",
+                      "httpPutResponseHopLimit": 2
                     },
                     "instanceTypes": [
                       "m5.large"
@@ -4647,7 +4648,8 @@
                     },
                     "name": "github-runners-test-AMILinuxBuilder-67243E6D",
                     "instanceMetadataOptions": {
-                      "httpTokens": "required"
+                      "httpTokens": "required",
+                      "httpPutResponseHopLimit": 2
                     },
                     "instanceTypes": [
                       "m5.large"
@@ -8153,7 +8155,8 @@
                     },
                     "name": "github-runners-test-AMILinuxarm64Builder-3F449283",
                     "instanceMetadataOptions": {
-                      "httpTokens": "required"
+                      "httpTokens": "required",
+                      "httpPutResponseHopLimit": 2
                     },
                     "instanceTypes": [
                       "m6g.large"
@@ -9267,7 +9270,8 @@
                     },
                     "name": "github-runners-test-WindowsEC2Builder-5FAF8285",
                     "instanceMetadataOptions": {
-                      "httpTokens": "required"
+                      "httpTokens": "required",
+                      "httpPutResponseHopLimit": 2
                     },
                     "instanceTypes": [
                       "m5.large"


### PR DESCRIPTION
IMSDv2 (#276) broke building runner Docker images for Windows. Container builds require a minimum of two hops.