### PR TITLE
fix: Don't start two runners with GitHub environments/deployments

### DIFF
--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -18,6 +18,8 @@ jobs:
             runs-on: [self-hosted, codebuild-x64]
             docker: true
             sudo: true
+            # test for https://github.com/CloudSnorkel/cdk-github-runners/issues/380
+            environment: env-test
           - name: codebuild arm64
             os: linux
             arch: ARM64
@@ -92,6 +94,7 @@ jobs:
             sudo: true
 
     name: ${{ matrix.name }}
+    environment: ${{ matrix.environment }}
 
     runs-on: ${{ matrix.runs-on }}
     steps:

--- a/src/status.lambda.ts
+++ b/src/status.lambda.ts
@@ -27,6 +27,13 @@ function lambdaArnToUrl(arn: string) {
   return `https://${region}.console.aws.amazon.com/lambda/home?region=${region}#/functions/${name}?tab=monitoring`;
 }
 
+function lambdaArnToLogGroup(arn: string) {
+  const parts = arn.split(':'); // arn:aws:lambda:us-east-1:12345678:function:name-XYZ
+  const name = parts[6];
+
+  return `/aws/lambda/${name}`;
+}
+
 function stepFunctionArnToUrl(arn: string) {
   const parts = arn.split(':'); // arn:aws:states:us-east-1:12345678:stateMachine:name-XYZ
   const region = parts[3];
@@ -146,6 +153,7 @@ export async function handler(event: Partial<AWSLambda.APIGatewayProxyEvent>) {
     troubleshooting: {
       webhookHandlerArn: process.env.WEBHOOK_HANDLER_ARN,
       webhookHandlerUrl: lambdaArnToUrl(process.env.WEBHOOK_HANDLER_ARN),
+      webhookHandlerLogGroup: lambdaArnToLogGroup(process.env.WEBHOOK_HANDLER_ARN),
       stepFunctionArn: process.env.STEP_FUNCTION_ARN,
       stepFunctionUrl: stepFunctionArnToUrl(process.env.STEP_FUNCTION_ARN),
       stepFunctionLogGroup: process.env.STEP_FUNCTION_LOG_GROUP,

--- a/src/webhook-handler.lambda.ts
+++ b/src/webhook-handler.lambda.ts
@@ -1,9 +1,9 @@
 import * as crypto from 'crypto';
 import * as AWSLambda from 'aws-lambda';
 import * as AWS from 'aws-sdk';
+import { getOctokit } from './lambda-github';
 import { getSecretJsonValue } from './lambda-helpers';
 import { SupportedLabels } from './webhook';
-import { getOctokit } from './lambda-github';
 
 const sf = new AWS.StepFunctions();
 
@@ -60,7 +60,7 @@ async function isDeploymentPending(payload: any) {
   const { octokit } = await getOctokit(payload.installation?.id);
   const statuses = await octokit.request(statusesUrl);
 
-  return statuses.data[0]?.state === "waiting";
+  return statuses.data[0]?.state === 'waiting';
 }
 
 function matchLabelsToProvider(labels: string[]) {
@@ -140,11 +140,11 @@ export async function handler(event: AWSLambda.APIGatewayProxyEventV2): Promise<
   }
 
   if (await isDeploymentPending(payload)) {
-      console.log(`Ignoring job as its deployment is still pending`);
-      return {
-          statusCode: 200,
-          body: 'OK. No runner started (deployment pending).',
-      };
+    console.log('Ignoring job as its deployment is still pending');
+    return {
+      statusCode: 200,
+      body: 'OK. No runner started (deployment pending).',
+    };
   }
 
   // don't start step function unless labels match a runner provider

--- a/src/webhook-handler.lambda.ts
+++ b/src/webhook-handler.lambda.ts
@@ -60,7 +60,7 @@ async function isDeploymentPending(payload: any) {
   const { octokit } = await getOctokit(payload.installation?.id);
   const statuses = await octokit.request(statusesUrl);
 
-  return statuses.data[0]?.state !== "queued";
+  return statuses.data[0]?.state === "waiting";
 }
 
 function matchLabelsToProvider(labels: string[]) {

--- a/src/webhook-handler.lambda.ts
+++ b/src/webhook-handler.lambda.ts
@@ -3,6 +3,7 @@ import * as AWSLambda from 'aws-lambda';
 import * as AWS from 'aws-sdk';
 import { getSecretJsonValue } from './lambda-helpers';
 import { SupportedLabels } from './webhook';
+import { getOctokit } from './lambda-github';
 
 const sf = new AWS.StepFunctions();
 
@@ -48,6 +49,18 @@ export function verifyBody(event: AWSLambda.APIGatewayProxyEventV2, secret: any)
   }
 
   return body.toString();
+}
+
+async function isDeploymentPending(payload: any) {
+  const statusesUrl = payload.deployment?.statuses_url;
+  if (statusesUrl === undefined) {
+    return false;
+  }
+
+  const { octokit } = await getOctokit(payload.installation?.id);
+  const statuses = await octokit.request(statusesUrl);
+
+  return statuses.data[0]?.state !== "queued";
 }
 
 function matchLabelsToProvider(labels: string[]) {
@@ -124,6 +137,14 @@ export async function handler(event: AWSLambda.APIGatewayProxyEventV2): Promise<
       statusCode: 200,
       body: 'OK. No runner started (no "self-hosted" label).',
     };
+  }
+
+  if (await isDeploymentPending(payload)) {
+      console.log(`Ignoring job as its deployment is still pending`);
+      return {
+          statusCode: 200,
+          body: 'OK. No runner started (deployment pending).',
+      };
   }
 
   // don't start step function unless labels match a runner provider

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -68,6 +68,8 @@ export class GithubWebhookHandler extends Construct {
         environment: {
           STEP_FUNCTION_ARN: props.orchestrator.stateMachineArn,
           WEBHOOK_SECRET_ARN: props.secrets.webhook.secretArn,
+          GITHUB_SECRET_ARN: props.secrets.github.secretArn,
+          GITHUB_PRIVATE_KEY_SECRET_ARN: props.secrets.githubPrivateKey.secretArn,
           SUPPORTED_LABELS: JSON.stringify(props.supportedLabels),
         },
         timeout: cdk.Duration.seconds(30),
@@ -79,6 +81,8 @@ export class GithubWebhookHandler extends Construct {
     this.url = access.bind(this, 'access', this.handler);
 
     props.secrets.webhook.grantRead(this.handler);
+    props.secrets.github.grantRead(this.handler);
+    props.secrets.githubPrivateKey.grantRead(this.handler);
     props.orchestrator.grantStartExecution(this.handler);
   }
 }

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -183,15 +183,15 @@
         }
       }
     },
-    "8d2fe7cd5baa10adb194b69b18aaedbd84e5d8dec379d007dcc4135acacfd182": {
+    "b04bca24af61fb137707c8dda8e5c5c3bd35999705dc011dd58aeb4be6a69947": {
       "source": {
-        "path": "asset.8d2fe7cd5baa10adb194b69b18aaedbd84e5d8dec379d007dcc4135acacfd182.lambda",
+        "path": "asset.b04bca24af61fb137707c8dda8e5c5c3bd35999705dc011dd58aeb4be6a69947.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "8d2fe7cd5baa10adb194b69b18aaedbd84e5d8dec379d007dcc4135acacfd182.zip",
+          "objectKey": "b04bca24af61fb137707c8dda8e5c5c3bd35999705dc011dd58aeb4be6a69947.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -235,7 +235,7 @@
         }
       }
     },
-    "09ed4d8caa4c900456bd69c928a6acc1546ad001defcdfe5ad4611561c5f21a9": {
+    "1c9b92f36627215ed19267b003dd65345848e2a99e34656d5b5b2d40a9e0e1ff": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -243,7 +243,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "09ed4d8caa4c900456bd69c928a6acc1546ad001defcdfe5ad4611561c5f21a9.json",
+          "objectKey": "1c9b92f36627215ed19267b003dd65345848e2a99e34656d5b5b2d40a9e0e1ff.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -183,15 +183,15 @@
         }
       }
     },
-    "613f6b9b955996f5af65fd19fc69b6f91a45f7271de98a454db015b7cc757e9b": {
+    "8d2fe7cd5baa10adb194b69b18aaedbd84e5d8dec379d007dcc4135acacfd182": {
       "source": {
-        "path": "asset.613f6b9b955996f5af65fd19fc69b6f91a45f7271de98a454db015b7cc757e9b.lambda",
+        "path": "asset.8d2fe7cd5baa10adb194b69b18aaedbd84e5d8dec379d007dcc4135acacfd182.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "613f6b9b955996f5af65fd19fc69b6f91a45f7271de98a454db015b7cc757e9b.zip",
+          "objectKey": "8d2fe7cd5baa10adb194b69b18aaedbd84e5d8dec379d007dcc4135acacfd182.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -235,7 +235,7 @@
         }
       }
     },
-    "0f995c3a9715caa75bf1b6221bc78b55e717343fc3bab3584650a6a7d5a83ad7": {
+    "09ed4d8caa4c900456bd69c928a6acc1546ad001defcdfe5ad4611561c5f21a9": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -243,7 +243,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "0f995c3a9715caa75bf1b6221bc78b55e717343fc3bab3584650a6a7d5a83ad7.json",
+          "objectKey": "09ed4d8caa4c900456bd69c928a6acc1546ad001defcdfe5ad4611561c5f21a9.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -183,15 +183,15 @@
         }
       }
     },
-    "3de9933acb4ef22a64f565aac3d1c553e79e37e2b78dbd68dff914eaf0afab57": {
+    "613f6b9b955996f5af65fd19fc69b6f91a45f7271de98a454db015b7cc757e9b": {
       "source": {
-        "path": "asset.3de9933acb4ef22a64f565aac3d1c553e79e37e2b78dbd68dff914eaf0afab57.lambda",
+        "path": "asset.613f6b9b955996f5af65fd19fc69b6f91a45f7271de98a454db015b7cc757e9b.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "3de9933acb4ef22a64f565aac3d1c553e79e37e2b78dbd68dff914eaf0afab57.zip",
+          "objectKey": "613f6b9b955996f5af65fd19fc69b6f91a45f7271de98a454db015b7cc757e9b.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -209,15 +209,15 @@
         }
       }
     },
-    "0dabbb1811a3f8a3a83de847f0cb208f97c2fbbace6e74a9687feb8d4c543a72": {
+    "f6bd7a51c37496572cc93e29101573598ccc4e3bf48de413ce58382b36b0a61c": {
       "source": {
-        "path": "asset.0dabbb1811a3f8a3a83de847f0cb208f97c2fbbace6e74a9687feb8d4c543a72.lambda",
+        "path": "asset.f6bd7a51c37496572cc93e29101573598ccc4e3bf48de413ce58382b36b0a61c.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "0dabbb1811a3f8a3a83de847f0cb208f97c2fbbace6e74a9687feb8d4c543a72.zip",
+          "objectKey": "f6bd7a51c37496572cc93e29101573598ccc4e3bf48de413ce58382b36b0a61c.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -235,7 +235,7 @@
         }
       }
     },
-    "2449cbcc466719bbee558864830c41fee889fe3a96672df06d8691dd21c51583": {
+    "0f995c3a9715caa75bf1b6221bc78b55e717343fc3bab3584650a6a7d5a83ad7": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -243,7 +243,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "2449cbcc466719bbee558864830c41fee889fe3a96672df06d8691dd21c51583.json",
+          "objectKey": "0f995c3a9715caa75bf1b6221bc78b55e717343fc3bab3584650a6a7d5a83ad7.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -16701,6 +16701,26 @@
        }
       },
       {
+       "Action": [
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:DescribeSecret"
+       ],
+       "Effect": "Allow",
+       "Resource": {
+        "Ref": "runnersSecretsGitHubEFD96479"
+       }
+      },
+      {
+       "Action": [
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:DescribeSecret"
+       ],
+       "Effect": "Allow",
+       "Resource": {
+        "Ref": "runnersSecretsGitHubPrivateKey79498F91"
+       }
+      },
+      {
        "Action": "states:StartExecution",
        "Effect": "Allow",
        "Resource": {
@@ -16725,7 +16745,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "3de9933acb4ef22a64f565aac3d1c553e79e37e2b78dbd68dff914eaf0afab57.zip"
+     "S3Key": "613f6b9b955996f5af65fd19fc69b6f91a45f7271de98a454db015b7cc757e9b.zip"
     },
     "Role": {
      "Fn::GetAtt": [
@@ -16741,6 +16761,12 @@
       },
       "WEBHOOK_SECRET_ARN": {
        "Ref": "runnersSecretsWebhook7AF0D74E"
+      },
+      "GITHUB_SECRET_ARN": {
+       "Ref": "runnersSecretsGitHubEFD96479"
+      },
+      "GITHUB_PRIVATE_KEY_SECRET_ARN": {
+       "Ref": "runnersSecretsGitHubPrivateKey79498F91"
       },
       "SUPPORTED_LABELS": "[{\"provider\":\"github-runners-test/CodeBuildx64\",\"labels\":[\"codebuild-x64\"]},{\"provider\":\"github-runners-test/CodeBuildARM\",\"labels\":[\"codebuild\",\"linux\",\"arm64\"]},{\"provider\":\"github-runners-test/CodeBuildWindows\",\"labels\":[\"codebuild\",\"windows\",\"x64\"]},{\"provider\":\"github-runners-test/ECS\",\"labels\":[\"ecs\",\"linux\",\"x64\"]},{\"provider\":\"github-runners-test/ECS ARM64\",\"labels\":[\"ecs\",\"linux\",\"arm64\"]},{\"provider\":\"github-runners-test/ECS Windows\",\"labels\":[\"ecs\",\"windows\",\"x64\"]},{\"provider\":\"github-runners-test/Lambda\",\"labels\":[\"lambda\",\"x64\"]},{\"provider\":\"github-runners-test/LambdaARM\",\"labels\":[\"lambda\",\"arm64\"]},{\"provider\":\"github-runners-test/Fargate\",\"labels\":[\"fargate\",\"linux\",\"x64\"]},{\"provider\":\"github-runners-test/Fargate-x64-spot\",\"labels\":[\"fargate-spot\",\"linux\",\"x64\"]},{\"provider\":\"github-runners-test/Fargate-arm64\",\"labels\":[\"fargate\",\"linux\",\"arm64\"]},{\"provider\":\"github-runners-test/Fargate-arm64-spot\",\"labels\":[\"fargate-spot\",\"linux\",\"arm64\"]},{\"provider\":\"github-runners-test/Fargate-Windows\",\"labels\":[\"fargate\",\"windows\",\"x64\"]},{\"provider\":\"github-runners-test/EC2 Linux\",\"labels\":[\"ec2\",\"linux\",\"x64\"]},{\"provider\":\"github-runners-test/EC2 Spot Linux\",\"labels\":[\"ec2-spot\",\"linux\",\"x64\"]},{\"provider\":\"github-runners-test/EC2 Linux arm64\",\"labels\":[\"ec2\",\"linux\",\"arm64\"]},{\"provider\":\"github-runners-test/EC2 Windows\",\"labels\":[\"ec2\",\"windows\",\"x64\"]}]",
       "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1"
@@ -17245,7 +17271,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "0dabbb1811a3f8a3a83de847f0cb208f97c2fbbace6e74a9687feb8d4c543a72.zip"
+     "S3Key": "f6bd7a51c37496572cc93e29101573598ccc4e3bf48de413ce58382b36b0a61c.zip"
     },
     "Role": {
      "Fn::GetAtt": [

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -16745,7 +16745,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "8d2fe7cd5baa10adb194b69b18aaedbd84e5d8dec379d007dcc4135acacfd182.zip"
+     "S3Key": "b04bca24af61fb137707c8dda8e5c5c3bd35999705dc011dd58aeb4be6a69947.zip"
     },
     "Role": {
      "Fn::GetAtt": [

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -16745,7 +16745,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "613f6b9b955996f5af65fd19fc69b6f91a45f7271de98a454db015b7cc757e9b.zip"
+     "S3Key": "8d2fe7cd5baa10adb194b69b18aaedbd84e5d8dec379d007dcc4135acacfd182.zip"
     },
     "Role": {
      "Fn::GetAtt": [


### PR DESCRIPTION
When GitHub environments are used, we get the `queued` webhook twice. Once when the job is first queued and another when the job is approved for deployment into the specific environment. This causes two runners to be started for the same job. This wastes resources.

To fix this, we check `dpeloyment.statuses_url` in the payload. If it exists, it contains a URL with details about the deployment status. When the deployment is still pending, the first item in the array will have `status: 'waiting'`. Once the deployment is approved and runners can actually run it, the first item in the array will have `status: 'queued'`. So if the status of the deployment is `waiting`, we don't start a runner. When the second webhook comes in, the status will be `queued` and we can start a runner.

Fixes #380