### PR TITLE
fix: Don't install Docker Desktop on Windows

### DIFF
--- a/API.md
+++ b/API.md
@@ -4667,8 +4667,6 @@ public readonly installDocker: boolean;
 
 Install Docker inside the image, so it can be used by the runner.
 
-You may want to disable this if you are building a Windows image and don't have a Docker Desktop license.
-
 ---
 
 ##### `instanceType`<sup>Optional</sup> <a name="instanceType" id="@cloudsnorkel/cdk-github-runners.AmiBuilderProps.property.instanceType"></a>
@@ -8612,7 +8610,7 @@ RunnerImageComponent.docker()
 
 A component to install Docker.
 
-On Windows this installs Docker Desktop.
+On Windows this sets up dockerd for Windows containers without Docker Desktop. If you need Linux containers on Windows, you'll need to install Docker Desktop which doesn't seem to play well with servers (PRs welcome).
 
 ##### `dockerInDocker` <a name="dockerInDocker" id="@cloudsnorkel/cdk-github-runners.RunnerImageComponent.dockerInDocker"></a>
 

--- a/src/image-builders/aws-image-builder/deprecated/ami.ts
+++ b/src/image-builders/aws-image-builder/deprecated/ami.ts
@@ -112,7 +112,7 @@ export interface AmiBuilderProps {
   readonly logRemovalPolicy?: RemovalPolicy;
 
   /**
-   * Install Docker inside the image, so it can be used by the runner. You may want to disable this if you are building a Windows image and don't have a Docker Desktop license.
+   * Install Docker inside the image, so it can be used by the runner.
    *
    * @default true
    */

--- a/src/image-builders/aws-image-builder/deprecated/windows-components.ts
+++ b/src/image-builders/aws-image-builder/deprecated/windows-components.ts
@@ -1,6 +1,7 @@
 import { aws_s3_assets as s3_assets } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import { RunnerVersion } from '../../../providers/common';
+import { Architecture, Os, RunnerVersion } from '../../../providers';
+import { RunnerImageComponent } from '../../components';
 import { ImageBuilderComponent } from '../builder';
 
 /**
@@ -100,13 +101,7 @@ export class WindowsComponents {
       platform: 'Windows',
       displayName: 'Docker',
       description: 'Install latest version of Docker',
-      commands: [
-        'Invoke-WebRequest -UseBasicParsing -Uri https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe -OutFile docker-setup.exe',
-        '$p = Start-Process "docker-setup.exe" -PassThru -Wait -ArgumentList "install --quiet --accept-license"',
-        'if ($p.ExitCode -ne 0) { throw "Exit code is $p.ExitCode" }',
-        'del docker-setup.exe',
-        'if (-Not(Test-Path -Path "$Env:ProgramFiles\\Docker")) { echo "Docker installation failed" ; exit 1 }',
-      ],
+      commands: RunnerImageComponent.docker().getCommands(Os.WINDOWS, Architecture.X86_64),
       reboot: true,
     });
   }

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -196,7 +196,7 @@
         }
       }
     },
-    "218cb7a9773cca2cbb3f9bbd9dcfd212dbe3bae711b1d4c19fd58e7764f292f1": {
+    "156e587ed5635d89093c5c17e13f99b7273b05543933e056271679700ff32235": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -204,7 +204,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "218cb7a9773cca2cbb3f9bbd9dcfd212dbe3bae711b1d4c19fd58e7764f292f1.json",
+          "objectKey": "156e587ed5635d89093c5c17e13f99b7273b05543933e056271679700ff32235.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -7691,11 +7691,24 @@
             "$ErrorActionPreference = 'Stop'",
             "$ProgressPreference = 'SilentlyContinue'",
             "Set-PSDebug -Trace 1",
-            "Invoke-WebRequest -UseBasicParsing -Uri https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe -OutFile docker-setup.exe",
-            "$p = Start-Process \"docker-setup.exe\" -PassThru -Wait -ArgumentList \"install --quiet --accept-license\"",
-            "if ($p.ExitCode -ne 0) { throw \"Exit code is $p.ExitCode\" }",
-            "del docker-setup.exe",
-            "if (-Not(Test-Path -Path \"$Env:ProgramFiles\\Docker\")) { echo \"Docker installation failed\" ; exit 1 }"
+            "cmd /c curl -w \"%{redirect_url}\" -fsS https://github.com/moby/moby/releases/latest > $Env:TEMP\\latest-docker",
+            "$LatestUrl = Get-Content $Env:TEMP\\latest-docker",
+            "$DOCKER_VERSION = ($LatestUrl -Split '/')[-1].substring(1)",
+            "Invoke-WebRequest -UseBasicParsing -Uri \"https://download.docker.com/win/static/stable/x86_64/docker-${DOCKER_VERSION}.zip\" -OutFile docker.zip",
+            "Expand-Archive docker.zip -DestinationPath \"$Env:ProgramFiles\"",
+            "del docker.zip",
+            "$persistedPaths = [Environment]::GetEnvironmentVariable('Path', [EnvironmentVariableTarget]::Machine)",
+            "[Environment]::SetEnvironmentVariable(\"PATH\", $persistedPaths + \";$Env:ProgramFiles\\Docker\", [EnvironmentVariableTarget]::Machine)",
+            "$env:PATH = $env:PATH + \";$Env:ProgramFiles\\Docker\"",
+            "dockerd --register-service",
+            "if ($LASTEXITCODE -ne 0) { throw \"Exit code is $LASTEXITCODE\" }",
+            "Enable-WindowsOptionalFeature -Online -FeatureName containers -All -NoRestart",
+            "cmd /c curl -w \"%{redirect_url}\" -fsS https://github.com/docker/compose/releases/latest > $Env:TEMP\\latest-docker-compose",
+            "$LatestUrl = Get-Content $Env:TEMP\\latest-docker-compose",
+            "$LatestDockerCompose = ($LatestUrl -Split '/')[-1]",
+            "Invoke-WebRequest -UseBasicParsing -Uri  \"https://github.com/docker/compose/releases/download/${LatestDockerCompose}/docker-compose-Windows-x86_64.exe\" -OutFile $Env:ProgramFiles\\Docker\\docker-compose.exe",
+            "New-Item -ItemType directory -Path \"$Env:ProgramFiles\\Docker\\cli-plugins\"",
+            "Copy-Item -Path \"$Env:ProgramFiles\\Docker\\docker-compose.exe\" -Destination \"$Env:ProgramFiles\\Docker\\cli-plugins\\docker-compose.exe\""
            ]
           }
          },
@@ -7722,7 +7735,7 @@
     "Version": {
      "Ref": "WindowsEC2BuilderComponent5DockerVersion40844B58"
     },
-    "Data": "{\"name\":\"Component 5 Docker\",\"schemaVersion\":\"1.0\",\"phases\":[{\"name\":\"build\",\"steps\":[{\"name\":\"Download\",\"action\":\"S3Download\",\"inputs\":[]},{\"name\":\"Run\",\"action\":\"ExecutePowerShell\",\"inputs\":{\"commands\":[\"$ErrorActionPreference = 'Stop'\",\"$ProgressPreference = 'SilentlyContinue'\",\"Set-PSDebug -Trace 1\",\"Invoke-WebRequest -UseBasicParsing -Uri https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe -OutFile docker-setup.exe\",\"$p = Start-Process \\\"docker-setup.exe\\\" -PassThru -Wait -ArgumentList \\\"install --quiet --accept-license\\\"\",\"if ($p.ExitCode -ne 0) { throw \\\"Exit code is $p.ExitCode\\\" }\",\"del docker-setup.exe\",\"if (-Not(Test-Path -Path \\\"$Env:ProgramFiles\\\\Docker\\\")) { echo \\\"Docker installation failed\\\" ; exit 1 }\"]}},{\"name\":\"Reboot\",\"action\":\"Reboot\",\"inputs\":{}}]}]}",
+    "Data": "{\"name\":\"Component 5 Docker\",\"schemaVersion\":\"1.0\",\"phases\":[{\"name\":\"build\",\"steps\":[{\"name\":\"Download\",\"action\":\"S3Download\",\"inputs\":[]},{\"name\":\"Run\",\"action\":\"ExecutePowerShell\",\"inputs\":{\"commands\":[\"$ErrorActionPreference = 'Stop'\",\"$ProgressPreference = 'SilentlyContinue'\",\"Set-PSDebug -Trace 1\",\"cmd /c curl -w \\\"%{redirect_url}\\\" -fsS https://github.com/moby/moby/releases/latest > $Env:TEMP\\\\latest-docker\",\"$LatestUrl = Get-Content $Env:TEMP\\\\latest-docker\",\"$DOCKER_VERSION = ($LatestUrl -Split '/')[-1].substring(1)\",\"Invoke-WebRequest -UseBasicParsing -Uri \\\"https://download.docker.com/win/static/stable/x86_64/docker-${DOCKER_VERSION}.zip\\\" -OutFile docker.zip\",\"Expand-Archive docker.zip -DestinationPath \\\"$Env:ProgramFiles\\\"\",\"del docker.zip\",\"$persistedPaths = [Environment]::GetEnvironmentVariable('Path', [EnvironmentVariableTarget]::Machine)\",\"[Environment]::SetEnvironmentVariable(\\\"PATH\\\", $persistedPaths + \\\";$Env:ProgramFiles\\\\Docker\\\", [EnvironmentVariableTarget]::Machine)\",\"$env:PATH = $env:PATH + \\\";$Env:ProgramFiles\\\\Docker\\\"\",\"dockerd --register-service\",\"if ($LASTEXITCODE -ne 0) { throw \\\"Exit code is $LASTEXITCODE\\\" }\",\"Enable-WindowsOptionalFeature -Online -FeatureName containers -All -NoRestart\",\"cmd /c curl -w \\\"%{redirect_url}\\\" -fsS https://github.com/docker/compose/releases/latest > $Env:TEMP\\\\latest-docker-compose\",\"$LatestUrl = Get-Content $Env:TEMP\\\\latest-docker-compose\",\"$LatestDockerCompose = ($LatestUrl -Split '/')[-1]\",\"Invoke-WebRequest -UseBasicParsing -Uri  \\\"https://github.com/docker/compose/releases/download/${LatestDockerCompose}/docker-compose-Windows-x86_64.exe\\\" -OutFile $Env:ProgramFiles\\\\Docker\\\\docker-compose.exe\",\"New-Item -ItemType directory -Path \\\"$Env:ProgramFiles\\\\Docker\\\\cli-plugins\\\"\",\"Copy-Item -Path \\\"$Env:ProgramFiles\\\\Docker\\\\docker-compose.exe\\\" -Destination \\\"$Env:ProgramFiles\\\\Docker\\\\cli-plugins\\\\docker-compose.exe\\\"\"]}},{\"name\":\"Reboot\",\"action\":\"Reboot\",\"inputs\":{}}]}]}",
     "Description": "Component 5 Docker"
    }
   },


### PR DESCRIPTION
It never worked. The pre-installed `dockerd` with Windows containers was the one that was functioning. We no longer have that pre-installed as we're not using the ECS-optimized base AMI.

This change installs `dockerd` just like ECS-optimized AMIs do. It also sets up `docker-compose`.

Related #252
Related #218