### PR TITLE
fix: Lambda image unable to find runner.js

### DIFF
--- a/src/image-builders/components.ts
+++ b/src/image-builders/components.ts
@@ -509,11 +509,11 @@ export abstract class RunnerImageComponent {
       getAssets(_os: Os, _architecture: Architecture): RunnerImageAsset[] {
         return [
           {
-            source: path.join(__dirname, '..', 'providers', 'docker-images', 'lambda', 'linux-x64', 'runner.js'),
+            source: path.join(__dirname, '..', '..', 'assets', 'docker-images', 'lambda', 'linux-x64', 'runner.js'),
             target: '${LAMBDA_TASK_ROOT}/runner.js',
           },
           {
-            source: path.join(__dirname, '..', 'providers', 'docker-images', 'lambda', 'linux-x64', 'runner.sh'),
+            source: path.join(__dirname, '..', '..', 'assets', 'docker-images', 'lambda', 'linux-x64', 'runner.sh'),
             target: '${LAMBDA_TASK_ROOT}/runner.sh',
           },
         ];


### PR DESCRIPTION
The code was trying to load an asset relative to the source file, but assets are always located in the `assets` folder. This only worked in development because the assets are still next to the source code while developing. All assets must always be loaded from the `assets` folder.

Fixes #305