### PR TITLE
fix: No child with id: 'CodeBuild' or 'Infrastructure'

### DIFF
--- a/src/image-builders/aws-image-builder/builder.ts
+++ b/src/image-builders/aws-image-builder/builder.ts
@@ -772,8 +772,13 @@ export class AwsImageBuilderFailedBuildNotifier implements cdk.IAspect {
   public visit(node: IConstruct): void {
     if (node instanceof AwsImageBuilderRunnerImageBuilder) {
       const builder = node as AwsImageBuilderRunnerImageBuilder;
-      const infra = builder.node.findChild('Infrastructure') as imagebuilder.CfnInfrastructureConfiguration;
-      infra.snsTopicArn = this.topic.topicArn;
+      const infraNode = builder.node.tryFindChild('Infrastructure');
+      if (infraNode) {
+        const infra = infraNode as imagebuilder.CfnInfrastructureConfiguration;
+        infra.snsTopicArn = this.topic.topicArn;
+      } else {
+        cdk.Annotations.of(builder).addWarning('Unused builder cannot get notifications of failed builds');
+      }
     }
   }
 }

--- a/src/image-builders/codebuild.ts
+++ b/src/image-builders/codebuild.ts
@@ -373,8 +373,13 @@ export class CodeBuildImageBuilderFailedBuildNotifier implements cdk.IAspect {
   public visit(node: IConstruct): void {
     if (node instanceof CodeBuildRunnerImageBuilder) {
       const builder = node as CodeBuildRunnerImageBuilder;
-      const project = builder.node.findChild('CodeBuild') as codebuild.Project;
-      project.notifyOnBuildFailed('BuildFailed', this.topic);
+      const projectNode = builder.node.tryFindChild('CodeBuild');
+      if (projectNode) {
+        const project = projectNode as codebuild.Project;
+        project.notifyOnBuildFailed('BuildFailed', this.topic);
+      } else {
+        cdk.Annotations.of(builder).addWarning('Unused builder cannot get notifications of failed builds');
+      }
     }
   }
 }


### PR DESCRIPTION
When a builder is created but not used, calling `failedImageBuildsTopic()` raises an exception.

```
No child with id: 'CodeBuild'
```

or

```
No child with id: 'Infrastructure'
```

For example, this would trigger the exceptions:

```
  const app = new cdk.App();
  const stack = new cdk.Stack(app, 'test');

  const vpc = new ec2.Vpc(stack, 'vpc');

  LambdaRunnerProvider.imageBuilder(stack, 'codebuild builder');
  Ec2RunnerProvider.imageBuilder(stack, 'ec2 image builder', { vpc });

  new GitHubRunners(stack, 'runners', {
    providers: [new LambdaRunnerProvider(stack, 'p1' /* not using builder on purpose */)],
  }).failedImageBuildsTopic();

  app.synth();
```

Fixes #490