### PR TITLE
feat: Option to speed up deploys by not waiting for runner images to build

### DIFF
--- a/API.md
+++ b/API.md
@@ -7802,6 +7802,7 @@ const runnerImageBuilderProps: RunnerImageBuilderProps = { ... }
 | <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerImageBuilderProps.property.securityGroups">securityGroups</a></code> | <code>aws-cdk-lib.aws_ec2.ISecurityGroup[]</code> | Security Groups to assign to this instance. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerImageBuilderProps.property.subnetSelection">subnetSelection</a></code> | <code>aws-cdk-lib.aws_ec2.SubnetSelection</code> | Where to place the network interfaces within the VPC. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerImageBuilderProps.property.vpc">vpc</a></code> | <code>aws-cdk-lib.aws_ec2.IVpc</code> | VPC to build the image in. |
+| <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerImageBuilderProps.property.waitOnDeploy">waitOnDeploy</a></code> | <code>boolean</code> | Wait for image to finish building during deployment. |
 
 ---
 
@@ -8010,6 +8011,25 @@ public readonly vpc: IVpc;
 - *Default:* no VPC
 
 VPC to build the image in.
+
+---
+
+##### `waitOnDeploy`<sup>Optional</sup> <a name="waitOnDeploy" id="@cloudsnorkel/cdk-github-runners.RunnerImageBuilderProps.property.waitOnDeploy"></a>
+
+```typescript
+public readonly waitOnDeploy: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Wait for image to finish building during deployment.
+
+It's usually best to leave this enabled to ensure everything is ready once deployment is done. However, it can be disabled to speed up deployment in case where you have a lot of image components that can take a long time to build.
+
+Disabling this option means a finished deployment is not ready to be used. You will have to wait for the image to finish building before the system can be used.
+
+Disabling this option may also mean any changes to settings or components can take up to a week (default rebuild interval) to take effect.
 
 ---
 

--- a/src/image-builders/common.ts
+++ b/src/image-builders/common.ts
@@ -233,6 +233,17 @@ export interface RunnerImageBuilderProps {
    * Options specific to AWS Image Builder. Only used when builderType is RunnerImageBuilderType.AWS_IMAGE_BUILDER.
    */
   readonly awsImageBuilderOptions?: AwsImageBuilderRunnerImageBuilderProps;
+
+  /**
+   * Wait for image to finish building during deployment. It's usually best to leave this enabled to ensure everything is ready once deployment is done. However, it can be disabled to speed up deployment in case where you have a lot of image components that can take a long time to build.
+   *
+   * Disabling this option means a finished deployment is not ready to be used. You will have to wait for the image to finish building before the system can be used.
+   *
+   * Disabling this option may also mean any changes to settings or components can take up to a week (default rebuild interval) to take effect.
+   *
+   * @default true
+   */
+  readonly waitOnDeploy?: boolean;
 }
 
 export enum RunnerImageBuilderType {

--- a/src/providers/lambda.ts
+++ b/src/providers/lambda.ts
@@ -259,7 +259,7 @@ export class LambdaRunnerProvider extends BaseProvider implements IRunnerProvide
     if (!image._dependable) {
       // AWS Image Builder can't get us dependable images and there is no point in using it anyway. CodeBuild is so much faster.
       // This may change if Lambda starts supporting Windows images. Then we would need AWS Image Builder.
-      cdk.Annotations.of(this).addError('Lambda provider can only work with images built by CodeBuild and not AWS Image Builder');
+      cdk.Annotations.of(this).addError('Lambda provider can only work with images built by CodeBuild and not AWS Image Builder. `waitOnDeploy: false` is also not supported.');
     }
 
     // get image digest and make sure to get it every time the lambda function might be updated

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -235,7 +235,7 @@
         }
       }
     },
-    "e2a950833136e41911deab538001a04df1bec5cddf0fc0e0d016be54b427b9f1": {
+    "420c5007c0ded3fcd493c11ed9455eca37eb3164609edf8e9f05c4b216d3cade": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -243,7 +243,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "e2a950833136e41911deab538001a04df1bec5cddf0fc0e0d016be54b427b9f1.json",
+          "objectKey": "420c5007c0ded3fcd493c11ed9455eca37eb3164609edf8e9f05c4b216d3cade.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -2885,41 +2885,6 @@
     "WindowsImageBuilderInfrastructureFF99A30B"
    ]
   },
-  "WindowsImageBuilderDockerPipeline3613721A": {
-   "Type": "AWS::ImageBuilder::ImagePipeline",
-   "Properties": {
-    "ContainerRecipeArn": {
-     "Fn::GetAtt": [
-      "WindowsImageBuilderContainerRecipeB2A421D7",
-      "Arn"
-     ]
-    },
-    "DistributionConfigurationArn": {
-     "Fn::GetAtt": [
-      "WindowsImageBuilderDockerDistributionCDE69DC2",
-      "Arn"
-     ]
-    },
-    "ImageTestsConfiguration": {
-     "ImageTestsEnabled": false
-    },
-    "InfrastructureConfigurationArn": {
-     "Fn::GetAtt": [
-      "WindowsImageBuilderInfrastructureFF99A30B",
-      "Arn"
-     ]
-    },
-    "Name": "github-runners-test-WindowsImageBuilder-18C0E1B2",
-    "Schedule": {
-     "PipelineExecutionStartCondition": "EXPRESSION_MATCH_ONLY",
-     "ScheduleExpression": "rate(7 days)"
-    }
-   },
-   "DependsOn": [
-    "WindowsImageBuilderDockerLogE660E23E",
-    "WindowsImageBuilderInfrastructureFF99A30B"
-   ]
-  },
   "WindowsImageBuilderCRPolicy81A41F62": {
    "Type": "AWS::IAM::Policy",
    "Properties": {
@@ -3063,6 +3028,41 @@
     },
     "ResourceType": "CONTAINER_IMAGE"
    }
+  },
+  "WindowsImageBuilderDockerPipeline3613721A": {
+   "Type": "AWS::ImageBuilder::ImagePipeline",
+   "Properties": {
+    "ContainerRecipeArn": {
+     "Fn::GetAtt": [
+      "WindowsImageBuilderContainerRecipeB2A421D7",
+      "Arn"
+     ]
+    },
+    "DistributionConfigurationArn": {
+     "Fn::GetAtt": [
+      "WindowsImageBuilderDockerDistributionCDE69DC2",
+      "Arn"
+     ]
+    },
+    "ImageTestsConfiguration": {
+     "ImageTestsEnabled": false
+    },
+    "InfrastructureConfigurationArn": {
+     "Fn::GetAtt": [
+      "WindowsImageBuilderInfrastructureFF99A30B",
+      "Arn"
+     ]
+    },
+    "Name": "github-runners-test-WindowsImageBuilder-18C0E1B2",
+    "Schedule": {
+     "PipelineExecutionStartCondition": "EXPRESSION_MATCH_ONLY",
+     "ScheduleExpression": "rate(7 days)"
+    }
+   },
+   "DependsOn": [
+    "WindowsImageBuilderDockerLogE660E23E",
+    "WindowsImageBuilderInfrastructureFF99A30B"
+   ]
   },
   "AMILinuxBuilderSGEDC86329": {
    "Type": "AWS::EC2::SecurityGroup",


### PR DESCRIPTION
If you add a lot of components to your runner image that can take a long time to build, you may want your CDK deployment to not wait for the image to finish. This can speed up the trial-and-error cycle of updating your image. It can make sure a random timeout in the image build process won't roll everything back.

Note that this does have some downsides.

1. Updating components doesn't trigger a new build. You may have to wait up to a week (rebuild interval) for a new image, unless you manually trigger it.
2. Fresh deployments will not be ready to use until the image is done. CDK deployment being done won't mean your setup is ready as the runner image may not be built yet.
3. With the right build timing, some resources may be left behind on stack destruction. This includes log groups and AWS Image Builder resources.

```
const builder = FargateRunnerProvider.imageBuilder(stack, 'Fargate builder no wait 4', {
  waitOnDeploy: false,
  codeBuildOptions: {
    timeout: cdk.Duration.hours(6),
  },
});
builder.addComponent(RunnerImageComponent.custom({
  commands: [
    // some commands that can take a long time to complete...
    'sleep 5h', // toy example
  ],
}));
```

See #540