### PR TITLE
fix: Using personal access token fails on installationId

### DIFF
--- a/src/webhook-handler.lambda.ts
+++ b/src/webhook-handler.lambda.ts
@@ -122,7 +122,7 @@ export async function handler(event: AWSLambda.APIGatewayProxyEventV2): Promise<
     repo: payload.repository.name,
     jobId: payload.workflow_job.id,
     jobUrl: payload.workflow_job.html_url,
-    installationId: payload.installation?.id,
+    installationId: payload.installation?.id ?? -1, // always pass value because step function can't handle missing input
     labels: labels,
   });
   const execution = await sf.startExecution({

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -183,15 +183,15 @@
         }
       }
     },
-    "ac08ece42be7080005ee1b06e2b937274aed1e965033838126e6160b619edfff": {
+    "ca892757dea4a581043309387d856d4a8ac1e73c938bb1355c3d5c7c0ad6a803": {
       "source": {
-        "path": "asset.ac08ece42be7080005ee1b06e2b937274aed1e965033838126e6160b619edfff.lambda",
+        "path": "asset.ca892757dea4a581043309387d856d4a8ac1e73c938bb1355c3d5c7c0ad6a803.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "ac08ece42be7080005ee1b06e2b937274aed1e965033838126e6160b619edfff.zip",
+          "objectKey": "ca892757dea4a581043309387d856d4a8ac1e73c938bb1355c3d5c7c0ad6a803.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -235,7 +235,7 @@
         }
       }
     },
-    "3b3f82e678e51a9a49115ca481c397fdd0b47a647b6b1c9bcdc42d7bb08518fe": {
+    "f65d32368cecdb379a10328d84f469733eafdfcd6ef3a418d6f14466d186a4f1": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -243,7 +243,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "3b3f82e678e51a9a49115ca481c397fdd0b47a647b6b1c9bcdc42d7bb08518fe.json",
+          "objectKey": "f65d32368cecdb379a10328d84f469733eafdfcd6ef3a418d6f14466d186a4f1.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -16817,7 +16817,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "ac08ece42be7080005ee1b06e2b937274aed1e965033838126e6160b619edfff.zip"
+     "S3Key": "ca892757dea4a581043309387d856d4a8ac1e73c938bb1355c3d5c7c0ad6a803.zip"
     },
     "Role": {
      "Fn::GetAtt": [


### PR DESCRIPTION
We pass `installationId` from the input into some parts of the step function. We can't use `undefined` or it won't show up in the input and the step function will fail.

Fixes #404