### PR TITLE
fix: GitHub environments can cause two runners to start

### DIFF
--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -183,15 +183,15 @@
         }
       }
     },
-    "ed5c066e93992a94683cd921dc0600114b092fd502c63ba0c386dabe7b25e3d0": {
+    "73d06969dae3fbc390363443faa852c89be78d59711051d161397b235cdec59e": {
       "source": {
-        "path": "asset.ed5c066e93992a94683cd921dc0600114b092fd502c63ba0c386dabe7b25e3d0.lambda",
+        "path": "asset.73d06969dae3fbc390363443faa852c89be78d59711051d161397b235cdec59e.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "ed5c066e93992a94683cd921dc0600114b092fd502c63ba0c386dabe7b25e3d0.zip",
+          "objectKey": "73d06969dae3fbc390363443faa852c89be78d59711051d161397b235cdec59e.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -235,7 +235,7 @@
         }
       }
     },
-    "6418593c96f29aa318ddab45d51a397bdfaa2ec0225c01e0f4d74ef8e720c498": {
+    "4aeb2b22f317868ba44488cc250b07a46464df5409141d7a08b66a32c44c110e": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -243,7 +243,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "6418593c96f29aa318ddab45d51a397bdfaa2ec0225c01e0f4d74ef8e720c498.json",
+          "objectKey": "4aeb2b22f317868ba44488cc250b07a46464df5409141d7a08b66a32c44c110e.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -16817,7 +16817,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "ed5c066e93992a94683cd921dc0600114b092fd502c63ba0c386dabe7b25e3d0.zip"
+     "S3Key": "73d06969dae3fbc390363443faa852c89be78d59711051d161397b235cdec59e.zip"
     },
     "Role": {
      "Fn::GetAtt": [


### PR DESCRIPTION
When GitHub environments are enabled, jobs start out as `queued`, switch to `waiting`, and finally switch to `queued` back. This will get us to spin up two runners as we spin one for each `queued` event.

To avoid the second runner, we use [step function idempotence](https://docs.aws.amazon.com/step-functions/latest/dg/express-at-least-once-execution.html). When we attempt to start an execution with the same name and same input it will either (1) be ignored if the previous execution is still running or (2) error out with `ExecutionAlreadyExists` if the previous execution has already finished. When we get that error, we will try again with a new execution name.

For the case where the job is approved for the environment before the runner times out, the second `queued` event will simply be ignored. This is because the execution name will be the same and the input will be the same. When we try to start another execution, AWS will just return the execution ARN of the existing still running execution.

For the case where approval takes a while, like when a manual user interaction is required, the second `queued` event will start another runner. We will try to start an execution with the same name, but it will fail with `ExecutionAlreadyExists`. Since we got a webhook event asking for a runner, we will try again with a new execution name. We use an increasing counter suffixed to the execution name and will increase it and try again as long as we get `ExecutionAlreadyExists`.

Issues:
* [ ] We will still possibly spin up two runners if the waiting period (which can be user controlled on the GitHub side) is longer than our runner idle timeout.
* [ ] If the first runner is stolen for another job and that job takes a very long time, we may fail to launch another runner for the original job. The other job will get its own runner spun up, but it can timeout. If the approval process finishes after the timeout, there will be no runner for this job and a new one won't be spun up because the first one is still running.

Fixes #380