### PR TITLE
fix: AMI cleaner not authorized to perform: ec2:DeregisterImage with multiple builders

### DIFF
--- a/src/image-builders/aws-image-builder/builder.ts
+++ b/src/image-builders/aws-image-builder/builder.ts
@@ -659,7 +659,6 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
           conditions: {
             StringEquals: {
               'aws:ResourceTag/GitHubRunners:Stack': stackName,
-              'aws:ResourceTag/GitHubRunners:Builder': builderName,
             },
           },
         }),

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -235,7 +235,7 @@
         }
       }
     },
-    "20a5927a78bfcde85acb5c539996034a945c6a14e4fc86761699ddf4113b12c6": {
+    "2aae55820f5b3b1bc6c23108a950d448c9f06303c2e15a71f6aed05080984ca5": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -243,7 +243,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "20a5927a78bfcde85acb5c539996034a945c6a14e4fc86761699ddf4113b12c6.json",
+          "objectKey": "2aae55820f5b3b1bc6c23108a950d448c9f06303c2e15a71f6aed05080984ca5.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -13582,8 +13582,7 @@
        ],
        "Condition": {
         "StringEquals": {
-         "aws:ResourceTag/GitHubRunners:Stack": "github-runners-test",
-         "aws:ResourceTag/GitHubRunners:Builder": "github-runners-test/AMI Linux Builder"
+         "aws:ResourceTag/GitHubRunners:Stack": "github-runners-test"
         }
        },
        "Effect": "Allow",


### PR DESCRIPTION
When multiple AMI builders were used in the same stack, the custom resource used to clean up AMIs on delete only had access to delete AMIs for one of the builders.

The error looked like:

```
Received response status [FAILED] from custom resource. Message returned: You are not authorized to perform this operation. User: arn:aws:sts::0123456789:assumed-role/github-runners-test-deleteamidcc036c8876b451ea2c15-0123456789/github-runners-test-deleteamidcc036c8876b451ea2c15-0123456789 is not authorized to perform: ec2:DeregisterImage on resource: arn:aws:ec2:us-east-1::image/ami-079195c0509e4a902 because no identity-based policy allows the ec2:DeregisterImage action.
```