### PR TITLE
feat: More aggressive retries

### DIFF
--- a/API.md
+++ b/API.md
@@ -9669,7 +9669,9 @@ Note that this is not the job log, but the runner itself. It will not contain ou
 
 ---
 
-##### `retryableErrors`<sup>Required</sup> <a name="retryableErrors" id="@cloudsnorkel/cdk-github-runners.IRunnerProvider.property.retryableErrors"></a>
+##### ~~`retryableErrors`~~<sup>Required</sup> <a name="retryableErrors" id="@cloudsnorkel/cdk-github-runners.IRunnerProvider.property.retryableErrors"></a>
+
+- *Deprecated:* do not use
 
 ```typescript
 public readonly retryableErrors: string[];

--- a/src/idle-runner-repear.lambda.ts
+++ b/src/idle-runner-repear.lambda.ts
@@ -64,7 +64,7 @@ exports.handler = async function (event: AWSLambda.SQSEvent): Promise<AWSLambda.
 
           try {
             // stop step function first, so it's marked as aborted with the proper error
-            // if we delete the runner first, the step function will be marked as error with a generic error
+            // if we delete the runner first, the step function will be marked as failed with a generic error
             console.log(`Stopping step function ${input.executionArn}...`);
             await sfn.stopExecution({
               executionArn: input.executionArn,

--- a/src/idle-runner-repear.lambda.ts
+++ b/src/idle-runner-repear.lambda.ts
@@ -60,13 +60,35 @@ exports.handler = async function (event: AWSLambda.SQSEvent): Promise<AWSLambda.
 
         if (diffMs > 1000 * input.maxIdleSeconds) {
           // max idle time reached, delete runner
-          console.log(`Runner ${input.runnerName} is idle for too long, deleting...`);
+          console.log(`Runner ${input.runnerName} is idle for too long`);
 
-          await octokit.rest.actions.deleteSelfHostedRunnerFromRepo({
-            owner: input.owner,
-            repo: input.repo,
-            runner_id: runner.id,
-          });
+          try {
+            // stop step function first, so it's marked as aborted with the proper error
+            // if we delete the runner first, the step function will be marked as error with a generic error
+            console.log(`Stopping step function ${input.executionArn}...`);
+            await sfn.stopExecution({
+              executionArn: input.executionArn,
+              error: 'IdleRunner',
+              cause: `Runner ${input.runnerName} on ${input.owner}/${input.repo} is idle for too long (${diffMs / 1000} seconds and limit is ${input.maxIdleSeconds} seconds)`,
+            }).promise();
+          } catch (e) {
+            console.error(`Failed to stop step function ${input.executionArn}: ${e}`);
+            retryLater();
+            continue;
+          }
+
+          try {
+            console.log(`Deleting runner ${runner.id}...`);
+            await octokit.rest.actions.deleteSelfHostedRunnerFromRepo({
+              owner: input.owner,
+              repo: input.repo,
+              runner_id: runner.id,
+            });
+          } catch (e) {
+            console.error(`Failed to delete runner ${runner.id}: ${e}`);
+            retryLater();
+            continue;
+          }
         } else {
           // still idle, timeout not reached -- retry later
           retryLater();

--- a/src/providers/common.ts
+++ b/src/providers/common.ts
@@ -430,6 +430,8 @@ export interface IRunnerProvider extends ec2.IConnectable, iam.IGrantable, ICons
 
   /**
    * List of step functions errors that should be retried.
+   *
+   * @deprecated do not use
    */
   readonly retryableErrors: string[];
 

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -157,15 +157,15 @@
         }
       }
     },
-    "285fb8797f2d4972268f77cc0bbaa5f546ec57fc1eafa6f7a75159fd98996a94": {
+    "17b627443ae41433c81dc05cbf0782a095db7da508cd26edc24cba98ec57119e": {
       "source": {
-        "path": "asset.285fb8797f2d4972268f77cc0bbaa5f546ec57fc1eafa6f7a75159fd98996a94.lambda",
+        "path": "asset.17b627443ae41433c81dc05cbf0782a095db7da508cd26edc24cba98ec57119e.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "285fb8797f2d4972268f77cc0bbaa5f546ec57fc1eafa6f7a75159fd98996a94.zip",
+          "objectKey": "17b627443ae41433c81dc05cbf0782a095db7da508cd26edc24cba98ec57119e.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -235,7 +235,7 @@
         }
       }
     },
-    "ce155ab64b0974c2fc7fe54631813ba3f0f8af1a476903a06498c10339961b24": {
+    "c368cdee30d7835ea54cbc594c4f84631fd45c9d250ac6f98b5debb0b0efc8a1": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -243,7 +243,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "ce155ab64b0974c2fc7fe54631813ba3f0f8af1a476903a06498c10339961b24.json",
+          "objectKey": "c368cdee30d7835ea54cbc594c4f84631fd45c9d250ac6f98b5debb0b0efc8a1.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -14251,6 +14251,44 @@
        ],
        "Effect": "Allow",
        "Resource": "*"
+      },
+      {
+       "Action": "states:StopExecution",
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::Join": [
+         "",
+         [
+          "arn:",
+          {
+           "Ref": "AWS::Partition"
+          },
+          ":states:",
+          {
+           "Ref": "AWS::Region"
+          },
+          ":",
+          {
+           "Ref": "AWS::AccountId"
+          },
+          ":execution:",
+          {
+           "Fn::Select": [
+            6,
+            {
+             "Fn::Split": [
+              ":",
+              {
+               "Ref": "runnersRunnerOrchestratorF9B66EBA"
+              }
+             ]
+            }
+           ]
+          },
+          ":*"
+         ]
+        ]
+       }
       }
      ],
      "Version": "2012-10-17"
@@ -14270,7 +14308,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "285fb8797f2d4972268f77cc0bbaa5f546ec57fc1eafa6f7a75159fd98996a94.zip"
+     "S3Key": "17b627443ae41433c81dc05cbf0782a095db7da508cd26edc24cba98ec57119e.zip"
     },
     "Role": {
      "Fn::GetAtt": [
@@ -15796,7 +15834,7 @@
        {
         "Ref": "runnersIdleReaperQueue117EFB9F"
        },
-       "\",\"MessageBody\":{\"executionArn.$\":\"$$.Execution.Id\",\"runnerName.$\":\"$$.Execution.Name\",\"owner.$\":\"$.owner\",\"repo.$\":\"$.repo\",\"installationId.$\":\"$.installationId\",\"maxIdleSeconds\":300}}},\"Retry on Error\":{\"Type\":\"Parallel\",\"ResultPath\":\"$.result\",\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"RunnerTokenError\",\"CodeBuild.CodeBuildException\",\"CodeBuild.AccountLimitExceededException\",\"Ecs.EcsException\",\"ECS.AmazonECSException\",\"Ecs.LimitExceededException\",\"Ecs.UpdateInProgressException\",\"Lambda.LambdaException\",\"Lambda.Ec2ThrottledException\",\"Lambda.Ec2UnexpectedException\",\"Lambda.EniLimitReachedException\",\"Lambda.TooManyRequestsException\",\"Ec2.Ec2Exception\",\"States.Timeout\"],\"IntervalSeconds\":60,\"MaxAttempts\":23,\"BackoffRate\":1.3}],\"Catch\":[{\"ErrorEquals\":[\"States.ALL\"],\"ResultPath\":\"$.error\",\"Next\":\"Delete Runner\"}],\"Branches\":[{\"StartAt\":\"Get Runner Token\",\"States\":{\"Get Runner Token\":{\"Next\":\"Choose provider\",\"Retry\":[{\"ErrorEquals\":[\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2}],\"Type\":\"Task\",\"ResultPath\":\"$.runner\",\"Resource\":\"",
+       "\",\"MessageBody\":{\"executionArn.$\":\"$$.Execution.Id\",\"runnerName.$\":\"$$.Execution.Name\",\"owner.$\":\"$.owner\",\"repo.$\":\"$.repo\",\"installationId.$\":\"$.installationId\",\"maxIdleSeconds\":300}}},\"Retry on Error\":{\"Type\":\"Parallel\",\"ResultPath\":\"$.result\",\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"States.ALL\"],\"IntervalSeconds\":60,\"MaxAttempts\":23,\"BackoffRate\":1.3}],\"Catch\":[{\"ErrorEquals\":[\"States.ALL\"],\"ResultPath\":\"$.error\",\"Next\":\"Delete Runner\"}],\"Branches\":[{\"StartAt\":\"Get Runner Token\",\"States\":{\"Get Runner Token\":{\"Next\":\"Choose provider\",\"Retry\":[{\"ErrorEquals\":[\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2}],\"Type\":\"Task\",\"ResultPath\":\"$.runner\",\"Resource\":\"",
        {
         "Fn::GetAtt": [
          "runnerstokenretrieverD5E8392A",


### PR DESCRIPTION
Try harder to not let a job stay pending. Retry whenever a runner fails for any reason.

The only gotcha here is idle runners. We don't want to let runners wait forever for a job in case it was cancelled. That's a waste of money. Our way of stopping idle runners by deleting them causes the runner process to fail. This bubbles up to the step function with a generic error. We won't be able to filter out that error in the step function to avoid endless retries on idle runners.

```
2023-05-20T22:23:33.612Z	72ef520c-0b31-4343-bba8-11057e3f860d	ERROR	An error occurred: Access denied. System:ServiceIdentity;DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD needs View permissions to perform the action.
2023-05-20T22:23:33.619Z	72ef520c-0b31-4343-bba8-11057e3f860d	INFO	Runner listener exit with retryable error, re-launch runner in 5 seconds.
2023-05-20T22:23:38.002Z	72ef520c-0b31-4343-bba8-11057e3f860d	INFO	Restarting runner...
2023-05-20T22:23:39.574Z	72ef520c-0b31-4343-bba8-11057e3f860d	INFO	√ Connected to GitHub
2023-05-20T22:23:39.738Z	72ef520c-0b31-4343-bba8-11057e3f860d	ERROR	Failed to create a session. The runner registration has been deleted from the server, please re-configure.
2023-05-20T22:23:39.746Z	72ef520c-0b31-4343-bba8-11057e3f860d	INFO	Runner listener exit with terminated error, stop the service, no retry needed.
2023-05-20T22:23:39.746Z	72ef520c-0b31-4343-bba8-11057e3f860d	INFO	Exiting runner...
2023-05-20T22:23:39.746Z	72ef520c-0b31-4343-bba8-11057e3f860d	INFO	Run done
2023-05-20T22:23:39.748Z	72ef520c-0b31-4343-bba8-11057e3f860d	ERROR	Invoke Error 	{
    "errorType": "Error",
    "errorMessage": "Runner failed with exit code 1",
    "stack": [
        "Error: Runner failed with exit code 1",
        "    at ChildProcess.<anonymous> (/var/task/runner.js:24:16)",
        "    at ChildProcess.emit (events.js:400:28)",
        "    at Process.ChildProcess._handle.onexit (internal/child_process.js:285:12)"
    ]
}
```

Instead of trying to figure out how to get the step function to recognize an idle runner being deleted situation, we just stop the step function too. This has the added benefit of marking it very clearly as an idle runner situation. The step function has a special aborted state and the error code is `IdleRunner`.

![image](https://github.com/CloudSnorkel/cdk-github-runners/assets/1156773/47eb498e-51e1-4326-9c97-c49382b206b4)

Having a special aborted state also helps us monitor the step function for real failures by only looking for failed step functions. Idle runners will be marked as aborted and not caught in the failed step function metric.