### PR TITLE
feat: Always use latest AMI for ECS instances

### DIFF
--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -209,7 +209,7 @@
         }
       }
     },
-    "9a23e2b991f6297d8813953fbb089de3e5c73501ed9e2b55d31c209d7012001f": {
+    "c8f8d58a26976edf389143516b45f35c0efef598e34669f5d7ed93b7914ae0c5": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -217,7 +217,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "9a23e2b991f6297d8813953fbb089de3e5c73501ed9e2b55d31c209d7012001f.json",
+          "objectKey": "c8f8d58a26976edf389143516b45f35c0efef598e34669f5d7ed93b7914ae0c5.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -209,7 +209,7 @@
         }
       }
     },
-    "e198e2b9bcbb61749570052c9134041267953c87340ad9a07baa614966e28c96": {
+    "9a23e2b991f6297d8813953fbb089de3e5c73501ed9e2b55d31c209d7012001f": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -217,7 +217,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "e198e2b9bcbb61749570052c9134041267953c87340ad9a07baa614966e28c96.json",
+          "objectKey": "9a23e2b991f6297d8813953fbb089de3e5c73501ed9e2b55d31c209d7012001f.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -9090,9 +9090,49 @@
        ],
        "Effect": "Allow",
        "Resource": {
-        "Fn::GetAtt": [
-         "WindowsImageBuilderRepositoryA4CBB6D8",
-         "Arn"
+        "Fn::Join": [
+         "",
+         [
+          "arn:",
+          {
+           "Ref": "AWS::Partition"
+          },
+          ":ecr:",
+          {
+           "Ref": "AWS::Region"
+          },
+          ":",
+          {
+           "Ref": "AWS::AccountId"
+          },
+          ":repository/",
+          {
+           "Fn::Select": [
+            0,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Fn::Select": [
+                1,
+                {
+                 "Fn::Split": [
+                  "/",
+                  {
+                   "Fn::GetAtt": [
+                    "WindowsImageBuilderDockerImage8672CA3E",
+                    "ImageUri"
+                   ]
+                  }
+                 ]
+                }
+               ]
+              }
+             ]
+            }
+           ]
+          }
+         ]
         ]
        }
       },
@@ -9229,37 +9269,11 @@
        "",
        [
         {
-         "Fn::Select": [
-          4,
-          {
-           "Fn::Split": [
-            ":",
-            {
-             "Fn::GetAtt": [
-              "WindowsImageBuilderRepositoryA4CBB6D8",
-              "Arn"
-             ]
-            }
-           ]
-          }
-         ]
+         "Ref": "AWS::AccountId"
         },
         ".dkr.ecr.",
         {
-         "Fn::Select": [
-          3,
-          {
-           "Fn::Split": [
-            ":",
-            {
-             "Fn::GetAtt": [
-              "WindowsImageBuilderRepositoryA4CBB6D8",
-              "Arn"
-             ]
-            }
-           ]
-          }
-         ]
+         "Ref": "AWS::Region"
         },
         ".",
         {
@@ -9267,7 +9281,30 @@
         },
         "/",
         {
-         "Ref": "WindowsImageBuilderRepositoryA4CBB6D8"
+         "Fn::Select": [
+          0,
+          {
+           "Fn::Split": [
+            ":",
+            {
+             "Fn::Select": [
+              1,
+              {
+               "Fn::Split": [
+                "/",
+                {
+                 "Fn::GetAtt": [
+                  "WindowsImageBuilderDockerImage8672CA3E",
+                  "ImageUri"
+                 ]
+                }
+               ]
+              }
+             ]
+            }
+           ]
+          }
+         ]
         },
         ":latest"
        ]
@@ -10716,9 +10753,49 @@
        ],
        "Effect": "Allow",
        "Resource": {
-        "Fn::GetAtt": [
-         "WindowsImageBuilderRepositoryA4CBB6D8",
-         "Arn"
+        "Fn::Join": [
+         "",
+         [
+          "arn:",
+          {
+           "Ref": "AWS::Partition"
+          },
+          ":ecr:",
+          {
+           "Ref": "AWS::Region"
+          },
+          ":",
+          {
+           "Ref": "AWS::AccountId"
+          },
+          ":repository/",
+          {
+           "Fn::Select": [
+            0,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Fn::Select": [
+                1,
+                {
+                 "Fn::Split": [
+                  "/",
+                  {
+                   "Fn::GetAtt": [
+                    "WindowsImageBuilderDockerImage8672CA3E",
+                    "ImageUri"
+                   ]
+                  }
+                 ]
+                }
+               ]
+              }
+             ]
+            }
+           ]
+          }
+         ]
         ]
        }
       },
@@ -10850,37 +10927,11 @@
          },
          ".amazonaws.com\nStart-Job -ScriptBlock { docker pull ",
          {
-          "Fn::Select": [
-           4,
-           {
-            "Fn::Split": [
-             ":",
-             {
-              "Fn::GetAtt": [
-               "WindowsImageBuilderRepositoryA4CBB6D8",
-               "Arn"
-              ]
-             }
-            ]
-           }
-          ]
+          "Ref": "AWS::AccountId"
          },
          ".dkr.ecr.",
          {
-          "Fn::Select": [
-           3,
-           {
-            "Fn::Split": [
-             ":",
-             {
-              "Fn::GetAtt": [
-               "WindowsImageBuilderRepositoryA4CBB6D8",
-               "Arn"
-              ]
-             }
-            ]
-           }
-          ]
+          "Ref": "AWS::Region"
          },
          ".",
          {
@@ -10888,7 +10939,30 @@
          },
          "/",
          {
-          "Ref": "WindowsImageBuilderRepositoryA4CBB6D8"
+          "Fn::Select": [
+           0,
+           {
+            "Fn::Split": [
+             ":",
+             {
+              "Fn::Select": [
+               1,
+               {
+                "Fn::Split": [
+                 "/",
+                 {
+                  "Fn::GetAtt": [
+                   "WindowsImageBuilderDockerImage8672CA3E",
+                   "ImageUri"
+                  ]
+                 }
+                ]
+               }
+              ]
+             }
+            ]
+           }
+          ]
          },
          ":latest }\nRemove-Item -Recurse C:\\ProgramData\\Amazon\\ECS\\Cache\nImport-Module ECSTools\n[Environment]::SetEnvironmentVariable(\"ECS_CLUSTER\", \"",
          {
@@ -11033,37 +11107,11 @@
         "",
         [
          {
-          "Fn::Select": [
-           4,
-           {
-            "Fn::Split": [
-             ":",
-             {
-              "Fn::GetAtt": [
-               "WindowsImageBuilderRepositoryA4CBB6D8",
-               "Arn"
-              ]
-             }
-            ]
-           }
-          ]
+          "Ref": "AWS::AccountId"
          },
          ".dkr.ecr.",
          {
-          "Fn::Select": [
-           3,
-           {
-            "Fn::Split": [
-             ":",
-             {
-              "Fn::GetAtt": [
-               "WindowsImageBuilderRepositoryA4CBB6D8",
-               "Arn"
-              ]
-             }
-            ]
-           }
-          ]
+          "Ref": "AWS::Region"
          },
          ".",
          {
@@ -11071,7 +11119,30 @@
          },
          "/",
          {
-          "Ref": "WindowsImageBuilderRepositoryA4CBB6D8"
+          "Fn::Select": [
+           0,
+           {
+            "Fn::Split": [
+             ":",
+             {
+              "Fn::Select": [
+               1,
+               {
+                "Fn::Split": [
+                 "/",
+                 {
+                  "Fn::GetAtt": [
+                   "WindowsImageBuilderDockerImage8672CA3E",
+                   "ImageUri"
+                  ]
+                 }
+                ]
+               }
+              ]
+             }
+            ]
+           }
+          ]
          },
          ":latest"
         ]
@@ -11143,9 +11214,49 @@
        ],
        "Effect": "Allow",
        "Resource": {
-        "Fn::GetAtt": [
-         "WindowsImageBuilderRepositoryA4CBB6D8",
-         "Arn"
+        "Fn::Join": [
+         "",
+         [
+          "arn:",
+          {
+           "Ref": "AWS::Partition"
+          },
+          ":ecr:",
+          {
+           "Ref": "AWS::Region"
+          },
+          ":",
+          {
+           "Ref": "AWS::AccountId"
+          },
+          ":repository/",
+          {
+           "Fn::Select": [
+            0,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Fn::Select": [
+                1,
+                {
+                 "Fn::Split": [
+                  "/",
+                  {
+                   "Fn::GetAtt": [
+                    "WindowsImageBuilderDockerImage8672CA3E",
+                    "ImageUri"
+                   ]
+                  }
+                 ]
+                }
+               ]
+              }
+             ]
+            }
+           ]
+          }
+         ]
         ]
        }
       },
@@ -12883,37 +12994,11 @@
         "",
         [
          {
-          "Fn::Select": [
-           4,
-           {
-            "Fn::Split": [
-             ":",
-             {
-              "Fn::GetAtt": [
-               "WindowsImageBuilderRepositoryA4CBB6D8",
-               "Arn"
-              ]
-             }
-            ]
-           }
-          ]
+          "Ref": "AWS::AccountId"
          },
          ".dkr.ecr.",
          {
-          "Fn::Select": [
-           3,
-           {
-            "Fn::Split": [
-             ":",
-             {
-              "Fn::GetAtt": [
-               "WindowsImageBuilderRepositoryA4CBB6D8",
-               "Arn"
-              ]
-             }
-            ]
-           }
-          ]
+          "Ref": "AWS::Region"
          },
          ".",
          {
@@ -12921,7 +13006,30 @@
          },
          "/",
          {
-          "Ref": "WindowsImageBuilderRepositoryA4CBB6D8"
+          "Fn::Select": [
+           0,
+           {
+            "Fn::Split": [
+             ":",
+             {
+              "Fn::Select": [
+               1,
+               {
+                "Fn::Split": [
+                 "/",
+                 {
+                  "Fn::GetAtt": [
+                   "WindowsImageBuilderDockerImage8672CA3E",
+                   "ImageUri"
+                  ]
+                 }
+                ]
+               }
+              ]
+             }
+            ]
+           }
+          ]
          },
          ":latest"
         ]
@@ -12997,9 +13105,49 @@
        ],
        "Effect": "Allow",
        "Resource": {
-        "Fn::GetAtt": [
-         "WindowsImageBuilderRepositoryA4CBB6D8",
-         "Arn"
+        "Fn::Join": [
+         "",
+         [
+          "arn:",
+          {
+           "Ref": "AWS::Partition"
+          },
+          ":ecr:",
+          {
+           "Ref": "AWS::Region"
+          },
+          ":",
+          {
+           "Ref": "AWS::AccountId"
+          },
+          ":repository/",
+          {
+           "Fn::Select": [
+            0,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Fn::Select": [
+                1,
+                {
+                 "Fn::Split": [
+                  "/",
+                  {
+                   "Fn::GetAtt": [
+                    "WindowsImageBuilderDockerImage8672CA3E",
+                    "ImageUri"
+                   ]
+                  }
+                 ]
+                }
+               ]
+              }
+             ]
+            }
+           ]
+          }
+         ]
         ]
        }
       },
@@ -16362,9 +16510,49 @@
        "Action": "ecr:DescribeImages",
        "Effect": "Allow",
        "Resource": {
-        "Fn::GetAtt": [
-         "WindowsImageBuilderRepositoryA4CBB6D8",
-         "Arn"
+        "Fn::Join": [
+         "",
+         [
+          "arn:",
+          {
+           "Ref": "AWS::Partition"
+          },
+          ":ecr:",
+          {
+           "Ref": "AWS::Region"
+          },
+          ":",
+          {
+           "Ref": "AWS::AccountId"
+          },
+          ":repository/",
+          {
+           "Fn::Select": [
+            0,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Fn::Select": [
+                1,
+                {
+                 "Fn::Split": [
+                  "/",
+                  {
+                   "Fn::GetAtt": [
+                    "WindowsImageBuilderDockerImage8672CA3E",
+                    "ImageUri"
+                   ]
+                  }
+                 ]
+                }
+               ]
+              }
+             ]
+            }
+           ]
+          }
+         ]
         ]
        }
       },
@@ -16751,37 +16939,11 @@
          "",
          [
           {
-           "Fn::Select": [
-            4,
-            {
-             "Fn::Split": [
-              ":",
-              {
-               "Fn::GetAtt": [
-                "WindowsImageBuilderRepositoryA4CBB6D8",
-                "Arn"
-               ]
-              }
-             ]
-            }
-           ]
+           "Ref": "AWS::AccountId"
           },
           ".dkr.ecr.",
           {
-           "Fn::Select": [
-            3,
-            {
-             "Fn::Split": [
-              ":",
-              {
-               "Fn::GetAtt": [
-                "WindowsImageBuilderRepositoryA4CBB6D8",
-                "Arn"
-               ]
-              }
-             ]
-            }
-           ]
+           "Ref": "AWS::Region"
           },
           ".",
           {
@@ -16789,7 +16951,30 @@
           },
           "/",
           {
-           "Ref": "WindowsImageBuilderRepositoryA4CBB6D8"
+           "Fn::Select": [
+            0,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Fn::Select": [
+                1,
+                {
+                 "Fn::Split": [
+                  "/",
+                  {
+                   "Fn::GetAtt": [
+                    "WindowsImageBuilderDockerImage8672CA3E",
+                    "ImageUri"
+                   ]
+                  }
+                 ]
+                }
+               ]
+              }
+             ]
+            }
+           ]
           }
          ]
         ]
@@ -17051,37 +17236,11 @@
          "",
          [
           {
-           "Fn::Select": [
-            4,
-            {
-             "Fn::Split": [
-              ":",
-              {
-               "Fn::GetAtt": [
-                "WindowsImageBuilderRepositoryA4CBB6D8",
-                "Arn"
-               ]
-              }
-             ]
-            }
-           ]
+           "Ref": "AWS::AccountId"
           },
           ".dkr.ecr.",
           {
-           "Fn::Select": [
-            3,
-            {
-             "Fn::Split": [
-              ":",
-              {
-               "Fn::GetAtt": [
-                "WindowsImageBuilderRepositoryA4CBB6D8",
-                "Arn"
-               ]
-              }
-             ]
-            }
-           ]
+           "Ref": "AWS::Region"
           },
           ".",
           {
@@ -17089,7 +17248,30 @@
           },
           "/",
           {
-           "Ref": "WindowsImageBuilderRepositoryA4CBB6D8"
+           "Fn::Select": [
+            0,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Fn::Select": [
+                1,
+                {
+                 "Fn::Split": [
+                  "/",
+                  {
+                   "Fn::GetAtt": [
+                    "WindowsImageBuilderDockerImage8672CA3E",
+                    "ImageUri"
+                   ]
+                  }
+                 ]
+                }
+               ]
+              }
+             ]
+            }
+           ]
           }
          ]
         ]
@@ -17689,37 +17871,11 @@
          "",
          [
           {
-           "Fn::Select": [
-            4,
-            {
-             "Fn::Split": [
-              ":",
-              {
-               "Fn::GetAtt": [
-                "WindowsImageBuilderRepositoryA4CBB6D8",
-                "Arn"
-               ]
-              }
-             ]
-            }
-           ]
+           "Ref": "AWS::AccountId"
           },
           ".dkr.ecr.",
           {
-           "Fn::Select": [
-            3,
-            {
-             "Fn::Split": [
-              ":",
-              {
-               "Fn::GetAtt": [
-                "WindowsImageBuilderRepositoryA4CBB6D8",
-                "Arn"
-               ]
-              }
-             ]
-            }
-           ]
+           "Ref": "AWS::Region"
           },
           ".",
           {
@@ -17727,7 +17883,30 @@
           },
           "/",
           {
-           "Ref": "WindowsImageBuilderRepositoryA4CBB6D8"
+           "Fn::Select": [
+            0,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Fn::Select": [
+                1,
+                {
+                 "Fn::Split": [
+                  "/",
+                  {
+                   "Fn::GetAtt": [
+                    "WindowsImageBuilderDockerImage8672CA3E",
+                    "ImageUri"
+                   ]
+                  }
+                 ]
+                }
+               ]
+              }
+             ]
+            }
+           ]
           }
          ]
         ]

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -9090,49 +9090,9 @@
        ],
        "Effect": "Allow",
        "Resource": {
-        "Fn::Join": [
-         "",
-         [
-          "arn:",
-          {
-           "Ref": "AWS::Partition"
-          },
-          ":ecr:",
-          {
-           "Ref": "AWS::Region"
-          },
-          ":",
-          {
-           "Ref": "AWS::AccountId"
-          },
-          ":repository/",
-          {
-           "Fn::Select": [
-            0,
-            {
-             "Fn::Split": [
-              ":",
-              {
-               "Fn::Select": [
-                1,
-                {
-                 "Fn::Split": [
-                  "/",
-                  {
-                   "Fn::GetAtt": [
-                    "WindowsImageBuilderDockerImage8672CA3E",
-                    "ImageUri"
-                   ]
-                  }
-                 ]
-                }
-               ]
-              }
-             ]
-            }
-           ]
-          }
-         ]
+        "Fn::GetAtt": [
+         "WindowsImageBuilderRepositoryA4CBB6D8",
+         "Arn"
         ]
        }
       },
@@ -9269,11 +9229,37 @@
        "",
        [
         {
-         "Ref": "AWS::AccountId"
+         "Fn::Select": [
+          4,
+          {
+           "Fn::Split": [
+            ":",
+            {
+             "Fn::GetAtt": [
+              "WindowsImageBuilderRepositoryA4CBB6D8",
+              "Arn"
+             ]
+            }
+           ]
+          }
+         ]
         },
         ".dkr.ecr.",
         {
-         "Ref": "AWS::Region"
+         "Fn::Select": [
+          3,
+          {
+           "Fn::Split": [
+            ":",
+            {
+             "Fn::GetAtt": [
+              "WindowsImageBuilderRepositoryA4CBB6D8",
+              "Arn"
+             ]
+            }
+           ]
+          }
+         ]
         },
         ".",
         {
@@ -9281,30 +9267,7 @@
         },
         "/",
         {
-         "Fn::Select": [
-          0,
-          {
-           "Fn::Split": [
-            ":",
-            {
-             "Fn::Select": [
-              1,
-              {
-               "Fn::Split": [
-                "/",
-                {
-                 "Fn::GetAtt": [
-                  "WindowsImageBuilderDockerImage8672CA3E",
-                  "ImageUri"
-                 ]
-                }
-               ]
-              }
-             ]
-            }
-           ]
-          }
-         ]
+         "Ref": "WindowsImageBuilderRepositoryA4CBB6D8"
         },
         ":latest"
        ]
@@ -9593,29 +9556,7 @@
     "DefaultCapacityProviderStrategy": []
    }
   },
-  "ECSAutoScalingGroupInstanceSecurityGroup87D56BFE": {
-   "Type": "AWS::EC2::SecurityGroup",
-   "Properties": {
-    "GroupDescription": "github-runners-test/ECS/Auto Scaling Group/InstanceSecurityGroup",
-    "SecurityGroupEgress": [
-     {
-      "CidrIp": "0.0.0.0/0",
-      "Description": "Allow all outbound traffic by default",
-      "IpProtocol": "-1"
-     }
-    ],
-    "Tags": [
-     {
-      "Key": "Name",
-      "Value": "github-runners-test/ECS/Auto Scaling Group"
-     }
-    ],
-    "VpcId": {
-     "Ref": "Vpc8378EB38"
-    }
-   }
-  },
-  "ECSAutoScalingGroupInstanceRoleCA234A7C": {
+  "ECSLaunchTemplateRole3D54417B": {
    "Type": "AWS::IAM::Role",
    "Properties": {
     "AssumeRolePolicyDocument": {
@@ -9653,16 +9594,10 @@
        ]
       ]
      }
-    ],
-    "Tags": [
-     {
-      "Key": "Name",
-      "Value": "github-runners-test/ECS/Auto Scaling Group"
-     }
     ]
    }
   },
-  "ECSAutoScalingGroupInstanceRoleDefaultPolicy86A5959D": {
+  "ECSLaunchTemplateRoleDefaultPolicyA6578409": {
    "Type": "AWS::IAM::Policy",
    "Properties": {
     "PolicyDocument": {
@@ -9728,138 +9663,165 @@
      ],
      "Version": "2012-10-17"
     },
-    "PolicyName": "ECSAutoScalingGroupInstanceRoleDefaultPolicy86A5959D",
+    "PolicyName": "ECSLaunchTemplateRoleDefaultPolicyA6578409",
     "Roles": [
      {
-      "Ref": "ECSAutoScalingGroupInstanceRoleCA234A7C"
+      "Ref": "ECSLaunchTemplateRole3D54417B"
      }
     ]
    }
   },
-  "ECSAutoScalingGroupInstanceProfile288AC654": {
+  "ECSLaunchTemplateProfileC7A3F149": {
    "Type": "AWS::IAM::InstanceProfile",
    "Properties": {
     "Roles": [
      {
-      "Ref": "ECSAutoScalingGroupInstanceRoleCA234A7C"
+      "Ref": "ECSLaunchTemplateRole3D54417B"
      }
     ]
    }
   },
-  "ECSAutoScalingGroupLaunchConfigC22C3413": {
-   "Type": "AWS::AutoScaling::LaunchConfiguration",
+  "ECSLaunchTemplate3A132D2F": {
+   "Type": "AWS::EC2::LaunchTemplate",
    "Properties": {
-    "ImageId": {
-     "Ref": "SsmParameterValueawsserviceecsoptimizedamiamazonlinux2recommendedimageidC96584B6F00A464EAD1953AFF4B05118Parameter"
-    },
-    "InstanceType": "m5.large",
-    "IamInstanceProfile": {
-     "Ref": "ECSAutoScalingGroupInstanceProfile288AC654"
-    },
-    "MetadataOptions": {
-     "HttpTokens": "required"
-    },
-    "SecurityGroups": [
-     {
-      "Fn::GetAtt": [
-       "ECSAutoScalingGroupInstanceSecurityGroup87D56BFE",
-       "GroupId"
-      ]
-     },
-     {
-      "Fn::GetAtt": [
-       "ECSsecuritygroup76605212",
-       "GroupId"
-      ]
-     }
-    ],
-    "UserData": {
-     "Fn::Base64": {
-      "Fn::Join": [
-       "",
-       [
-        "#!/bin/bash\naws ecr get-login-password --region ",
-        {
-         "Ref": "AWS::Region"
-        },
-        " | docker login --username AWS --password-stdin ",
-        {
-         "Ref": "AWS::AccountId"
-        },
-        ".dkr.ecr.",
-        {
-         "Ref": "AWS::Region"
-        },
-        ".amazonaws.com\ndocker pull ",
-        {
-         "Fn::Select": [
-          4,
-          {
-           "Fn::Split": [
-            ":",
-            {
-             "Ref": "CodeBuildImageBuilderB8638EC8"
-            }
-           ]
-          }
-         ]
-        },
-        ".dkr.ecr.",
-        {
-         "Fn::Select": [
-          3,
-          {
-           "Fn::Split": [
-            ":",
-            {
-             "Ref": "CodeBuildImageBuilderB8638EC8"
-            }
-           ]
-          }
-         ]
-        },
-        ".",
-        {
-         "Ref": "AWS::URLSuffix"
-        },
-        "/",
-        {
-         "Fn::GetAtt": [
-          "CodeBuildImageBuilderB8638EC8",
-          "Name"
-         ]
-        },
-        ":latest &\necho ECS_CLUSTER=",
-        {
-         "Ref": "ECScluster20BC0B82"
-        },
-        " >> /etc/ecs/ecs.config\nsudo iptables --insert FORWARD 1 --in-interface docker+ --destination 169.254.169.254/32 --jump DROP\nsudo service iptables save\necho ECS_AWSVPC_BLOCK_IMDS=true >> /etc/ecs/ecs.config"
+    "LaunchTemplateData": {
+     "IamInstanceProfile": {
+      "Arn": {
+       "Fn::GetAtt": [
+        "ECSLaunchTemplateProfileC7A3F149",
+        "Arn"
        ]
+      }
+     },
+     "ImageId": "resolve:ssm:/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id",
+     "InstanceType": "m5.large",
+     "MetadataOptions": {
+      "HttpTokens": "required"
+     },
+     "SecurityGroupIds": [
+      {
+       "Fn::GetAtt": [
+        "ECSsecuritygroup76605212",
+        "GroupId"
+       ]
+      }
+     ],
+     "TagSpecifications": [
+      {
+       "ResourceType": "instance",
+       "Tags": [
+        {
+         "Key": "Name",
+         "Value": "github-runners-test/ECS/Launch Template"
+        }
+       ]
+      },
+      {
+       "ResourceType": "volume",
+       "Tags": [
+        {
+         "Key": "Name",
+         "Value": "github-runners-test/ECS/Launch Template"
+        }
+       ]
+      }
+     ],
+     "UserData": {
+      "Fn::Base64": {
+       "Fn::Join": [
+        "",
+        [
+         "#!/bin/bash\naws ecr get-login-password --region ",
+         {
+          "Ref": "AWS::Region"
+         },
+         " | docker login --username AWS --password-stdin ",
+         {
+          "Ref": "AWS::AccountId"
+         },
+         ".dkr.ecr.",
+         {
+          "Ref": "AWS::Region"
+         },
+         ".amazonaws.com\ndocker pull ",
+         {
+          "Fn::Select": [
+           4,
+           {
+            "Fn::Split": [
+             ":",
+             {
+              "Ref": "CodeBuildImageBuilderB8638EC8"
+             }
+            ]
+           }
+          ]
+         },
+         ".dkr.ecr.",
+         {
+          "Fn::Select": [
+           3,
+           {
+            "Fn::Split": [
+             ":",
+             {
+              "Ref": "CodeBuildImageBuilderB8638EC8"
+             }
+            ]
+           }
+          ]
+         },
+         ".",
+         {
+          "Ref": "AWS::URLSuffix"
+         },
+         "/",
+         {
+          "Fn::GetAtt": [
+           "CodeBuildImageBuilderB8638EC8",
+           "Name"
+          ]
+         },
+         ":latest &\necho ECS_CLUSTER=",
+         {
+          "Ref": "ECScluster20BC0B82"
+         },
+         " >> /etc/ecs/ecs.config\nsudo iptables --insert FORWARD 1 --in-interface docker+ --destination 169.254.169.254/32 --jump DROP\nsudo service iptables save\necho ECS_AWSVPC_BLOCK_IMDS=true >> /etc/ecs/ecs.config"
+        ]
+       ]
+      }
+     }
+    },
+    "TagSpecifications": [
+     {
+      "ResourceType": "launch-template",
+      "Tags": [
+       {
+        "Key": "Name",
+        "Value": "github-runners-test/ECS/Launch Template"
+       }
       ]
      }
-    }
-   },
-   "DependsOn": [
-    "ECSAutoScalingGroupInstanceRoleDefaultPolicy86A5959D",
-    "ECSAutoScalingGroupInstanceRoleCA234A7C"
-   ]
+    ]
+   }
   },
   "ECSAutoScalingGroupASG88763D9A": {
    "Type": "AWS::AutoScaling::AutoScalingGroup",
    "Properties": {
     "MaxSize": "1",
     "MinSize": "0",
-    "LaunchConfigurationName": {
-     "Ref": "ECSAutoScalingGroupLaunchConfigC22C3413"
+    "LaunchTemplate": {
+     "LaunchTemplateId": {
+      "Ref": "ECSLaunchTemplate3A132D2F"
+     },
+     "Version": {
+      "Fn::GetAtt": [
+       "ECSLaunchTemplate3A132D2F",
+       "LatestVersionNumber"
+      ]
+     }
     },
     "NewInstancesProtectedFromScaleIn": true,
-    "Tags": [
-     {
-      "Key": "Name",
-      "PropagateAtLaunch": true,
-      "Value": "github-runners-test/ECS/Auto Scaling Group"
-     }
-    ],
     "VPCZoneIdentifier": [
      {
       "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
@@ -10147,29 +10109,7 @@
     "DefaultCapacityProviderStrategy": []
    }
   },
-  "ECSARM64AutoScalingGroupInstanceSecurityGroupB68B781E": {
-   "Type": "AWS::EC2::SecurityGroup",
-   "Properties": {
-    "GroupDescription": "github-runners-test/ECS ARM64/Auto Scaling Group/InstanceSecurityGroup",
-    "SecurityGroupEgress": [
-     {
-      "CidrIp": "0.0.0.0/0",
-      "Description": "Allow all outbound traffic by default",
-      "IpProtocol": "-1"
-     }
-    ],
-    "Tags": [
-     {
-      "Key": "Name",
-      "Value": "github-runners-test/ECS ARM64/Auto Scaling Group"
-     }
-    ],
-    "VpcId": {
-     "Ref": "Vpc8378EB38"
-    }
-   }
-  },
-  "ECSARM64AutoScalingGroupInstanceRole01030665": {
+  "ECSARM64LaunchTemplateRole9D1574E2": {
    "Type": "AWS::IAM::Role",
    "Properties": {
     "AssumeRolePolicyDocument": {
@@ -10207,16 +10147,10 @@
        ]
       ]
      }
-    ],
-    "Tags": [
-     {
-      "Key": "Name",
-      "Value": "github-runners-test/ECS ARM64/Auto Scaling Group"
-     }
     ]
    }
   },
-  "ECSARM64AutoScalingGroupInstanceRoleDefaultPolicyD0E29275": {
+  "ECSARM64LaunchTemplateRoleDefaultPolicy0705A7AA": {
    "Type": "AWS::IAM::Policy",
    "Properties": {
     "PolicyDocument": {
@@ -10282,138 +10216,165 @@
      ],
      "Version": "2012-10-17"
     },
-    "PolicyName": "ECSARM64AutoScalingGroupInstanceRoleDefaultPolicyD0E29275",
+    "PolicyName": "ECSARM64LaunchTemplateRoleDefaultPolicy0705A7AA",
     "Roles": [
      {
-      "Ref": "ECSARM64AutoScalingGroupInstanceRole01030665"
+      "Ref": "ECSARM64LaunchTemplateRole9D1574E2"
      }
     ]
    }
   },
-  "ECSARM64AutoScalingGroupInstanceProfile768645E6": {
+  "ECSARM64LaunchTemplateProfileBF272018": {
    "Type": "AWS::IAM::InstanceProfile",
    "Properties": {
     "Roles": [
      {
-      "Ref": "ECSARM64AutoScalingGroupInstanceRole01030665"
+      "Ref": "ECSARM64LaunchTemplateRole9D1574E2"
      }
     ]
    }
   },
-  "ECSARM64AutoScalingGroupLaunchConfig9B8B62ED": {
-   "Type": "AWS::AutoScaling::LaunchConfiguration",
+  "ECSARM64LaunchTemplateC44F6059": {
+   "Type": "AWS::EC2::LaunchTemplate",
    "Properties": {
-    "ImageId": {
-     "Ref": "SsmParameterValueawsserviceecsoptimizedamiamazonlinux2arm64recommendedimageidC96584B6F00A464EAD1953AFF4B05118Parameter"
-    },
-    "InstanceType": "m6g.large",
-    "IamInstanceProfile": {
-     "Ref": "ECSARM64AutoScalingGroupInstanceProfile768645E6"
-    },
-    "MetadataOptions": {
-     "HttpTokens": "required"
-    },
-    "SecurityGroups": [
-     {
-      "Fn::GetAtt": [
-       "ECSARM64AutoScalingGroupInstanceSecurityGroupB68B781E",
-       "GroupId"
-      ]
-     },
-     {
-      "Fn::GetAtt": [
-       "ECSARM64securitygroup281D94B2",
-       "GroupId"
-      ]
-     }
-    ],
-    "UserData": {
-     "Fn::Base64": {
-      "Fn::Join": [
-       "",
-       [
-        "#!/bin/bash\naws ecr get-login-password --region ",
-        {
-         "Ref": "AWS::Region"
-        },
-        " | docker login --username AWS --password-stdin ",
-        {
-         "Ref": "AWS::AccountId"
-        },
-        ".dkr.ecr.",
-        {
-         "Ref": "AWS::Region"
-        },
-        ".amazonaws.com\ndocker pull ",
-        {
-         "Fn::Select": [
-          4,
-          {
-           "Fn::Split": [
-            ":",
-            {
-             "Ref": "CodeBuildImageBuilderarmBuilder755EB37D"
-            }
-           ]
-          }
-         ]
-        },
-        ".dkr.ecr.",
-        {
-         "Fn::Select": [
-          3,
-          {
-           "Fn::Split": [
-            ":",
-            {
-             "Ref": "CodeBuildImageBuilderarmBuilder755EB37D"
-            }
-           ]
-          }
-         ]
-        },
-        ".",
-        {
-         "Ref": "AWS::URLSuffix"
-        },
-        "/",
-        {
-         "Fn::GetAtt": [
-          "CodeBuildImageBuilderarmBuilder755EB37D",
-          "Name"
-         ]
-        },
-        ":latest &\necho ECS_CLUSTER=",
-        {
-         "Ref": "ECSARM64cluster4ECAA083"
-        },
-        " >> /etc/ecs/ecs.config\nsudo iptables --insert FORWARD 1 --in-interface docker+ --destination 169.254.169.254/32 --jump DROP\nsudo service iptables save\necho ECS_AWSVPC_BLOCK_IMDS=true >> /etc/ecs/ecs.config"
+    "LaunchTemplateData": {
+     "IamInstanceProfile": {
+      "Arn": {
+       "Fn::GetAtt": [
+        "ECSARM64LaunchTemplateProfileBF272018",
+        "Arn"
        ]
+      }
+     },
+     "ImageId": "resolve:ssm:/aws/service/ecs/optimized-ami/amazon-linux-2/arm64/recommended/image_id",
+     "InstanceType": "m6g.large",
+     "MetadataOptions": {
+      "HttpTokens": "required"
+     },
+     "SecurityGroupIds": [
+      {
+       "Fn::GetAtt": [
+        "ECSARM64securitygroup281D94B2",
+        "GroupId"
+       ]
+      }
+     ],
+     "TagSpecifications": [
+      {
+       "ResourceType": "instance",
+       "Tags": [
+        {
+         "Key": "Name",
+         "Value": "github-runners-test/ECS ARM64/Launch Template"
+        }
+       ]
+      },
+      {
+       "ResourceType": "volume",
+       "Tags": [
+        {
+         "Key": "Name",
+         "Value": "github-runners-test/ECS ARM64/Launch Template"
+        }
+       ]
+      }
+     ],
+     "UserData": {
+      "Fn::Base64": {
+       "Fn::Join": [
+        "",
+        [
+         "#!/bin/bash\naws ecr get-login-password --region ",
+         {
+          "Ref": "AWS::Region"
+         },
+         " | docker login --username AWS --password-stdin ",
+         {
+          "Ref": "AWS::AccountId"
+         },
+         ".dkr.ecr.",
+         {
+          "Ref": "AWS::Region"
+         },
+         ".amazonaws.com\ndocker pull ",
+         {
+          "Fn::Select": [
+           4,
+           {
+            "Fn::Split": [
+             ":",
+             {
+              "Ref": "CodeBuildImageBuilderarmBuilder755EB37D"
+             }
+            ]
+           }
+          ]
+         },
+         ".dkr.ecr.",
+         {
+          "Fn::Select": [
+           3,
+           {
+            "Fn::Split": [
+             ":",
+             {
+              "Ref": "CodeBuildImageBuilderarmBuilder755EB37D"
+             }
+            ]
+           }
+          ]
+         },
+         ".",
+         {
+          "Ref": "AWS::URLSuffix"
+         },
+         "/",
+         {
+          "Fn::GetAtt": [
+           "CodeBuildImageBuilderarmBuilder755EB37D",
+           "Name"
+          ]
+         },
+         ":latest &\necho ECS_CLUSTER=",
+         {
+          "Ref": "ECSARM64cluster4ECAA083"
+         },
+         " >> /etc/ecs/ecs.config\nsudo iptables --insert FORWARD 1 --in-interface docker+ --destination 169.254.169.254/32 --jump DROP\nsudo service iptables save\necho ECS_AWSVPC_BLOCK_IMDS=true >> /etc/ecs/ecs.config"
+        ]
+       ]
+      }
+     }
+    },
+    "TagSpecifications": [
+     {
+      "ResourceType": "launch-template",
+      "Tags": [
+       {
+        "Key": "Name",
+        "Value": "github-runners-test/ECS ARM64/Launch Template"
+       }
       ]
      }
-    }
-   },
-   "DependsOn": [
-    "ECSARM64AutoScalingGroupInstanceRoleDefaultPolicyD0E29275",
-    "ECSARM64AutoScalingGroupInstanceRole01030665"
-   ]
+    ]
+   }
   },
   "ECSARM64AutoScalingGroupASGA19FC118": {
    "Type": "AWS::AutoScaling::AutoScalingGroup",
    "Properties": {
     "MaxSize": "1",
     "MinSize": "0",
-    "LaunchConfigurationName": {
-     "Ref": "ECSARM64AutoScalingGroupLaunchConfig9B8B62ED"
+    "LaunchTemplate": {
+     "LaunchTemplateId": {
+      "Ref": "ECSARM64LaunchTemplateC44F6059"
+     },
+     "Version": {
+      "Fn::GetAtt": [
+       "ECSARM64LaunchTemplateC44F6059",
+       "LatestVersionNumber"
+      ]
+     }
     },
     "NewInstancesProtectedFromScaleIn": true,
-    "Tags": [
-     {
-      "Key": "Name",
-      "PropagateAtLaunch": true,
-      "Value": "github-runners-test/ECS ARM64/Auto Scaling Group"
-     }
-    ],
     "VPCZoneIdentifier": [
      {
       "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
@@ -10701,29 +10662,7 @@
     "DefaultCapacityProviderStrategy": []
    }
   },
-  "ECSWindowsAutoScalingGroupInstanceSecurityGroupA3DBA17A": {
-   "Type": "AWS::EC2::SecurityGroup",
-   "Properties": {
-    "GroupDescription": "github-runners-test/ECS Windows/Auto Scaling Group/InstanceSecurityGroup",
-    "SecurityGroupEgress": [
-     {
-      "CidrIp": "0.0.0.0/0",
-      "Description": "Allow all outbound traffic by default",
-      "IpProtocol": "-1"
-     }
-    ],
-    "Tags": [
-     {
-      "Key": "Name",
-      "Value": "github-runners-test/ECS Windows/Auto Scaling Group"
-     }
-    ],
-    "VpcId": {
-     "Ref": "Vpc8378EB38"
-    }
-   }
-  },
-  "ECSWindowsAutoScalingGroupInstanceRoleFB287046": {
+  "ECSWindowsLaunchTemplateRole610E9A88": {
    "Type": "AWS::IAM::Role",
    "Properties": {
     "AssumeRolePolicyDocument": {
@@ -10761,16 +10700,10 @@
        ]
       ]
      }
-    ],
-    "Tags": [
-     {
-      "Key": "Name",
-      "Value": "github-runners-test/ECS Windows/Auto Scaling Group"
-     }
     ]
    }
   },
-  "ECSWindowsAutoScalingGroupInstanceRoleDefaultPolicyAEE83B95": {
+  "ECSWindowsLaunchTemplateRoleDefaultPolicy48457459": {
    "Type": "AWS::IAM::Policy",
    "Properties": {
     "PolicyDocument": {
@@ -10783,49 +10716,9 @@
        ],
        "Effect": "Allow",
        "Resource": {
-        "Fn::Join": [
-         "",
-         [
-          "arn:",
-          {
-           "Ref": "AWS::Partition"
-          },
-          ":ecr:",
-          {
-           "Ref": "AWS::Region"
-          },
-          ":",
-          {
-           "Ref": "AWS::AccountId"
-          },
-          ":repository/",
-          {
-           "Fn::Select": [
-            0,
-            {
-             "Fn::Split": [
-              ":",
-              {
-               "Fn::Select": [
-                1,
-                {
-                 "Fn::Split": [
-                  "/",
-                  {
-                   "Fn::GetAtt": [
-                    "WindowsImageBuilderDockerImage8672CA3E",
-                    "ImageUri"
-                   ]
-                  }
-                 ]
-                }
-               ]
-              }
-             ]
-            }
-           ]
-          }
-         ]
+        "Fn::GetAtt": [
+         "WindowsImageBuilderRepositoryA4CBB6D8",
+         "Arn"
         ]
        }
       },
@@ -10879,138 +10772,168 @@
      ],
      "Version": "2012-10-17"
     },
-    "PolicyName": "ECSWindowsAutoScalingGroupInstanceRoleDefaultPolicyAEE83B95",
+    "PolicyName": "ECSWindowsLaunchTemplateRoleDefaultPolicy48457459",
     "Roles": [
      {
-      "Ref": "ECSWindowsAutoScalingGroupInstanceRoleFB287046"
+      "Ref": "ECSWindowsLaunchTemplateRole610E9A88"
      }
     ]
    }
   },
-  "ECSWindowsAutoScalingGroupInstanceProfileD8019407": {
+  "ECSWindowsLaunchTemplateProfile4B6AA05B": {
    "Type": "AWS::IAM::InstanceProfile",
    "Properties": {
     "Roles": [
      {
-      "Ref": "ECSWindowsAutoScalingGroupInstanceRoleFB287046"
+      "Ref": "ECSWindowsLaunchTemplateRole610E9A88"
      }
     ]
    }
   },
-  "ECSWindowsAutoScalingGroupLaunchConfigAD09CF33": {
-   "Type": "AWS::AutoScaling::LaunchConfiguration",
+  "ECSWindowsLaunchTemplateA6BF5C73": {
+   "Type": "AWS::EC2::LaunchTemplate",
    "Properties": {
-    "ImageId": {
-     "Ref": "SsmParameterValueawsserviceamiwindowslatestWindowsServer2019EnglishFullECSOptimizedimageidC96584B6F00A464EAD1953AFF4B05118Parameter"
-    },
-    "InstanceType": "m5.large",
-    "IamInstanceProfile": {
-     "Ref": "ECSWindowsAutoScalingGroupInstanceProfileD8019407"
-    },
-    "MetadataOptions": {
-     "HttpTokens": "required"
-    },
-    "SecurityGroups": [
-     {
-      "Fn::GetAtt": [
-       "ECSWindowsAutoScalingGroupInstanceSecurityGroupA3DBA17A",
-       "GroupId"
-      ]
-     },
-     {
-      "Fn::GetAtt": [
-       "ECSWindowssecuritygroupB4EE54DA",
-       "GroupId"
-      ]
-     }
-    ],
-    "UserData": {
-     "Fn::Base64": {
-      "Fn::Join": [
-       "",
-       [
-        "<powershell>(Get-ECRLoginCommand).Password | docker login --username AWS --password-stdin ",
-        {
-         "Ref": "AWS::AccountId"
-        },
-        ".dkr.ecr.",
-        {
-         "Ref": "AWS::Region"
-        },
-        ".amazonaws.com\nStart-Job -ScriptBlock { docker pull ",
-        {
-         "Ref": "AWS::AccountId"
-        },
-        ".dkr.ecr.",
-        {
-         "Ref": "AWS::Region"
-        },
-        ".",
-        {
-         "Ref": "AWS::URLSuffix"
-        },
-        "/",
-        {
-         "Fn::Select": [
-          0,
-          {
-           "Fn::Split": [
-            ":",
-            {
-             "Fn::Select": [
-              1,
-              {
-               "Fn::Split": [
-                "/",
-                {
-                 "Fn::GetAtt": [
-                  "WindowsImageBuilderDockerImage8672CA3E",
-                  "ImageUri"
-                 ]
-                }
-               ]
-              }
-             ]
-            }
-           ]
-          }
-         ]
-        },
-        ":latest }\nRemove-Item -Recurse C:\\ProgramData\\Amazon\\ECS\\Cache\nImport-Module ECSTools\n[Environment]::SetEnvironmentVariable(\"ECS_CLUSTER\", \"",
-        {
-         "Ref": "ECSWindowscluster14061F74"
-        },
-        "\", \"Machine\")\n[Environment]::SetEnvironmentVariable(\"ECS_ENABLE_AWSLOGS_EXECUTIONROLE_OVERRIDE\", \"true\", \"Machine\")\n[Environment]::SetEnvironmentVariable(\"ECS_AVAILABLE_LOGGING_DRIVERS\", '[\"json-file\",\"awslogs\"]', \"Machine\")\n[Environment]::SetEnvironmentVariable(\"ECS_ENABLE_TASK_IAM_ROLE\", \"true\", \"Machine\")\nInitialize-ECSAgent -Cluster '",
-        {
-         "Ref": "ECSWindowscluster14061F74"
-        },
-        "' -EnableTaskIAMRole</powershell>"
+    "LaunchTemplateData": {
+     "IamInstanceProfile": {
+      "Arn": {
+       "Fn::GetAtt": [
+        "ECSWindowsLaunchTemplateProfile4B6AA05B",
+        "Arn"
        ]
+      }
+     },
+     "ImageId": "resolve:ssm:/aws/service/ami-windows-latest/Windows_Server-2019-English-Full-ECS_Optimized/image_id",
+     "InstanceType": "m5.large",
+     "MetadataOptions": {
+      "HttpTokens": "required"
+     },
+     "SecurityGroupIds": [
+      {
+       "Fn::GetAtt": [
+        "ECSWindowssecuritygroupB4EE54DA",
+        "GroupId"
+       ]
+      }
+     ],
+     "TagSpecifications": [
+      {
+       "ResourceType": "instance",
+       "Tags": [
+        {
+         "Key": "Name",
+         "Value": "github-runners-test/ECS Windows/Launch Template"
+        }
+       ]
+      },
+      {
+       "ResourceType": "volume",
+       "Tags": [
+        {
+         "Key": "Name",
+         "Value": "github-runners-test/ECS Windows/Launch Template"
+        }
+       ]
+      }
+     ],
+     "UserData": {
+      "Fn::Base64": {
+       "Fn::Join": [
+        "",
+        [
+         "<powershell>(Get-ECRLoginCommand).Password | docker login --username AWS --password-stdin ",
+         {
+          "Ref": "AWS::AccountId"
+         },
+         ".dkr.ecr.",
+         {
+          "Ref": "AWS::Region"
+         },
+         ".amazonaws.com\nStart-Job -ScriptBlock { docker pull ",
+         {
+          "Fn::Select": [
+           4,
+           {
+            "Fn::Split": [
+             ":",
+             {
+              "Fn::GetAtt": [
+               "WindowsImageBuilderRepositoryA4CBB6D8",
+               "Arn"
+              ]
+             }
+            ]
+           }
+          ]
+         },
+         ".dkr.ecr.",
+         {
+          "Fn::Select": [
+           3,
+           {
+            "Fn::Split": [
+             ":",
+             {
+              "Fn::GetAtt": [
+               "WindowsImageBuilderRepositoryA4CBB6D8",
+               "Arn"
+              ]
+             }
+            ]
+           }
+          ]
+         },
+         ".",
+         {
+          "Ref": "AWS::URLSuffix"
+         },
+         "/",
+         {
+          "Ref": "WindowsImageBuilderRepositoryA4CBB6D8"
+         },
+         ":latest }\nRemove-Item -Recurse C:\\ProgramData\\Amazon\\ECS\\Cache\nImport-Module ECSTools\n[Environment]::SetEnvironmentVariable(\"ECS_CLUSTER\", \"",
+         {
+          "Ref": "ECSWindowscluster14061F74"
+         },
+         "\", \"Machine\")\n[Environment]::SetEnvironmentVariable(\"ECS_ENABLE_AWSLOGS_EXECUTIONROLE_OVERRIDE\", \"true\", \"Machine\")\n[Environment]::SetEnvironmentVariable(\"ECS_AVAILABLE_LOGGING_DRIVERS\", '[\"json-file\",\"awslogs\"]', \"Machine\")\n[Environment]::SetEnvironmentVariable(\"ECS_ENABLE_TASK_IAM_ROLE\", \"true\", \"Machine\")\nInitialize-ECSAgent -Cluster '",
+         {
+          "Ref": "ECSWindowscluster14061F74"
+         },
+         "' -EnableTaskIAMRole</powershell>"
+        ]
+       ]
+      }
+     }
+    },
+    "TagSpecifications": [
+     {
+      "ResourceType": "launch-template",
+      "Tags": [
+       {
+        "Key": "Name",
+        "Value": "github-runners-test/ECS Windows/Launch Template"
+       }
       ]
      }
-    }
-   },
-   "DependsOn": [
-    "ECSWindowsAutoScalingGroupInstanceRoleDefaultPolicyAEE83B95",
-    "ECSWindowsAutoScalingGroupInstanceRoleFB287046"
-   ]
+    ]
+   }
   },
   "ECSWindowsAutoScalingGroupASG864E3AAF": {
    "Type": "AWS::AutoScaling::AutoScalingGroup",
    "Properties": {
     "MaxSize": "1",
     "MinSize": "0",
-    "LaunchConfigurationName": {
-     "Ref": "ECSWindowsAutoScalingGroupLaunchConfigAD09CF33"
+    "LaunchTemplate": {
+     "LaunchTemplateId": {
+      "Ref": "ECSWindowsLaunchTemplateA6BF5C73"
+     },
+     "Version": {
+      "Fn::GetAtt": [
+       "ECSWindowsLaunchTemplateA6BF5C73",
+       "LatestVersionNumber"
+      ]
+     }
     },
     "NewInstancesProtectedFromScaleIn": true,
-    "Tags": [
-     {
-      "Key": "Name",
-      "PropagateAtLaunch": true,
-      "Value": "github-runners-test/ECS Windows/Auto Scaling Group"
-     }
-    ],
     "VPCZoneIdentifier": [
      {
       "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
@@ -11110,11 +11033,37 @@
         "",
         [
          {
-          "Ref": "AWS::AccountId"
+          "Fn::Select": [
+           4,
+           {
+            "Fn::Split": [
+             ":",
+             {
+              "Fn::GetAtt": [
+               "WindowsImageBuilderRepositoryA4CBB6D8",
+               "Arn"
+              ]
+             }
+            ]
+           }
+          ]
          },
          ".dkr.ecr.",
          {
-          "Ref": "AWS::Region"
+          "Fn::Select": [
+           3,
+           {
+            "Fn::Split": [
+             ":",
+             {
+              "Fn::GetAtt": [
+               "WindowsImageBuilderRepositoryA4CBB6D8",
+               "Arn"
+              ]
+             }
+            ]
+           }
+          ]
          },
          ".",
          {
@@ -11122,30 +11071,7 @@
          },
          "/",
          {
-          "Fn::Select": [
-           0,
-           {
-            "Fn::Split": [
-             ":",
-             {
-              "Fn::Select": [
-               1,
-               {
-                "Fn::Split": [
-                 "/",
-                 {
-                  "Fn::GetAtt": [
-                   "WindowsImageBuilderDockerImage8672CA3E",
-                   "ImageUri"
-                  ]
-                 }
-                ]
-               }
-              ]
-             }
-            ]
-           }
-          ]
+          "Ref": "WindowsImageBuilderRepositoryA4CBB6D8"
          },
          ":latest"
         ]
@@ -11217,49 +11143,9 @@
        ],
        "Effect": "Allow",
        "Resource": {
-        "Fn::Join": [
-         "",
-         [
-          "arn:",
-          {
-           "Ref": "AWS::Partition"
-          },
-          ":ecr:",
-          {
-           "Ref": "AWS::Region"
-          },
-          ":",
-          {
-           "Ref": "AWS::AccountId"
-          },
-          ":repository/",
-          {
-           "Fn::Select": [
-            0,
-            {
-             "Fn::Split": [
-              ":",
-              {
-               "Fn::Select": [
-                1,
-                {
-                 "Fn::Split": [
-                  "/",
-                  {
-                   "Fn::GetAtt": [
-                    "WindowsImageBuilderDockerImage8672CA3E",
-                    "ImageUri"
-                   ]
-                  }
-                 ]
-                }
-               ]
-              }
-             ]
-            }
-           ]
-          }
-         ]
+        "Fn::GetAtt": [
+         "WindowsImageBuilderRepositoryA4CBB6D8",
+         "Arn"
         ]
        }
       },
@@ -12997,11 +12883,37 @@
         "",
         [
          {
-          "Ref": "AWS::AccountId"
+          "Fn::Select": [
+           4,
+           {
+            "Fn::Split": [
+             ":",
+             {
+              "Fn::GetAtt": [
+               "WindowsImageBuilderRepositoryA4CBB6D8",
+               "Arn"
+              ]
+             }
+            ]
+           }
+          ]
          },
          ".dkr.ecr.",
          {
-          "Ref": "AWS::Region"
+          "Fn::Select": [
+           3,
+           {
+            "Fn::Split": [
+             ":",
+             {
+              "Fn::GetAtt": [
+               "WindowsImageBuilderRepositoryA4CBB6D8",
+               "Arn"
+              ]
+             }
+            ]
+           }
+          ]
          },
          ".",
          {
@@ -13009,30 +12921,7 @@
          },
          "/",
          {
-          "Fn::Select": [
-           0,
-           {
-            "Fn::Split": [
-             ":",
-             {
-              "Fn::Select": [
-               1,
-               {
-                "Fn::Split": [
-                 "/",
-                 {
-                  "Fn::GetAtt": [
-                   "WindowsImageBuilderDockerImage8672CA3E",
-                   "ImageUri"
-                  ]
-                 }
-                ]
-               }
-              ]
-             }
-            ]
-           }
-          ]
+          "Ref": "WindowsImageBuilderRepositoryA4CBB6D8"
          },
          ":latest"
         ]
@@ -13108,49 +12997,9 @@
        ],
        "Effect": "Allow",
        "Resource": {
-        "Fn::Join": [
-         "",
-         [
-          "arn:",
-          {
-           "Ref": "AWS::Partition"
-          },
-          ":ecr:",
-          {
-           "Ref": "AWS::Region"
-          },
-          ":",
-          {
-           "Ref": "AWS::AccountId"
-          },
-          ":repository/",
-          {
-           "Fn::Select": [
-            0,
-            {
-             "Fn::Split": [
-              ":",
-              {
-               "Fn::Select": [
-                1,
-                {
-                 "Fn::Split": [
-                  "/",
-                  {
-                   "Fn::GetAtt": [
-                    "WindowsImageBuilderDockerImage8672CA3E",
-                    "ImageUri"
-                   ]
-                  }
-                 ]
-                }
-               ]
-              }
-             ]
-            }
-           ]
-          }
-         ]
+        "Fn::GetAtt": [
+         "WindowsImageBuilderRepositoryA4CBB6D8",
+         "Arn"
         ]
        }
       },
@@ -16513,49 +16362,9 @@
        "Action": "ecr:DescribeImages",
        "Effect": "Allow",
        "Resource": {
-        "Fn::Join": [
-         "",
-         [
-          "arn:",
-          {
-           "Ref": "AWS::Partition"
-          },
-          ":ecr:",
-          {
-           "Ref": "AWS::Region"
-          },
-          ":",
-          {
-           "Ref": "AWS::AccountId"
-          },
-          ":repository/",
-          {
-           "Fn::Select": [
-            0,
-            {
-             "Fn::Split": [
-              ":",
-              {
-               "Fn::Select": [
-                1,
-                {
-                 "Fn::Split": [
-                  "/",
-                  {
-                   "Fn::GetAtt": [
-                    "WindowsImageBuilderDockerImage8672CA3E",
-                    "ImageUri"
-                   ]
-                  }
-                 ]
-                }
-               ]
-              }
-             ]
-            }
-           ]
-          }
-         ]
+        "Fn::GetAtt": [
+         "WindowsImageBuilderRepositoryA4CBB6D8",
+         "Arn"
         ]
        }
       },
@@ -16942,11 +16751,37 @@
          "",
          [
           {
-           "Ref": "AWS::AccountId"
+           "Fn::Select": [
+            4,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Fn::GetAtt": [
+                "WindowsImageBuilderRepositoryA4CBB6D8",
+                "Arn"
+               ]
+              }
+             ]
+            }
+           ]
           },
           ".dkr.ecr.",
           {
-           "Ref": "AWS::Region"
+           "Fn::Select": [
+            3,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Fn::GetAtt": [
+                "WindowsImageBuilderRepositoryA4CBB6D8",
+                "Arn"
+               ]
+              }
+             ]
+            }
+           ]
           },
           ".",
           {
@@ -16954,30 +16789,7 @@
           },
           "/",
           {
-           "Fn::Select": [
-            0,
-            {
-             "Fn::Split": [
-              ":",
-              {
-               "Fn::Select": [
-                1,
-                {
-                 "Fn::Split": [
-                  "/",
-                  {
-                   "Fn::GetAtt": [
-                    "WindowsImageBuilderDockerImage8672CA3E",
-                    "ImageUri"
-                   ]
-                  }
-                 ]
-                }
-               ]
-              }
-             ]
-            }
-           ]
+           "Ref": "WindowsImageBuilderRepositoryA4CBB6D8"
           }
          ]
         ]
@@ -17239,11 +17051,37 @@
          "",
          [
           {
-           "Ref": "AWS::AccountId"
+           "Fn::Select": [
+            4,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Fn::GetAtt": [
+                "WindowsImageBuilderRepositoryA4CBB6D8",
+                "Arn"
+               ]
+              }
+             ]
+            }
+           ]
           },
           ".dkr.ecr.",
           {
-           "Ref": "AWS::Region"
+           "Fn::Select": [
+            3,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Fn::GetAtt": [
+                "WindowsImageBuilderRepositoryA4CBB6D8",
+                "Arn"
+               ]
+              }
+             ]
+            }
+           ]
           },
           ".",
           {
@@ -17251,30 +17089,7 @@
           },
           "/",
           {
-           "Fn::Select": [
-            0,
-            {
-             "Fn::Split": [
-              ":",
-              {
-               "Fn::Select": [
-                1,
-                {
-                 "Fn::Split": [
-                  "/",
-                  {
-                   "Fn::GetAtt": [
-                    "WindowsImageBuilderDockerImage8672CA3E",
-                    "ImageUri"
-                   ]
-                  }
-                 ]
-                }
-               ]
-              }
-             ]
-            }
-           ]
+           "Ref": "WindowsImageBuilderRepositoryA4CBB6D8"
           }
          ]
         ]
@@ -17874,11 +17689,37 @@
          "",
          [
           {
-           "Ref": "AWS::AccountId"
+           "Fn::Select": [
+            4,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Fn::GetAtt": [
+                "WindowsImageBuilderRepositoryA4CBB6D8",
+                "Arn"
+               ]
+              }
+             ]
+            }
+           ]
           },
           ".dkr.ecr.",
           {
-           "Ref": "AWS::Region"
+           "Fn::Select": [
+            3,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Fn::GetAtt": [
+                "WindowsImageBuilderRepositoryA4CBB6D8",
+                "Arn"
+               ]
+              }
+             ]
+            }
+           ]
           },
           ".",
           {
@@ -17886,30 +17727,7 @@
           },
           "/",
           {
-           "Fn::Select": [
-            0,
-            {
-             "Fn::Split": [
-              ":",
-              {
-               "Fn::Select": [
-                1,
-                {
-                 "Fn::Split": [
-                  "/",
-                  {
-                   "Fn::GetAtt": [
-                    "WindowsImageBuilderDockerImage8672CA3E",
-                    "ImageUri"
-                   ]
-                  }
-                 ]
-                }
-               ]
-              }
-             ]
-            }
-           ]
+           "Ref": "WindowsImageBuilderRepositoryA4CBB6D8"
           }
          ]
         ]
@@ -18260,9 +18078,9 @@
    "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
    "Default": "/aws/service/ecs/optimized-ami/amazon-linux-2/arm64/recommended/image_id"
   },
-  "SsmParameterValueawsserviceamiwindowslatestWindowsServer2019EnglishFullECSOptimizedimageidC96584B6F00A464EAD1953AFF4B05118Parameter": {
+  "SsmParameterValueawsserviceecsoptimizedamiwindowsserver2019englishfullrecommendedimageidC96584B6F00A464EAD1953AFF4B05118Parameter": {
    "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
-   "Default": "/aws/service/ami-windows-latest/Windows_Server-2019-English-Full-ECS_Optimized/image_id"
+   "Default": "/aws/service/ecs/optimized-ami/windows_server/2019/english/full/recommended/image_id"
   },
   "BootstrapVersion": {
    "Type": "AWS::SSM::Parameter::Value<String>",


### PR DESCRIPTION
Get AMI from SSM during instance deployment instead of stack deployment. This requires a switch to launch templates as they support the new `resolve:ssm:...` format for AMI.

https://docs.aws.amazon.com/autoscaling/ec2/userguide/using-systems-manager-parameters.html