### PR TITLE
fix: Limit EC2 runner access to Step Function API

### DIFF
--- a/src/providers/ec2.ts
+++ b/src/providers/ec2.ts
@@ -325,6 +325,11 @@ export class Ec2RunnerProvider extends BaseProvider implements IRunnerProvider {
     this.grantPrincipal.addToPrincipalPolicy(new iam.PolicyStatement({
       actions: ['states:SendTaskFailure', 'states:SendTaskSuccess', 'states:SendTaskHeartbeat'],
       resources: ['*'], // no support for stateMachine.stateMachineArn :(
+      conditions: {
+        StringEquals: {
+          'aws:ResourceTag/aws:cloudformation:stack-id': cdk.Stack.of(this).stackId,
+        },
+      },
     }));
     this.grantPrincipal.addToPrincipalPolicy(MINIMAL_EC2_SSM_SESSION_MANAGER_POLICY_STATEMENT);
 

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -235,7 +235,7 @@
         }
       }
     },
-    "db1111872290394bf0d1d5ff83705ae5699b46e79e81601b762ac517424f7a28": {
+    "936166eb616ec056c83fac9ce3a38bb472fab48446d49c91bd13f123a3986758": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -243,7 +243,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "db1111872290394bf0d1d5ff83705ae5699b46e79e81601b762ac517424f7a28.json",
+          "objectKey": "936166eb616ec056c83fac9ce3a38bb472fab48446d49c91bd13f123a3986758.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -13345,6 +13345,13 @@
         "states:SendTaskSuccess",
         "states:SendTaskHeartbeat"
        ],
+       "Condition": {
+        "StringEquals": {
+         "aws:ResourceTag/aws:cloudformation:stack-id": {
+          "Ref": "AWS::StackId"
+         }
+        }
+       },
        "Effect": "Allow",
        "Resource": "*"
       },
@@ -13609,6 +13616,13 @@
         "states:SendTaskSuccess",
         "states:SendTaskHeartbeat"
        ],
+       "Condition": {
+        "StringEquals": {
+         "aws:ResourceTag/aws:cloudformation:stack-id": {
+          "Ref": "AWS::StackId"
+         }
+        }
+       },
        "Effect": "Allow",
        "Resource": "*"
       },
@@ -13763,6 +13777,13 @@
         "states:SendTaskSuccess",
         "states:SendTaskHeartbeat"
        ],
+       "Condition": {
+        "StringEquals": {
+         "aws:ResourceTag/aws:cloudformation:stack-id": {
+          "Ref": "AWS::StackId"
+         }
+        }
+       },
        "Effect": "Allow",
        "Resource": "*"
       },
@@ -13917,6 +13938,13 @@
         "states:SendTaskSuccess",
         "states:SendTaskHeartbeat"
        ],
+       "Condition": {
+        "StringEquals": {
+         "aws:ResourceTag/aws:cloudformation:stack-id": {
+          "Ref": "AWS::StackId"
+         }
+        }
+       },
        "Effect": "Allow",
        "Resource": "*"
       },


### PR DESCRIPTION
Use resource tag to limit EC2 runner access to `states:SendTask*`. This will prevent any malicious or buggy GitHub Actions jobs from messing with step functions that don't belong to them.