### PR TITLE
chore: Fix snapshot updater

### DIFF
--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -81,7 +81,7 @@ jobs:
             ------
 
             *Automatically created by projen via the "upgrade-snapshot" workflow*
-          branch: github-actions/upgrade-snapshot
+          branch: ${{ github.event.workflow_run.head_branch }}-upgrade-snapshot
           title: "chore(deps): update snapshot for dependencies upgrade"
           body: |-
             Update snapshot. See details in [workflow run].


### PR DESCRIPTION
It works on all branches, so shouldn't reuse the branch name.