### PR TITLE
feat: Include job url in step function input

### DIFF
--- a/src/webhook-handler.lambda.ts
+++ b/src/webhook-handler.lambda.ts
@@ -119,6 +119,7 @@ exports.handler = async function (event: AWSLambda.APIGatewayProxyEventV2): Prom
       owner: payload.repository.owner.login,
       repo: payload.repository.name,
       jobId: payload.workflow_job.id,
+      jobUrl: payload.workflow_job.html_url,
       installationId: payload.installation?.id,
       labels: labels,
     }),

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -170,15 +170,15 @@
         }
       }
     },
-    "6e50b29336865ad777b78c6f67bb8f9a6458d3599515b818a7705d4c2c781180": {
+    "0708d4f6248f8492e6607541f011f51845223c883f5976e0603d820a8180056f": {
       "source": {
-        "path": "asset.6e50b29336865ad777b78c6f67bb8f9a6458d3599515b818a7705d4c2c781180.lambda",
+        "path": "asset.0708d4f6248f8492e6607541f011f51845223c883f5976e0603d820a8180056f.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "6e50b29336865ad777b78c6f67bb8f9a6458d3599515b818a7705d4c2c781180.zip",
+          "objectKey": "0708d4f6248f8492e6607541f011f51845223c883f5976e0603d820a8180056f.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -222,7 +222,7 @@
         }
       }
     },
-    "fd6e9f719076b80073bae6e171ff085cb4b0fbf5783af914bc2979dee9382e7c": {
+    "dbe576c488908bf16d6a14b8a43c61c22651d836d1b3efaab13c75bce6c270ac": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -230,7 +230,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "fd6e9f719076b80073bae6e171ff085cb4b0fbf5783af914bc2979dee9382e7c.json",
+          "objectKey": "dbe576c488908bf16d6a14b8a43c61c22651d836d1b3efaab13c75bce6c270ac.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -16320,7 +16320,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "6e50b29336865ad777b78c6f67bb8f9a6458d3599515b818a7705d4c2c781180.zip"
+     "S3Key": "0708d4f6248f8492e6607541f011f51845223c883f5976e0603d820a8180056f.zip"
     },
     "Role": {
      "Fn::GetAtt": [


### PR DESCRIPTION
This helps debugging issues by making it simpler to associate jobs with runner infrastructure.

The URL is only for the job that triggered the runner, but the job the runner executes might be different. That's because GitHub randomly assigns jobs to runners based on labels alone.