### PR TITLE
fix: Missing permission for new double runner protection with GitHub environments

### DIFF
--- a/SETUP_GITHUB.md
+++ b/SETUP_GITHUB.md
@@ -30,6 +30,7 @@ Integration with GitHub can be done using an [app](#app-authentication) or [pers
 4. In the repository permissions section enable:
     1. Actions: Read and write
     2. Administration: Read and write
+    3. Deployments: Read and write
 5. In the event subscription section enable:
     1. Workflow job
 6. Under "Where can this GitHub App be installed?" select "Only on this account"

--- a/SETUP_GITHUB.md
+++ b/SETUP_GITHUB.md
@@ -30,7 +30,7 @@ Integration with GitHub can be done using an [app](#app-authentication) or [pers
 4. In the repository permissions section enable:
     1. Actions: Read and write
     2. Administration: Read and write
-    3. Deployments: Read and write
+    3. Deployments: Read-only
 5. In the event subscription section enable:
     1. Workflow job
 6. Under "Where can this GitHub App be installed?" select "Only on this account"

--- a/setup/src/App.svelte
+++ b/setup/src/App.svelte
@@ -22,7 +22,7 @@
     default_permissions: {
       actions: 'write',
       administration: 'write',
-      deployments: 'write',
+      deployments: 'read',
     },
     default_events: [
       'workflow_job',

--- a/setup/src/App.svelte
+++ b/setup/src/App.svelte
@@ -22,6 +22,7 @@
     default_permissions: {
       actions: 'write',
       administration: 'write',
+      deployments: 'write',
     },
     default_events: [
       'workflow_job',

--- a/src/webhook-handler.lambda.ts
+++ b/src/webhook-handler.lambda.ts
@@ -57,10 +57,15 @@ async function isDeploymentPending(payload: any) {
     return false;
   }
 
-  const { octokit } = await getOctokit(payload.installation?.id);
-  const statuses = await octokit.request(statusesUrl);
+  try {
+    const { octokit } = await getOctokit(payload.installation?.id);
+    const statuses = await octokit.request(statusesUrl);
 
-  return statuses.data[0]?.state === 'waiting';
+    return statuses.data[0]?.state === 'waiting';
+  } catch (e) {
+    console.error('Unable to check deployment. Try adding deployment read permission.', e);
+    return false;
+  }
 }
 
 function matchLabelsToProvider(labels: string[]) {

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -183,28 +183,28 @@
         }
       }
     },
-    "b04bca24af61fb137707c8dda8e5c5c3bd35999705dc011dd58aeb4be6a69947": {
+    "bf4d0ebab7563887e6e9c1d6ff18d6c68c81b2646a5e929f368e812edb31eba6": {
       "source": {
-        "path": "asset.b04bca24af61fb137707c8dda8e5c5c3bd35999705dc011dd58aeb4be6a69947.lambda",
+        "path": "asset.bf4d0ebab7563887e6e9c1d6ff18d6c68c81b2646a5e929f368e812edb31eba6.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "b04bca24af61fb137707c8dda8e5c5c3bd35999705dc011dd58aeb4be6a69947.zip",
+          "objectKey": "bf4d0ebab7563887e6e9c1d6ff18d6c68c81b2646a5e929f368e812edb31eba6.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "9a531fc161e68165fc571ff40cf6189a38c07223aff8baae6c2ab6d1d003dc8b": {
+    "e34829239cd67c2056f541f2fd2d4112372000b7cb7a1520b05964d220bf4395": {
       "source": {
-        "path": "asset.9a531fc161e68165fc571ff40cf6189a38c07223aff8baae6c2ab6d1d003dc8b.lambda",
+        "path": "asset.e34829239cd67c2056f541f2fd2d4112372000b7cb7a1520b05964d220bf4395.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "9a531fc161e68165fc571ff40cf6189a38c07223aff8baae6c2ab6d1d003dc8b.zip",
+          "objectKey": "e34829239cd67c2056f541f2fd2d4112372000b7cb7a1520b05964d220bf4395.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -235,7 +235,7 @@
         }
       }
     },
-    "2bb013b24e8ed63bbede4e667e5e08e9b10ea3be9a11a9ae25e1d90b38e957f2": {
+    "01d7a8e9a800d3fa41bcd7fcaef8e331931295d223650c67a43dab0ead6de5bc": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -243,7 +243,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "2bb013b24e8ed63bbede4e667e5e08e9b10ea3be9a11a9ae25e1d90b38e957f2.json",
+          "objectKey": "01d7a8e9a800d3fa41bcd7fcaef8e331931295d223650c67a43dab0ead6de5bc.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -16745,7 +16745,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "b04bca24af61fb137707c8dda8e5c5c3bd35999705dc011dd58aeb4be6a69947.zip"
+     "S3Key": "bf4d0ebab7563887e6e9c1d6ff18d6c68c81b2646a5e929f368e812edb31eba6.zip"
     },
     "Role": {
      "Fn::GetAtt": [
@@ -16944,7 +16944,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "9a531fc161e68165fc571ff40cf6189a38c07223aff8baae6c2ab6d1d003dc8b.zip"
+     "S3Key": "e34829239cd67c2056f541f2fd2d4112372000b7cb7a1520b05964d220bf4395.zip"
     },
     "Role": {
      "Fn::GetAtt": [


### PR DESCRIPTION
We added a workaround for double runners when using GitHub deployments/environments with #416. For private repositories using deployments/environments, this requires a new permission for the GitHub app or personal access token. The new required permission is [read-only for deployments](https://docs.github.com/en/rest/overview/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-deployments).

This PR updates the documentation and the automated setup process to reflect this new requirement. It also makes this new required permission optional for better backwards compatibility with existing installations.

If you need to add this permission to an existing installation, follow these steps:
1. Generate a new `status.json` using something like `aws --region us-east-1 lambda invoke --function-name github-runners-status12345-xyz status.json`. The exact command can be found in the output section of your deployed CloudFormation stack.
2. In `status.json` find your GitHub application URL under `github.auth.app.url` and navigate to it.
3. Click "App settings" on the right
4. Click "Permissions & events" on the left
5. Click to expand "Repository permissions"
6. Scroll down to Deployments and choose Read-only access.
7. Scroll to the bottom and hit "Save changes"
8. Check your email for notification that the permissions have changed and need to be updated for each app installation

You can also choose to delete the app, put a new value in the setup secret (`status.json` -- `github.setup.secretUrl`), and run through the setup process again.

Related to #380

Fixes #426 