### PR TITLE
chore: aws-cdk-lib.aws_stepfunctions.TaskStateBaseProps#heartbeat is deprecated

### DIFF
--- a/src/providers/ec2.ts
+++ b/src/providers/ec2.ts
@@ -395,7 +395,7 @@ export class Ec2RunnerProvider extends BaseProvider implements IRunnerProvider {
         integrationPattern: IntegrationPattern.WAIT_FOR_TASK_TOKEN,
         service: 'ec2',
         action: 'runInstances',
-        heartbeat: Duration.minutes(10),
+        heartbeatTimeout: stepfunctions.Timeout.duration(Duration.minutes(10)),
         parameters: {
           LaunchTemplate: {
             LaunchTemplateId: this.ami.launchTemplate.launchTemplateId,


### PR DESCRIPTION
Fixes #397