### PR TITLE
fix: Unable to build Linux Docker runner images with AWS Image Builder

### DIFF
--- a/src/image-builders/aws-image-builder/container.ts
+++ b/src/image-builders/aws-image-builder/container.ts
@@ -41,10 +41,8 @@ export interface ContainerRecipeProperties {
 
   /**
    * Parent image for the new Docker Image.
-   *
-   * @default 'mcr.microsoft.com/windows/servercore:ltsc2019-amd64'
    */
-  readonly parentImage?: string;
+  readonly parentImage: string;
 }
 
 /**
@@ -76,7 +74,8 @@ export class ContainerRecipe extends ImageBuilderObjectBase {
     const recipe = new imagebuilder.CfnContainerRecipe(this, 'Recipe', {
       name: this.name,
       version: this.version,
-      parentImage: props.parentImage ?? 'mcr.microsoft.com/windows/servercore:ltsc2019-amd64',
+      parentImage: props.parentImage,
+      platformOverride: props.platform == 'Linux' ? 'Linux' : undefined,
       components,
       containerType: 'DOCKER',
       targetRepository: {

--- a/src/image-builders/aws-image-builder/deprecated/container.ts
+++ b/src/image-builders/aws-image-builder/deprecated/container.ts
@@ -151,7 +151,7 @@ export interface ContainerImageBuilderProps {
  */
 export class ContainerImageBuilder extends ImageBuilderBase {
   readonly repository: ecr.IRepository;
-  private readonly parentImage: string | undefined;
+  private readonly parentImage: string;
   private boundImage?: RunnerImage;
 
   constructor(scope: Construct, id: string, props?: ContainerImageBuilderProps) {
@@ -171,7 +171,7 @@ export class ContainerImageBuilder extends ImageBuilderBase {
       imageTypeName: 'image',
     });
 
-    this.parentImage = props?.parentImage;
+    this.parentImage = props?.parentImage ?? 'mcr.microsoft.com/windows/servercore:ltsc2019-amd64';
 
     // create repository that only keeps one tag
     this.repository = new ecr.Repository(this, 'Repository', {


### PR DESCRIPTION
When trying to build a Docker runner image using AWS Image Builder, an error like this pops up:

```
github-runners-test |  21 | 10:30:50 PM | CREATE_FAILED        | AWS::ImageBuilder::ContainerRecipe             | Fargate builder no wait 5/Container Recipe/Recipe (Fargatebuildernowait5ContainerRecipeE02237FD) Resource handler returned message: "The value supplied for parameter 'parentImage' is not valid. You must specify a platform override when using ECR Public Repositories as your parent image. (Service: Imagebuilder, Status Code: 400, Request ID: 23846b6b-dfc4-4f05-8444-998238125330)" (RequestToken: 43be45ef-513a-4616-330e-c27d0d39fada, HandlerErrorCode: InvalidRequest)
```

Sample code:

```
FargateRunnerProvider.imageBuilder(stack, 'Fargate builder no wait 5', {
  builderType: RunnerImageBuilderType.AWS_IMAGE_BUILDER,
  architecture: Architecture.X86_64,
  vpc,
})
```