### PR TITLE
feat: Optional Logs Insights queries to help diagnose issues

### DIFF
--- a/API.md
+++ b/API.md
@@ -3199,6 +3199,7 @@ new GitHubRunners(scope: Construct, id: string, props?: GitHubRunnersProps)
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.GitHubRunners.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@cloudsnorkel/cdk-github-runners.GitHubRunners.createLogsInsightsQueries">createLogsInsightsQueries</a></code> | Creates CloudWatch Logs Insights saved queries that can be used to debug issues with the runners. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.GitHubRunners.failedImageBuildsTopic">failedImageBuildsTopic</a></code> | Creates a topic for notifications when a runner image build fails. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.GitHubRunners.metricFailed">metricFailed</a></code> | Metric for failed runner executions. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.GitHubRunners.metricJobCompleted">metricJobCompleted</a></code> | Metric for the number of GitHub Actions jobs completed. |
@@ -3214,6 +3215,19 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
+
+##### `createLogsInsightsQueries` <a name="createLogsInsightsQueries" id="@cloudsnorkel/cdk-github-runners.GitHubRunners.createLogsInsightsQueries"></a>
+
+```typescript
+public createLogsInsightsQueries(): void
+```
+
+Creates CloudWatch Logs Insights saved queries that can be used to debug issues with the runners.
+
+* "Webhook errors" helps diagnose configuration issues with GitHub integration
+* "Ignored webhook" helps understand why runners aren't started
+* "Ignored jobs based on labels" helps debug label matching issues
+* "Webhook started runners" helps understand which runners were started
 
 ##### `failedImageBuildsTopic` <a name="failedImageBuildsTopic" id="@cloudsnorkel/cdk-github-runners.GitHubRunners.failedImageBuildsTopic"></a>
 

--- a/README.md
+++ b/README.md
@@ -280,6 +280,16 @@ Runners are started in response to a webhook coming in from GitHub. If there are
    2. If you see too many errors, make sure you're only sending `workflow_job` events
 5. When using GitHub app, make sure there are active installations in `github.auth.app.installations`
 
+All logs are saved in CloudWatch.
+* Log group names can be found in `status.json` for each provider, image builder, and other parts of the system
+* Some useful Logs Insights queries can be enabled with `GitHubRunners.createLogsInsightsQueries()`
+
+To get `status.json`, check out the CloudFormation stack output for a command that generates it. The command looks like:
+
+```
+aws --region us-east-1 lambda invoke --function-name status-XYZ123 status.json
+```
+
 ## Monitoring
 
 There are two important ways to monitor your runners:

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -235,7 +235,7 @@
         }
       }
     },
-    "1c9b92f36627215ed19267b003dd65345848e2a99e34656d5b5b2d40a9e0e1ff": {
+    "5d4715129583e637ba2c7b9d7770e53d2579d8787841d542e5cad95a1ecf3924": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -243,7 +243,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "1c9b92f36627215ed19267b003dd65345848e2a99e34656d5b5b2d40a9e0e1ff.json",
+          "objectKey": "5d4715129583e637ba2c7b9d7770e53d2579d8787841d542e5cad95a1ecf3924.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -18842,6 +18842,66 @@
     }
    }
   },
+  "runnersWebhookerrors72F5BFF3": {
+   "Type": "AWS::Logs::QueryDefinition",
+   "Properties": {
+    "Name": "GitHub Runners/Webhook errors",
+    "QueryString": "parse @message /^(?<timestamp>[^\\s]+)\\t(?<requestId>[^\\s]+)\\t(?<level>[^\\s]+)\\t(?<message>.+$)/\n| filter level = \"ERROR\"\n| sort @timestamp desc\n| limit 100",
+    "LogGroupNames": [
+     {
+      "Fn::GetAtt": [
+       "runnersWebhookHandlerwebhookhandlerLogRetention0F5ED260",
+       "LogGroupName"
+      ]
+     }
+    ]
+   }
+  },
+  "runnersIgnoredwebhooksAD368063": {
+   "Type": "AWS::Logs::QueryDefinition",
+   "Properties": {
+    "Name": "GitHub Runners/Ignored webhooks",
+    "QueryString": "parse @message /^(?<timestamp>[^\\s]+)\\t(?<requestId>[^\\s]+)\\t(?<level>[^\\s]+)\\t(?<message>.+$)/\n| filter strcontains(message, \"Ignoring\")\n| sort @timestamp desc\n| limit 100",
+    "LogGroupNames": [
+     {
+      "Fn::GetAtt": [
+       "runnersWebhookHandlerwebhookhandlerLogRetention0F5ED260",
+       "LogGroupName"
+      ]
+     }
+    ]
+   }
+  },
+  "runnersIgnoredjobsbasedonlabels120F3D1A": {
+   "Type": "AWS::Logs::QueryDefinition",
+   "Properties": {
+    "Name": "GitHub Runners/Ignored jobs based on labels",
+    "QueryString": "parse @message /^(?<timestamp>[^\\s]+)\\t(?<requestId>[^\\s]+)\\t(?<level>[^\\s]+)\\t(?<message>.+$)/\n| filter strcontains(message, \"Ignoring labels\")\n| sort @timestamp desc\n| limit 100",
+    "LogGroupNames": [
+     {
+      "Fn::GetAtt": [
+       "runnersWebhookHandlerwebhookhandlerLogRetention0F5ED260",
+       "LogGroupName"
+      ]
+     }
+    ]
+   }
+  },
+  "runnersWebhookstartedrunners63776EDF": {
+   "Type": "AWS::Logs::QueryDefinition",
+   "Properties": {
+    "Name": "GitHub Runners/Webhook started runners",
+    "QueryString": "fields @timestamp, @message\n| filter jobUrl like /http.*/\n| sort @timestamp desc\n| limit 100",
+    "LogGroupNames": [
+     {
+      "Fn::GetAtt": [
+       "runnersWebhookHandlerwebhookhandlerLogRetention0F5ED260",
+       "LogGroupName"
+      ]
+     }
+    ]
+   }
+  },
   "AMIRootDeviceReaderdcc036c8876b451ea2c1552f9e06e9e1ServiceRole69906A36": {
    "Type": "AWS::IAM::Role",
    "Properties": {

--- a/test/default.integ.ts
+++ b/test/default.integ.ts
@@ -238,5 +238,6 @@ const runners = new GitHubRunners(stack, 'runners', {
 
 runners.metricJobCompleted();
 runners.failedImageBuildsTopic();
+runners.createLogsInsightsQueries();
 
 app.synth();


### PR DESCRIPTION
Use `GitHubRunners.createLogsInsightsQueries()` to create some useful Logs Insights queries that help diagnose GitHub integration issues.

![image](https://github.com/CloudSnorkel/cdk-github-runners/assets/1156773/b806f2f0-c689-4d66-8f65-a0eb9a1006a8)

Fix #393