### PR TITLE
chore: Fix AWS Image Builder

### DIFF
--- a/src/image-builders/aws-image-builder/ami.ts
+++ b/src/image-builders/aws-image-builder/ami.ts
@@ -3,7 +3,7 @@ import { aws_imagebuilder as imagebuilder } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { ImageBuilderComponent } from './builder';
 import { ImageBuilderObjectBase } from './common';
-import { Architecture, Os } from '../../providers/common';
+import { Architecture, Os } from '../../providers';
 import { uniqueImageBuilderName } from '../common';
 
 /**

--- a/src/image-builders/aws-image-builder/builder.ts
+++ b/src/image-builders/aws-image-builder/builder.ts
@@ -27,7 +27,7 @@ import { FilterFailedBuildsFunction } from './filter-failed-builds-function';
 import { ReaperFunction } from './reaper-function';
 import { Architecture, Os, RunnerAmi, RunnerImage, RunnerVersion } from '../../providers';
 import { BuildImageFunction } from '../../providers/build-image-function';
-import { MINIMAL_EC2_SSM_SESSION_MANAGER_POLICY_STATEMENT, singletonLambda } from '../../utils';
+import { singletonLambda } from '../../utils';
 import { RunnerImageBuilderBase, RunnerImageBuilderProps, uniqueImageBuilderName } from '../common';
 
 export interface AwsImageBuilderRunnerImageBuilderProps {
@@ -303,7 +303,6 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
     this.role = new iam.Role(this, 'Role', {
       assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
     });
-    this.role.addToPrincipalPolicy(MINIMAL_EC2_SSM_SESSION_MANAGER_POLICY_STATEMENT);
   }
 
   private platform() {
@@ -384,6 +383,7 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
 
     const log = this.createLog('Docker Log', recipe.name);
     const infra = this.createInfrastructure([
+      iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'),
       iam.ManagedPolicy.fromAwsManagedPolicyName('EC2InstanceProfileForImageBuilderECRContainerBuilds'),
     ]);
     const image = this.createImage(infra, dist, log, undefined, recipe.arn);
@@ -599,6 +599,7 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
 
     const log = this.createLog('Ami Log', recipe.name);
     const infra = this.createInfrastructure([
+      iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'),
       iam.ManagedPolicy.fromAwsManagedPolicyName('EC2InstanceProfileForImageBuilder'),
     ]);
     this.createImage(infra, dist, log, recipe.arn, undefined);

--- a/src/image-builders/aws-image-builder/deprecated/ami.ts
+++ b/src/image-builders/aws-image-builder/deprecated/ami.ts
@@ -296,6 +296,7 @@ export class AmiBuilder extends ImageBuilderBase {
 
     const log = this.createLog(recipe.name);
     const infra = this.createInfrastructure([
+      iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'),
       iam.ManagedPolicy.fromAwsManagedPolicyName('EC2InstanceProfileForImageBuilder'),
     ]);
     this.createImage(infra, dist, log, recipe.arn, undefined);

--- a/src/image-builders/aws-image-builder/deprecated/common.ts
+++ b/src/image-builders/aws-image-builder/deprecated/common.ts
@@ -2,7 +2,6 @@ import * as cdk from 'aws-cdk-lib';
 import { aws_ec2 as ec2, aws_events as events, aws_iam as iam, aws_imagebuilder as imagebuilder, aws_logs as logs, RemovalPolicy } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { Architecture, Os, RunnerAmi, RunnerImage, RunnerVersion } from '../../../providers';
-import { MINIMAL_EC2_SSM_SESSION_MANAGER_POLICY_STATEMENT } from '../../../utils';
 import { ImageBuilderBaseProps, IRunnerImageBuilder, uniqueImageBuilderName } from '../../common';
 import { ImageBuilderComponent } from '../builder';
 
@@ -100,7 +99,6 @@ export abstract class ImageBuilderBase extends Construct implements IRunnerImage
       assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
       managedPolicies: managedPolicies,
     });
-    role.addToPrincipalPolicy(MINIMAL_EC2_SSM_SESSION_MANAGER_POLICY_STATEMENT);
 
     for (const component of this.components) {
       component.grantAssetsRead(role);

--- a/src/image-builders/aws-image-builder/deprecated/container.ts
+++ b/src/image-builders/aws-image-builder/deprecated/container.ts
@@ -277,6 +277,7 @@ export class ContainerImageBuilder extends ImageBuilderBase {
 
     const log = this.createLog(recipe.name);
     const infra = this.createInfrastructure([
+      iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'),
       iam.ManagedPolicy.fromAwsManagedPolicyName('EC2InstanceProfileForImageBuilderECRContainerBuilds'),
     ]);
     const image = this.createImage(infra, dist, log, undefined, recipe.arn);

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -235,7 +235,7 @@
         }
       }
     },
-    "936166eb616ec056c83fac9ce3a38bb472fab48446d49c91bd13f123a3986758": {
+    "7a8e8a694d69f5fdb9354b0ca52d4af301794de55ac1909c6a15c6b0feacf433": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -243,7 +243,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "936166eb616ec056c83fac9ce3a38bb472fab48446d49c91bd13f123a3986758.json",
+          "objectKey": "7a8e8a694d69f5fdb9354b0ca52d4af301794de55ac1909c6a15c6b0feacf433.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -2140,6 +2140,18 @@
         {
          "Ref": "AWS::Partition"
         },
+        ":iam::aws:policy/AmazonSSMManagedInstanceCore"
+       ]
+      ]
+     },
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
         ":iam::aws:policy/EC2InstanceProfileForImageBuilderECRContainerBuilds"
        ]
       ]
@@ -2152,18 +2164,6 @@
    "Properties": {
     "PolicyDocument": {
      "Statement": [
-      {
-       "Action": [
-        "ssmmessages:CreateControlChannel",
-        "ssmmessages:CreateDataChannel",
-        "ssmmessages:OpenControlChannel",
-        "ssmmessages:OpenDataChannel",
-        "s3:GetEncryptionConfiguration",
-        "ssm:UpdateInstanceInformation"
-       ],
-       "Effect": "Allow",
-       "Resource": "*"
-      },
       {
        "Action": [
         "s3:GetObject*",
@@ -3117,6 +3117,18 @@
         {
          "Ref": "AWS::Partition"
         },
+        ":iam::aws:policy/AmazonSSMManagedInstanceCore"
+       ]
+      ]
+     },
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
         ":iam::aws:policy/EC2InstanceProfileForImageBuilder"
        ]
       ]
@@ -3129,18 +3141,6 @@
    "Properties": {
     "PolicyDocument": {
      "Statement": [
-      {
-       "Action": [
-        "ssmmessages:CreateControlChannel",
-        "ssmmessages:CreateDataChannel",
-        "ssmmessages:OpenControlChannel",
-        "ssmmessages:OpenDataChannel",
-        "s3:GetEncryptionConfiguration",
-        "ssm:UpdateInstanceInformation"
-       ],
-       "Effect": "Allow",
-       "Resource": "*"
-      },
       {
        "Action": [
         "s3:GetObject*",
@@ -6117,6 +6117,18 @@
         {
          "Ref": "AWS::Partition"
         },
+        ":iam::aws:policy/AmazonSSMManagedInstanceCore"
+       ]
+      ]
+     },
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
         ":iam::aws:policy/EC2InstanceProfileForImageBuilder"
        ]
       ]
@@ -6129,18 +6141,6 @@
    "Properties": {
     "PolicyDocument": {
      "Statement": [
-      {
-       "Action": [
-        "ssmmessages:CreateControlChannel",
-        "ssmmessages:CreateDataChannel",
-        "ssmmessages:OpenControlChannel",
-        "ssmmessages:OpenDataChannel",
-        "s3:GetEncryptionConfiguration",
-        "ssm:UpdateInstanceInformation"
-       ],
-       "Effect": "Allow",
-       "Resource": "*"
-      },
       {
        "Action": [
         "s3:GetObject*",
@@ -7224,6 +7224,18 @@
         {
          "Ref": "AWS::Partition"
         },
+        ":iam::aws:policy/AmazonSSMManagedInstanceCore"
+       ]
+      ]
+     },
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
         ":iam::aws:policy/EC2InstanceProfileForImageBuilder"
        ]
       ]
@@ -7236,18 +7248,6 @@
    "Properties": {
     "PolicyDocument": {
      "Statement": [
-      {
-       "Action": [
-        "ssmmessages:CreateControlChannel",
-        "ssmmessages:CreateDataChannel",
-        "ssmmessages:OpenControlChannel",
-        "ssmmessages:OpenDataChannel",
-        "s3:GetEncryptionConfiguration",
-        "ssm:UpdateInstanceInformation"
-       ],
-       "Effect": "Allow",
-       "Resource": "*"
-      },
       {
        "Action": [
         "s3:GetObject*",


### PR DESCRIPTION
Undo #361 972d085

`AmazonSSMManagedInstanceCore` is sadly required here. It's less of a big deal as the image builders themselves don't run any user code from GitHub Actions. It will be nice to limit this policy in the future, but I couldn't find any decent documentation on the required permissions.