### PR TITLE
feat: Enable command execution in ECS, Fargate and EC2

### DIFF
--- a/src/image-builders/aws-image-builder/builder.ts
+++ b/src/image-builders/aws-image-builder/builder.ts
@@ -27,7 +27,7 @@ import { FilterFailedBuildsFunction } from './filter-failed-builds-function';
 import { ReaperFunction } from './reaper-function';
 import { Architecture, Os, RunnerAmi, RunnerImage, RunnerVersion } from '../../providers';
 import { BuildImageFunction } from '../../providers/build-image-function';
-import { singletonLambda } from '../../utils';
+import { MINIMAL_EC2_SSM_SESSION_MANAGER_POLICY_STATEMENT, singletonLambda } from '../../utils';
 import { RunnerImageBuilderBase, RunnerImageBuilderProps, uniqueImageBuilderName } from '../common';
 
 export interface AwsImageBuilderRunnerImageBuilderProps {
@@ -303,6 +303,7 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
     this.role = new iam.Role(this, 'Role', {
       assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
     });
+    this.role.addToPrincipalPolicy(MINIMAL_EC2_SSM_SESSION_MANAGER_POLICY_STATEMENT);
   }
 
   private platform() {
@@ -383,7 +384,6 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
 
     const log = this.createLog('Docker Log', recipe.name);
     const infra = this.createInfrastructure([
-      iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'),
       iam.ManagedPolicy.fromAwsManagedPolicyName('EC2InstanceProfileForImageBuilderECRContainerBuilds'),
     ]);
     const image = this.createImage(infra, dist, log, undefined, recipe.arn);
@@ -599,7 +599,6 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
 
     const log = this.createLog('Ami Log', recipe.name);
     const infra = this.createInfrastructure([
-      iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'),
       iam.ManagedPolicy.fromAwsManagedPolicyName('EC2InstanceProfileForImageBuilder'),
     ]);
     this.createImage(infra, dist, log, recipe.arn, undefined);

--- a/src/image-builders/aws-image-builder/deprecated/ami.ts
+++ b/src/image-builders/aws-image-builder/deprecated/ami.ts
@@ -15,7 +15,7 @@ import { Construct } from 'constructs';
 import { ImageBuilderBase } from './common';
 import { LinuxUbuntuComponents } from './linux-components';
 import { WindowsComponents } from './windows-components';
-import { Architecture, Os, RunnerAmi, RunnerImage, RunnerVersion } from '../../../providers/common';
+import { Architecture, Os, RunnerAmi, RunnerImage, RunnerVersion } from '../../../providers';
 import { singletonLambda } from '../../../utils';
 import { uniqueImageBuilderName } from '../../common';
 import { AmiRecipe, defaultBaseAmi } from '../ami';
@@ -296,7 +296,6 @@ export class AmiBuilder extends ImageBuilderBase {
 
     const log = this.createLog(recipe.name);
     const infra = this.createInfrastructure([
-      iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'),
       iam.ManagedPolicy.fromAwsManagedPolicyName('EC2InstanceProfileForImageBuilder'),
     ]);
     this.createImage(infra, dist, log, recipe.arn, undefined);

--- a/src/image-builders/aws-image-builder/deprecated/common.ts
+++ b/src/image-builders/aws-image-builder/deprecated/common.ts
@@ -1,7 +1,8 @@
 import * as cdk from 'aws-cdk-lib';
 import { aws_ec2 as ec2, aws_events as events, aws_iam as iam, aws_imagebuilder as imagebuilder, aws_logs as logs, RemovalPolicy } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import { Architecture, Os, RunnerAmi, RunnerImage, RunnerVersion } from '../../../providers/common';
+import { Architecture, Os, RunnerAmi, RunnerImage, RunnerVersion } from '../../../providers';
+import { MINIMAL_EC2_SSM_SESSION_MANAGER_POLICY_STATEMENT } from '../../../utils';
 import { ImageBuilderBaseProps, IRunnerImageBuilder, uniqueImageBuilderName } from '../../common';
 import { ImageBuilderComponent } from '../builder';
 
@@ -99,6 +100,7 @@ export abstract class ImageBuilderBase extends Construct implements IRunnerImage
       assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
       managedPolicies: managedPolicies,
     });
+    role.addToPrincipalPolicy(MINIMAL_EC2_SSM_SESSION_MANAGER_POLICY_STATEMENT);
 
     for (const component of this.components) {
       component.grantAssetsRead(role);

--- a/src/image-builders/aws-image-builder/deprecated/container.ts
+++ b/src/image-builders/aws-image-builder/deprecated/container.ts
@@ -277,7 +277,6 @@ export class ContainerImageBuilder extends ImageBuilderBase {
 
     const log = this.createLog(recipe.name);
     const infra = this.createInfrastructure([
-      iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'),
       iam.ManagedPolicy.fromAwsManagedPolicyName('EC2InstanceProfileForImageBuilderECRContainerBuilds'),
     ]);
     const image = this.createImage(infra, dist, log, undefined, recipe.arn);

--- a/src/providers/codebuild.ts
+++ b/src/providers/codebuild.ts
@@ -336,6 +336,10 @@ export class CodeBuildRunnerProvider extends BaseProvider implements IRunnerProv
     );
 
     this.grantPrincipal = this.project.grantPrincipal;
+
+    // allow SSM Session Manager access
+    // this.project.role?.addToPrincipalPolicy(MINIMAL_SSM_SESSION_MANAGER_POLICY_STATEMENT);
+    // step function won't let us pass `debugSessionEnabled: true` unless we use batch, so we can't use this
   }
 
   /**
@@ -346,7 +350,7 @@ export class CodeBuildRunnerProvider extends BaseProvider implements IRunnerProv
    * @param parameters workflow job details
    */
   getStepFunctionTask(parameters: RunnerRuntimeParameters): stepfunctions.IChainable {
-    const step = new stepfunctions_tasks.CodeBuildStartBuild(
+    return new stepfunctions_tasks.CodeBuildStartBuild(
       this,
       this.labels.join(', '),
       {
@@ -380,8 +384,6 @@ export class CodeBuildRunnerProvider extends BaseProvider implements IRunnerProv
         },
       },
     );
-
-    return step;
   }
 
   grantStateMachine(_: iam.IGrantable) {

--- a/src/providers/ec2.ts
+++ b/src/providers/ec2.ts
@@ -25,6 +25,7 @@ import {
   RunnerVersion,
 } from './common';
 import { IRunnerImageBuilder, RunnerImageBuilder, RunnerImageBuilderProps, RunnerImageBuilderType, RunnerImageComponent } from '../image-builders';
+import { MINIMAL_EC2_SSM_SESSION_MANAGER_POLICY_STATEMENT } from '../utils';
 
 // this script is specifically made so `poweroff` is absolutely always called
 // each `{}` is a variable coming from `params` below
@@ -320,14 +321,12 @@ export class Ec2RunnerProvider extends BaseProvider implements IRunnerProvider {
 
     this.grantPrincipal = this.role = new iam.Role(this, 'Role', {
       assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
-      managedPolicies: [
-        iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'),
-      ],
     });
     this.grantPrincipal.addToPrincipalPolicy(new iam.PolicyStatement({
       actions: ['states:SendTaskFailure', 'states:SendTaskSuccess', 'states:SendTaskHeartbeat'],
       resources: ['*'], // no support for stateMachine.stateMachineArn :(
     }));
+    this.grantPrincipal.addToPrincipalPolicy(MINIMAL_EC2_SSM_SESSION_MANAGER_POLICY_STATEMENT);
 
     this.logGroup = new logs.LogGroup(
       this,

--- a/src/providers/fargate.ts
+++ b/src/providers/fargate.ts
@@ -23,6 +23,7 @@ import {
   RunnerVersion,
 } from './common';
 import { IRunnerImageBuilder, RunnerImageBuilder, RunnerImageBuilderProps, RunnerImageComponent } from '../image-builders';
+import { MINIMAL_SSM_SESSION_MANAGER_POLICY_STATEMENT } from '../utils';
 
 /**
  * Properties for FargateRunnerProvider.
@@ -435,6 +436,9 @@ export class FargateRunnerProvider extends BaseProvider implements IRunnerProvid
     );
 
     this.grantPrincipal = this.task.taskRole;
+
+    // allow SSM Session Manager
+    this.task.taskRole.addToPrincipalPolicy(MINIMAL_SSM_SESSION_MANAGER_POLICY_STATEMENT);
   }
 
   /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { aws_lambda as lambda } from 'aws-cdk-lib';
+import { aws_iam as iam, aws_lambda as lambda } from 'aws-cdk-lib';
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
@@ -18,3 +18,51 @@ export function singletonLambda<FunctionType extends lambda.Function>(
 
   return new functionType(cdk.Stack.of(scope), constructName, props);
 }
+
+/**
+ * The absolute minimum permissions required for SSM Session Manager to work. Unlike `AmazonSSMManagedInstanceCore`, it doesn't give permission to read all SSM parameters.
+ *
+ * @internal
+ */
+export const MINIMAL_SSM_SESSION_MANAGER_POLICY_STATEMENT = new iam.PolicyStatement({
+  actions: [
+    'ssmmessages:CreateControlChannel',
+    'ssmmessages:CreateDataChannel',
+    'ssmmessages:OpenControlChannel',
+    'ssmmessages:OpenDataChannel',
+  ],
+  resources: ['*'],
+});
+
+/**
+ * The absolute minimum permissions required for SSM Session Manager on ECS to work. Unlike `AmazonSSMManagedInstanceCore`, it doesn't give permission to read all SSM parameters.
+ *
+ * @internal
+ */
+export const MINIMAL_ECS_SSM_SESSION_MANAGER_POLICY_STATEMENT = new iam.PolicyStatement({
+  actions: [
+    'ssmmessages:CreateControlChannel',
+    'ssmmessages:CreateDataChannel',
+    'ssmmessages:OpenControlChannel',
+    'ssmmessages:OpenDataChannel',
+    's3:GetEncryptionConfiguration',
+  ],
+  resources: ['*'],
+});
+
+/**
+ * The absolute minimum permissions required for SSM Session Manager on EC2 to work. Unlike `AmazonSSMManagedInstanceCore`, it doesn't give permission to read all SSM parameters.
+ *
+ * @internal
+ */
+export const MINIMAL_EC2_SSM_SESSION_MANAGER_POLICY_STATEMENT = new iam.PolicyStatement({
+  actions: [
+    'ssmmessages:CreateControlChannel',
+    'ssmmessages:CreateDataChannel',
+    'ssmmessages:OpenControlChannel',
+    'ssmmessages:OpenDataChannel',
+    's3:GetEncryptionConfiguration',
+    'ssm:UpdateInstanceInformation',
+  ],
+  resources: ['*'],
+});

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -196,15 +196,15 @@
         }
       }
     },
-    "aaec57f0c284dd86cf542c51f4c629062ecbbb25a78009d2087edf8ca2a676a4": {
+    "a96b1864893ebe28a61c735e5796cc76e184541d5cefae0d8c02f6e82ef44211": {
       "source": {
-        "path": "asset.aaec57f0c284dd86cf542c51f4c629062ecbbb25a78009d2087edf8ca2a676a4.lambda",
+        "path": "asset.a96b1864893ebe28a61c735e5796cc76e184541d5cefae0d8c02f6e82ef44211.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "aaec57f0c284dd86cf542c51f4c629062ecbbb25a78009d2087edf8ca2a676a4.zip",
+          "objectKey": "a96b1864893ebe28a61c735e5796cc76e184541d5cefae0d8c02f6e82ef44211.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -235,7 +235,7 @@
         }
       }
     },
-    "9f1d448bf49524a19eeadd8eb8a0defa4f6b50351eda343e18450ce29b1adc5b": {
+    "db1111872290394bf0d1d5ff83705ae5699b46e79e81601b762ac517424f7a28": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -243,7 +243,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "9f1d448bf49524a19eeadd8eb8a0defa4f6b50351eda343e18450ce29b1adc5b.json",
+          "objectKey": "db1111872290394bf0d1d5ff83705ae5699b46e79e81601b762ac517424f7a28.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -196,15 +196,15 @@
         }
       }
     },
-    "a96b1864893ebe28a61c735e5796cc76e184541d5cefae0d8c02f6e82ef44211": {
+    "aaec57f0c284dd86cf542c51f4c629062ecbbb25a78009d2087edf8ca2a676a4": {
       "source": {
-        "path": "asset.a96b1864893ebe28a61c735e5796cc76e184541d5cefae0d8c02f6e82ef44211.lambda",
+        "path": "asset.aaec57f0c284dd86cf542c51f4c629062ecbbb25a78009d2087edf8ca2a676a4.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "a96b1864893ebe28a61c735e5796cc76e184541d5cefae0d8c02f6e82ef44211.zip",
+          "objectKey": "aaec57f0c284dd86cf542c51f4c629062ecbbb25a78009d2087edf8ca2a676a4.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -235,7 +235,7 @@
         }
       }
     },
-    "26f752ed54fe55d8e4617129d277a0e790e0801fd10dbbc2d331f427a78cc995": {
+    "9f1d448bf49524a19eeadd8eb8a0defa4f6b50351eda343e18450ce29b1adc5b": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -243,7 +243,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "26f752ed54fe55d8e4617129d277a0e790e0801fd10dbbc2d331f427a78cc995.json",
+          "objectKey": "9f1d448bf49524a19eeadd8eb8a0defa4f6b50351eda343e18450ce29b1adc5b.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -16843,7 +16843,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "aaec57f0c284dd86cf542c51f4c629062ecbbb25a78009d2087edf8ca2a676a4.zip"
+     "S3Key": "a96b1864893ebe28a61c735e5796cc76e184541d5cefae0d8c02f6e82ef44211.zip"
     },
     "Role": {
      "Fn::GetAtt": [

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -2140,18 +2140,6 @@
         {
          "Ref": "AWS::Partition"
         },
-        ":iam::aws:policy/AmazonSSMManagedInstanceCore"
-       ]
-      ]
-     },
-     {
-      "Fn::Join": [
-       "",
-       [
-        "arn:",
-        {
-         "Ref": "AWS::Partition"
-        },
         ":iam::aws:policy/EC2InstanceProfileForImageBuilderECRContainerBuilds"
        ]
       ]
@@ -2164,6 +2152,18 @@
    "Properties": {
     "PolicyDocument": {
      "Statement": [
+      {
+       "Action": [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel",
+        "s3:GetEncryptionConfiguration",
+        "ssm:UpdateInstanceInformation"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
+      },
       {
        "Action": [
         "s3:GetObject*",
@@ -3117,18 +3117,6 @@
         {
          "Ref": "AWS::Partition"
         },
-        ":iam::aws:policy/AmazonSSMManagedInstanceCore"
-       ]
-      ]
-     },
-     {
-      "Fn::Join": [
-       "",
-       [
-        "arn:",
-        {
-         "Ref": "AWS::Partition"
-        },
         ":iam::aws:policy/EC2InstanceProfileForImageBuilder"
        ]
       ]
@@ -3141,6 +3129,18 @@
    "Properties": {
     "PolicyDocument": {
      "Statement": [
+      {
+       "Action": [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel",
+        "s3:GetEncryptionConfiguration",
+        "ssm:UpdateInstanceInformation"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
+      },
       {
        "Action": [
         "s3:GetObject*",
@@ -6117,18 +6117,6 @@
         {
          "Ref": "AWS::Partition"
         },
-        ":iam::aws:policy/AmazonSSMManagedInstanceCore"
-       ]
-      ]
-     },
-     {
-      "Fn::Join": [
-       "",
-       [
-        "arn:",
-        {
-         "Ref": "AWS::Partition"
-        },
         ":iam::aws:policy/EC2InstanceProfileForImageBuilder"
        ]
       ]
@@ -6141,6 +6129,18 @@
    "Properties": {
     "PolicyDocument": {
      "Statement": [
+      {
+       "Action": [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel",
+        "s3:GetEncryptionConfiguration",
+        "ssm:UpdateInstanceInformation"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
+      },
       {
        "Action": [
         "s3:GetObject*",
@@ -7224,18 +7224,6 @@
         {
          "Ref": "AWS::Partition"
         },
-        ":iam::aws:policy/AmazonSSMManagedInstanceCore"
-       ]
-      ]
-     },
-     {
-      "Fn::Join": [
-       "",
-       [
-        "arn:",
-        {
-         "Ref": "AWS::Partition"
-        },
         ":iam::aws:policy/EC2InstanceProfileForImageBuilder"
        ]
       ]
@@ -7248,6 +7236,18 @@
    "Properties": {
     "PolicyDocument": {
      "Statement": [
+      {
+       "Action": [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel",
+        "s3:GetEncryptionConfiguration",
+        "ssm:UpdateInstanceInformation"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
+      },
       {
        "Action": [
         "s3:GetObject*",
@@ -9576,21 +9576,7 @@
       }
      ],
      "Version": "2012-10-17"
-    },
-    "ManagedPolicyArns": [
-     {
-      "Fn::Join": [
-       "",
-       [
-        "arn:",
-        {
-         "Ref": "AWS::Partition"
-        },
-        ":iam::aws:policy/AmazonSSMManagedInstanceCore"
-       ]
-      ]
-     }
-    ]
+    }
    }
   },
   "ECSLaunchTemplateRoleDefaultPolicyA6578409": {
@@ -9598,6 +9584,18 @@
    "Properties": {
     "PolicyDocument": {
      "Statement": [
+      {
+       "Action": [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel",
+        "s3:GetEncryptionConfiguration",
+        "ssm:UpdateInstanceInformation"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
+      },
       {
        "Action": [
         "ecr:BatchCheckLayerAvailability",
@@ -9912,6 +9910,33 @@
     }
    }
   },
+  "ECStaskTaskRoleDefaultPolicy46A3CB3A": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel",
+        "s3:GetEncryptionConfiguration"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "ECStaskTaskRoleDefaultPolicy46A3CB3A",
+    "Roles": [
+     {
+      "Ref": "ECStaskTaskRoleFE831ECD"
+     }
+    ]
+   }
+  },
   "ECStask8F0DD550": {
    "Type": "AWS::ECS::TaskDefinition",
    "Properties": {
@@ -10132,21 +10157,7 @@
       }
      ],
      "Version": "2012-10-17"
-    },
-    "ManagedPolicyArns": [
-     {
-      "Fn::Join": [
-       "",
-       [
-        "arn:",
-        {
-         "Ref": "AWS::Partition"
-        },
-        ":iam::aws:policy/AmazonSSMManagedInstanceCore"
-       ]
-      ]
-     }
-    ]
+    }
    }
   },
   "ECSARM64LaunchTemplateRoleDefaultPolicy0705A7AA": {
@@ -10154,6 +10165,18 @@
    "Properties": {
     "PolicyDocument": {
      "Statement": [
+      {
+       "Action": [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel",
+        "s3:GetEncryptionConfiguration",
+        "ssm:UpdateInstanceInformation"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
+      },
       {
        "Action": [
         "ecr:BatchCheckLayerAvailability",
@@ -10462,6 +10485,33 @@
     }
    }
   },
+  "ECSARM64taskTaskRoleDefaultPolicyD893D7DC": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel",
+        "s3:GetEncryptionConfiguration"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "ECSARM64taskTaskRoleDefaultPolicyD893D7DC",
+    "Roles": [
+     {
+      "Ref": "ECSARM64taskTaskRole23B1CB4E"
+     }
+    ]
+   }
+  },
   "ECSARM64task27EB8443": {
    "Type": "AWS::ECS::TaskDefinition",
    "Properties": {
@@ -10682,21 +10732,7 @@
       }
      ],
      "Version": "2012-10-17"
-    },
-    "ManagedPolicyArns": [
-     {
-      "Fn::Join": [
-       "",
-       [
-        "arn:",
-        {
-         "Ref": "AWS::Partition"
-        },
-        ":iam::aws:policy/AmazonSSMManagedInstanceCore"
-       ]
-      ]
-     }
-    ]
+    }
    }
   },
   "ECSWindowsLaunchTemplateRoleDefaultPolicy48457459": {
@@ -10704,6 +10740,18 @@
    "Properties": {
     "PolicyDocument": {
      "Statement": [
+      {
+       "Action": [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel",
+        "s3:GetEncryptionConfiguration",
+        "ssm:UpdateInstanceInformation"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
+      },
       {
        "Action": [
         "ecr:BatchCheckLayerAvailability",
@@ -11010,6 +11058,33 @@
      ],
      "Version": "2012-10-17"
     }
+   }
+  },
+  "ECSWindowstaskTaskRoleDefaultPolicy529AC984": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel",
+        "s3:GetEncryptionConfiguration"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "ECSWindowstaskTaskRoleDefaultPolicy529AC984",
+    "Roles": [
+     {
+      "Ref": "ECSWindowstaskTaskRole17C8DA48"
+     }
+    ]
    }
   },
   "ECSWindowstask73A31B6C": {
@@ -11973,6 +12048,32 @@
     }
    }
   },
+  "FargatetaskTaskRoleDefaultPolicy4E176780": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "FargatetaskTaskRoleDefaultPolicy4E176780",
+    "Roles": [
+     {
+      "Ref": "FargatetaskTaskRoleEFFCDAF8"
+     }
+    ]
+   }
+  },
   "FargatetaskFDFF3302": {
    "Type": "AWS::ECS::TaskDefinition",
    "Properties": {
@@ -12208,6 +12309,32 @@
      ],
      "Version": "2012-10-17"
     }
+   }
+  },
+  "Fargatex64spottaskTaskRoleDefaultPolicyDBB9916E": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "Fargatex64spottaskTaskRoleDefaultPolicyDBB9916E",
+    "Roles": [
+     {
+      "Ref": "Fargatex64spottaskTaskRole02893C25"
+     }
+    ]
    }
   },
   "Fargatex64spottask4C8B023D": {
@@ -12447,6 +12574,32 @@
     }
    }
   },
+  "Fargatearm64taskTaskRoleDefaultPolicy0D37729A": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "Fargatearm64taskTaskRoleDefaultPolicy0D37729A",
+    "Roles": [
+     {
+      "Ref": "Fargatearm64taskTaskRoleD3C2CD58"
+     }
+    ]
+   }
+  },
   "Fargatearm64taskECD67399": {
    "Type": "AWS::ECS::TaskDefinition",
    "Properties": {
@@ -12682,6 +12835,32 @@
      ],
      "Version": "2012-10-17"
     }
+   }
+  },
+  "Fargatearm64spottaskTaskRoleDefaultPolicyB8772E50": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "Fargatearm64spottaskTaskRoleDefaultPolicyB8772E50",
+    "Roles": [
+     {
+      "Ref": "Fargatearm64spottaskTaskRole0F078C81"
+     }
+    ]
    }
   },
   "Fargatearm64spottaskD21E60F2": {
@@ -12921,6 +13100,32 @@
     }
    }
   },
+  "FargateWindowstaskTaskRoleDefaultPolicy17F0249C": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "FargateWindowstaskTaskRoleDefaultPolicy17F0249C",
+    "Roles": [
+     {
+      "Ref": "FargateWindowstaskTaskRole364508C8"
+     }
+    ]
+   }
+  },
   "FargateWindowstask9F9B942D": {
    "Type": "AWS::ECS::TaskDefinition",
    "Properties": {
@@ -13126,21 +13331,7 @@
       }
      ],
      "Version": "2012-10-17"
-    },
-    "ManagedPolicyArns": [
-     {
-      "Fn::Join": [
-       "",
-       [
-        "arn:",
-        {
-         "Ref": "AWS::Partition"
-        },
-        ":iam::aws:policy/AmazonSSMManagedInstanceCore"
-       ]
-      ]
-     }
-    ]
+    }
    }
   },
   "EC2LinuxRoleDefaultPolicy1369791B": {
@@ -13153,6 +13344,18 @@
         "states:SendTaskFailure",
         "states:SendTaskSuccess",
         "states:SendTaskHeartbeat"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
+      },
+      {
+       "Action": [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel",
+        "s3:GetEncryptionConfiguration",
+        "ssm:UpdateInstanceInformation"
        ],
        "Effect": "Allow",
        "Resource": "*"
@@ -13392,21 +13595,7 @@
       }
      ],
      "Version": "2012-10-17"
-    },
-    "ManagedPolicyArns": [
-     {
-      "Fn::Join": [
-       "",
-       [
-        "arn:",
-        {
-         "Ref": "AWS::Partition"
-        },
-        ":iam::aws:policy/AmazonSSMManagedInstanceCore"
-       ]
-      ]
-     }
-    ]
+    }
    }
   },
   "EC2SpotLinuxRoleDefaultPolicy061AD1D0": {
@@ -13419,6 +13608,18 @@
         "states:SendTaskFailure",
         "states:SendTaskSuccess",
         "states:SendTaskHeartbeat"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
+      },
+      {
+       "Action": [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel",
+        "s3:GetEncryptionConfiguration",
+        "ssm:UpdateInstanceInformation"
        ],
        "Effect": "Allow",
        "Resource": "*"
@@ -13548,21 +13749,7 @@
       }
      ],
      "Version": "2012-10-17"
-    },
-    "ManagedPolicyArns": [
-     {
-      "Fn::Join": [
-       "",
-       [
-        "arn:",
-        {
-         "Ref": "AWS::Partition"
-        },
-        ":iam::aws:policy/AmazonSSMManagedInstanceCore"
-       ]
-      ]
-     }
-    ]
+    }
    }
   },
   "EC2Linuxarm64RoleDefaultPolicyDE9193C3": {
@@ -13575,6 +13762,18 @@
         "states:SendTaskFailure",
         "states:SendTaskSuccess",
         "states:SendTaskHeartbeat"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
+      },
+      {
+       "Action": [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel",
+        "s3:GetEncryptionConfiguration",
+        "ssm:UpdateInstanceInformation"
        ],
        "Effect": "Allow",
        "Resource": "*"
@@ -13704,21 +13903,7 @@
       }
      ],
      "Version": "2012-10-17"
-    },
-    "ManagedPolicyArns": [
-     {
-      "Fn::Join": [
-       "",
-       [
-        "arn:",
-        {
-         "Ref": "AWS::Partition"
-        },
-        ":iam::aws:policy/AmazonSSMManagedInstanceCore"
-       ]
-      ]
-     }
-    ]
+    }
    }
   },
   "EC2WindowsRoleDefaultPolicyB6A15409": {
@@ -13731,6 +13916,18 @@
         "states:SendTaskFailure",
         "states:SendTaskSuccess",
         "states:SendTaskHeartbeat"
+       ],
+       "Effect": "Allow",
+       "Resource": "*"
+      },
+      {
+       "Action": [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel",
+        "s3:GetEncryptionConfiguration",
+        "ssm:UpdateInstanceInformation"
        ],
        "Effect": "Allow",
        "Resource": "*"
@@ -15876,7 +16073,7 @@
          "Arn"
         ]
        },
-       "\",\"TaskDefinition\":\"githubrunnerstestECStaskCE74CC84\",\"Overrides\":{\"ContainerOverrides\":[{\"Name\":\"runner\",\"Environment\":[{\"Name\":\"RUNNER_TOKEN\",\"Value.$\":\"$.runner.token\"},{\"Name\":\"RUNNER_NAME\",\"Value.$\":\"$$.Execution.Name\"},{\"Name\":\"RUNNER_LABEL\",\"Value\":\"ecs,linux,x64\"},{\"Name\":\"GITHUB_DOMAIN\",\"Value.$\":\"$.runner.domain\"},{\"Name\":\"OWNER\",\"Value.$\":\"$.owner\"},{\"Name\":\"REPO\",\"Value.$\":\"$.repo\"}]}]},\"PropagateTags\":\"TASK_DEFINITION\",\"CapacityProviderStrategy\":[{\"CapacityProvider\":\"",
+       "\",\"TaskDefinition\":\"githubrunnerstestECStaskCE74CC84\",\"Overrides\":{\"ContainerOverrides\":[{\"Name\":\"runner\",\"Environment\":[{\"Name\":\"RUNNER_TOKEN\",\"Value.$\":\"$.runner.token\"},{\"Name\":\"RUNNER_NAME\",\"Value.$\":\"$$.Execution.Name\"},{\"Name\":\"RUNNER_LABEL\",\"Value\":\"ecs,linux,x64\"},{\"Name\":\"GITHUB_DOMAIN\",\"Value.$\":\"$.runner.domain\"},{\"Name\":\"OWNER\",\"Value.$\":\"$.owner\"},{\"Name\":\"REPO\",\"Value.$\":\"$.repo\"}]}]},\"PropagateTags\":\"TASK_DEFINITION\",\"EnableExecuteCommand\":true,\"CapacityProviderStrategy\":[{\"CapacityProvider\":\"",
        {
         "Ref": "ECSCapacityProviderABF1B146"
        },
@@ -15891,7 +16088,7 @@
          "Arn"
         ]
        },
-       "\",\"TaskDefinition\":\"githubrunnerstestECSARM64taskE94E43A3\",\"Overrides\":{\"ContainerOverrides\":[{\"Name\":\"runner\",\"Environment\":[{\"Name\":\"RUNNER_TOKEN\",\"Value.$\":\"$.runner.token\"},{\"Name\":\"RUNNER_NAME\",\"Value.$\":\"$$.Execution.Name\"},{\"Name\":\"RUNNER_LABEL\",\"Value\":\"ecs,linux,arm64\"},{\"Name\":\"GITHUB_DOMAIN\",\"Value.$\":\"$.runner.domain\"},{\"Name\":\"OWNER\",\"Value.$\":\"$.owner\"},{\"Name\":\"REPO\",\"Value.$\":\"$.repo\"}]}]},\"PropagateTags\":\"TASK_DEFINITION\",\"CapacityProviderStrategy\":[{\"CapacityProvider\":\"",
+       "\",\"TaskDefinition\":\"githubrunnerstestECSARM64taskE94E43A3\",\"Overrides\":{\"ContainerOverrides\":[{\"Name\":\"runner\",\"Environment\":[{\"Name\":\"RUNNER_TOKEN\",\"Value.$\":\"$.runner.token\"},{\"Name\":\"RUNNER_NAME\",\"Value.$\":\"$$.Execution.Name\"},{\"Name\":\"RUNNER_LABEL\",\"Value\":\"ecs,linux,arm64\"},{\"Name\":\"GITHUB_DOMAIN\",\"Value.$\":\"$.runner.domain\"},{\"Name\":\"OWNER\",\"Value.$\":\"$.owner\"},{\"Name\":\"REPO\",\"Value.$\":\"$.repo\"}]}]},\"PropagateTags\":\"TASK_DEFINITION\",\"EnableExecuteCommand\":true,\"CapacityProviderStrategy\":[{\"CapacityProvider\":\"",
        {
         "Ref": "ECSARM64CapacityProvider8627FEF9"
        },
@@ -15906,7 +16103,7 @@
          "Arn"
         ]
        },
-       "\",\"TaskDefinition\":\"githubrunnerstestECSWindowstask6B1D5861\",\"Overrides\":{\"ContainerOverrides\":[{\"Name\":\"runner\",\"Environment\":[{\"Name\":\"RUNNER_TOKEN\",\"Value.$\":\"$.runner.token\"},{\"Name\":\"RUNNER_NAME\",\"Value.$\":\"$$.Execution.Name\"},{\"Name\":\"RUNNER_LABEL\",\"Value\":\"ecs,windows,x64\"},{\"Name\":\"GITHUB_DOMAIN\",\"Value.$\":\"$.runner.domain\"},{\"Name\":\"OWNER\",\"Value.$\":\"$.owner\"},{\"Name\":\"REPO\",\"Value.$\":\"$.repo\"}]}]},\"PropagateTags\":\"TASK_DEFINITION\",\"CapacityProviderStrategy\":[{\"CapacityProvider\":\"",
+       "\",\"TaskDefinition\":\"githubrunnerstestECSWindowstask6B1D5861\",\"Overrides\":{\"ContainerOverrides\":[{\"Name\":\"runner\",\"Environment\":[{\"Name\":\"RUNNER_TOKEN\",\"Value.$\":\"$.runner.token\"},{\"Name\":\"RUNNER_NAME\",\"Value.$\":\"$$.Execution.Name\"},{\"Name\":\"RUNNER_LABEL\",\"Value\":\"ecs,windows,x64\"},{\"Name\":\"GITHUB_DOMAIN\",\"Value.$\":\"$.runner.domain\"},{\"Name\":\"OWNER\",\"Value.$\":\"$.owner\"},{\"Name\":\"REPO\",\"Value.$\":\"$.repo\"}]}]},\"PropagateTags\":\"TASK_DEFINITION\",\"EnableExecuteCommand\":false,\"CapacityProviderStrategy\":[{\"CapacityProvider\":\"",
        {
         "Ref": "ECSWindowsCapacityProvider8F8896A5"
        },
@@ -16646,7 +16843,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "a96b1864893ebe28a61c735e5796cc76e184541d5cefae0d8c02f6e82ef44211.zip"
+     "S3Key": "aaec57f0c284dd86cf542c51f4c629062ecbbb25a78009d2087edf8ca2a676a4.zip"
     },
     "Role": {
      "Fn::GetAtt": [


### PR DESCRIPTION
Let users execute a command inside the runner containers for debugging. This uses SSM Session Manager. For EC2 it's a button in the console. For ECS/Fargate it's the `aws ecs execute-command` CLI.

We can't enable it for CodeBuild because that requires using batch builds. The required code was left commented out.

This also reduces the permissions given to runners for SSM Session Manager. Instead of using the `AmazonSSMManagedInstanceCore` managed policy, we supply only the bare minimum of permissions. We no longer give everything `ssm:GetParameters` on `*` that comes with `AmazonSSMManagedInstanceCore`.

Fixes #101