### PR TITLE
fix: Faster storage clean-up on ECS

### DIFF
--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -235,7 +235,7 @@
         }
       }
     },
-    "c963c7d0a6c2c9ebafddc697bea538c4b61d294265ffe37d01cd2f29c858a9f2": {
+    "4d5124bbc7daacb610af3c7f6f62ae5b982495303274d2db33e8f290566bd273": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -243,7 +243,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "c963c7d0a6c2c9ebafddc697bea538c4b61d294265ffe37d01cd2f29c858a9f2.json",
+          "objectKey": "4d5124bbc7daacb610af3c7f6f62ae5b982495303274d2db33e8f290566bd273.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -9790,7 +9790,7 @@
          {
           "Ref": "CodeBuildImageBuilderRepository9DE3B6F0"
          },
-         ":latest &\necho ECS_CLUSTER=",
+         ":latest &\necho ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION=5s >> /etc/ecs/ecs.config && echo ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION_JITTER=5s >> /etc/ecs/ecs.config\necho ECS_CLUSTER=",
          {
           "Ref": "ECScluster20BC0B82"
          },
@@ -10340,7 +10340,7 @@
          {
           "Ref": "CodeBuildImageBuilderarmRepositoryE967421B"
          },
-         ":latest &\necho ECS_CLUSTER=",
+         ":latest &\necho ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION=5s >> /etc/ecs/ecs.config && echo ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION_JITTER=5s >> /etc/ecs/ecs.config\necho ECS_CLUSTER=",
          {
           "Ref": "ECSARM64cluster4ECAA083"
          },
@@ -10886,7 +10886,7 @@
          {
           "Ref": "WindowsImageBuilderRepositoryA4CBB6D8"
          },
-         ":latest }\nRemove-Item -Recurse C:\\ProgramData\\Amazon\\ECS\\Cache\nImport-Module ECSTools\n[Environment]::SetEnvironmentVariable(\"ECS_CLUSTER\", \"",
+         ":latest }\necho ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION=5s >> /etc/ecs/ecs.config && echo ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION_JITTER=5s >> /etc/ecs/ecs.config\nRemove-Item -Recurse C:\\ProgramData\\Amazon\\ECS\\Cache\nImport-Module ECSTools\n[Environment]::SetEnvironmentVariable(\"ECS_CLUSTER\", \"",
          {
           "Ref": "ECSWindowscluster14061F74"
          },


### PR DESCRIPTION
The defaults for ECS only clean-up a container between 10 minutes and one hour after it's done. With the potential for our container to be very big, storage can run out real quick.

This fix forces ECS to clean-up stopped containers within seconds after they're done.