### PR TITLE
feat: Logging improvements for internal Lambda functions

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -214,7 +214,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.110.0",
+      "version": "^2.123.0",
       "type": "peer"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -7,7 +7,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   author: 'Amir Szekely',
   authorAddress: 'amir@cloudsnorkel.com',
   stability: Stability.EXPERIMENTAL,
-  cdkVersion: '2.110.0', // 2.21.1 for lambda url, 2.29.0 for Names.uniqueResourceName(), 2.50.0 for JsonPath.base64Encode, 2.77.0 for node 16, 2.110.0 for ib lifecycle
+  cdkVersion: '2.123.0', // 2.21.1 for lambda url, 2.29.0 for Names.uniqueResourceName(), 2.50.0 for JsonPath.base64Encode, 2.77.0 for node 16, 2.110.0 for ib lifecycle, 2.123.0 for lambda logs
   defaultReleaseBranch: 'main',
   name: '@cloudsnorkel/cdk-github-runners',
   repositoryUrl: 'https://github.com/CloudSnorkel/cdk-github-runners.git',

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@typescript-eslint/eslint-plugin": "^6",
     "@typescript-eslint/parser": "^6",
     "aws-cdk": "^2",
-    "aws-cdk-lib": "2.110.0",
+    "aws-cdk-lib": "2.123.0",
     "bootstrap": "^5.2.0",
     "constructs": "10.0.5",
     "esbuild": "^0.20.2",
@@ -122,7 +122,7 @@
     "vite-plugin-singlefile": "^0.13.5"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.110.0",
+    "aws-cdk-lib": "^2.123.0",
     "constructs": "^10.0.5"
   },
   "keywords": [

--- a/src/idle-runner-repear.lambda.ts
+++ b/src/idle-runner-repear.lambda.ts
@@ -21,7 +21,10 @@ export async function handler(event: AWSLambda.SQSEvent): Promise<AWSLambda.SQSB
 
   for (const record of event.Records) {
     const input = JSON.parse(record.body) as IdleReaperLambdaInput;
-    console.log(`Checking runner for ${input.owner}/${input.repo} [execution-id=${input.runnerName}]`);
+    console.log({
+      notice: 'Checking runner',
+      input,
+    });
 
     const retryLater = () => result.batchItemFailures.push({ itemIdentifier: record.messageId });
 
@@ -29,7 +32,10 @@ export async function handler(event: AWSLambda.SQSEvent): Promise<AWSLambda.SQSB
     const execution = await sfn.send(new DescribeExecutionCommand({ executionArn: input.executionArn }));
     if (execution.status != 'RUNNING') {
       // no need to test again as runner already finished
-      console.log('Runner already finished');
+      console.log({
+        notice: 'Runner already finished',
+        input,
+      });
       continue;
     }
 
@@ -45,7 +51,10 @@ export async function handler(event: AWSLambda.SQSEvent): Promise<AWSLambda.SQSB
     // find runner
     const runner = await getRunner(octokitCache, runnerLevel, input.owner, input.repo, input.runnerName);
     if (!runner) {
-      console.error(`Runner not running yet for ${input.owner}/${input.repo}:${input.runnerName}`);
+      console.log({
+        notice: 'Runner not running yet',
+        input,
+      });
       retryLater();
       continue;
     }
@@ -54,7 +63,10 @@ export async function handler(event: AWSLambda.SQSEvent): Promise<AWSLambda.SQSB
     // we want to try again because the runner might be retried due to e.g. lambda timeout
     // we need to keep following the retry too and make sure it doesn't go idle
     if (runner.busy) {
-      console.log('Runner is not idle');
+      console.log({
+        notice: 'Runner is not idle',
+        input,
+      });
       retryLater();
       continue;
     }
@@ -68,32 +80,50 @@ export async function handler(event: AWSLambda.SQSEvent): Promise<AWSLambda.SQSB
         const now = new Date();
         const diffMs = now.getTime() - startedDate.getTime();
 
-        console.log(`Runner ${input.runnerName} started ${diffMs/1000} seconds ago`);
+        console.log({
+          notice: `Runner ${input.runnerName} started ${diffMs / 1000} seconds ago`,
+          input,
+        });
 
         if (diffMs > 1000 * input.maxIdleSeconds) {
           // max idle time reached, delete runner
-          console.log(`Runner ${input.runnerName} is idle for too long`);
+          console.log({
+            notice: `Runner ${input.runnerName} is idle for too long`,
+            input,
+          });
 
           try {
             // stop step function first, so it's marked as aborted with the proper error
             // if we delete the runner first, the step function will be marked as failed with a generic error
-            console.log(`Stopping step function ${input.executionArn}...`);
+            console.log({
+              notice: `Stopping step function ${input.executionArn}...`,
+              input,
+            });
             await sfn.send(new StopExecutionCommand({
               executionArn: input.executionArn,
               error: 'IdleRunner',
               cause: `Runner ${input.runnerName} on ${input.owner}/${input.repo} is idle for too long (${diffMs / 1000} seconds and limit is ${input.maxIdleSeconds} seconds)`,
             }));
           } catch (e) {
-            console.error(`Failed to stop step function ${input.executionArn}: ${e}`);
+            console.error({
+              notice: `Failed to stop step function ${input.executionArn}: ${e}`,
+              input,
+            });
             retryLater();
             continue;
           }
 
           try {
-            console.log(`Deleting runner ${runner.id}...`);
+            console.log({
+              notice: `Deleting runner ${runner.id}...`,
+              input,
+            });
             await deleteRunner(octokitCache, runnerLevel, input.owner, input.repo, runner.id);
           } catch (e) {
-            console.error(`Failed to delete runner ${runner.id}: ${e}`);
+            console.error({
+              notice: `Failed to delete runner ${runner.id}: ${e}`,
+              input,
+            });
             retryLater();
             continue;
           }
@@ -109,7 +139,10 @@ export async function handler(event: AWSLambda.SQSEvent): Promise<AWSLambda.SQSB
 
     if (!found) {
       // no started label? retry later (it won't retry forever as eventually the runner will stop and the step function will finish)
-      console.error('No `cdkghr:started:xxx` label found???');
+      console.error({
+        notice: 'No `cdkghr:started:xxx` label found???',
+        input,
+      });
       retryLater();
     }
   }

--- a/src/image-builders/aws-image-builder/builder.ts
+++ b/src/image-builders/aws-image-builder/builder.ts
@@ -6,6 +6,7 @@ import {
   aws_events as events,
   aws_iam as iam,
   aws_imagebuilder as imagebuilder,
+  aws_lambda as lambda,
   aws_logs as logs,
   aws_s3_assets as s3_assets,
   aws_sns as sns,
@@ -24,7 +25,7 @@ import { ContainerRecipe, defaultBaseDockerImage } from './container';
 import { DeleteAmiFunction } from './delete-ami-function';
 import { FilterFailedBuildsFunction } from './filter-failed-builds-function';
 import { Architecture, Os, RunnerAmi, RunnerImage, RunnerVersion } from '../../providers';
-import { singletonLambda } from '../../utils';
+import { singletonLogGroup, singletonLambda, SingletonLogType } from '../../utils';
 import { BuildImageFunction } from '../build-image-function';
 import { RunnerImageBuilderBase, RunnerImageBuilderProps, uniqueImageBuilderName } from '../common';
 
@@ -444,7 +445,8 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
     const crHandler = singletonLambda(BuildImageFunction, this, 'build-image', {
       description: 'Custom resource handler that triggers CodeBuild to build runner images, and cleans-up images on deletion',
       timeout: cdk.Duration.minutes(3),
-      logRetention: logs.RetentionDays.ONE_MONTH,
+      logGroup: singletonLogGroup(this, SingletonLogType.RUNNER_IMAGE_BUILD),
+      logFormat: lambda.LogFormat.JSON,
     });
 
     const policy = new iam.Policy(this, 'CR Policy', {
@@ -785,7 +787,8 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
         }),
       ],
       timeout: cdk.Duration.minutes(5),
-      logRetention: logs.RetentionDays.ONE_MONTH,
+      logGroup: singletonLogGroup(this, SingletonLogType.RUNNER_IMAGE_BUILD),
+      logFormat: lambda.LogFormat.JSON,
     });
 
     // delete all AMIs when this construct is removed
@@ -871,10 +874,11 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
  * @internal
  */
 export class AwsImageBuilderFailedBuildNotifier implements cdk.IAspect {
-  public static createFilteringTopic(scope: Construct, targetTopic: sns.Topic) {
+  public static createFilteringTopic(scope: Construct, targetTopic: sns.Topic): sns.ITopic {
     const topic = new sns.Topic(scope, 'Image Builder Builds');
     const filter = new FilterFailedBuildsFunction(scope, 'Image Builder Builds Filter', {
-      logRetention: logs.RetentionDays.ONE_MONTH,
+      logGroup: singletonLogGroup(scope, SingletonLogType.RUNNER_IMAGE_BUILD),
+      logFormat: lambda.LogFormat.JSON,
       environment: {
         TARGET_TOPIC_ARN: targetTopic.topicArn,
       },

--- a/src/image-builders/aws-image-builder/common.ts
+++ b/src/image-builders/aws-image-builder/common.ts
@@ -1,8 +1,8 @@
 import * as cdk from 'aws-cdk-lib';
-import { aws_iam as iam, aws_logs as logs, CustomResource } from 'aws-cdk-lib';
+import { aws_iam as iam, aws_lambda as lambda, CustomResource } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { VersionerFunction } from './versioner-function';
-import { singletonLambda } from '../../utils';
+import { singletonLogGroup, singletonLambda, SingletonLogType } from '../../utils';
 
 /**
  * @internal
@@ -38,7 +38,8 @@ export abstract class ImageBuilderObjectBase extends cdk.Resource {
           resources: ['*'],
         }),
       ],
-      logRetention: logs.RetentionDays.ONE_MONTH,
+      logGroup: singletonLogGroup(this, SingletonLogType.RUNNER_IMAGE_BUILD),
+      logFormat: lambda.LogFormat.JSON,
       timeout: cdk.Duration.minutes(5),
     });
   }

--- a/src/image-builders/aws-image-builder/delete-ami.lambda.ts
+++ b/src/image-builders/aws-image-builder/delete-ami.lambda.ts
@@ -27,13 +27,18 @@ async function deleteAmis(stackName: string, builderName: string) {
 
   let imagesToDelete = images.Images ?? [];
 
-  console.log(`Found ${imagesToDelete.length} AMIs`);
-  console.log(JSON.stringify(imagesToDelete.map(i => i.ImageId)));
+  console.log({
+    notice: `Found ${imagesToDelete.length} AMIs`,
+    images: imagesToDelete.map(i => i.ImageId),
+  });
 
   // delete all that we found
   for (const image of imagesToDelete) {
     if (!image.ImageId) {
-      console.warn(`No image id? ${JSON.stringify(image)}`);
+      console.warn({
+        notice: 'No image id?',
+        image,
+      });
       continue;
     }
 
@@ -57,7 +62,7 @@ async function deleteAmis(stackName: string, builderName: string) {
 
 export async function handler(event: AWSLambda.CloudFormationCustomResourceEvent, context: AWSLambda.Context) {
   try {
-    console.log(JSON.stringify({ ...event, ResponseURL: '...' }));
+    console.log({ ...event, ResponseURL: '...' });
 
     switch (event.RequestType) {
       case 'Create':

--- a/src/image-builders/aws-image-builder/filter-failed-builds.lambda.ts
+++ b/src/image-builders/aws-image-builder/filter-failed-builds.lambda.ts
@@ -4,7 +4,7 @@ import * as AWSLambda from 'aws-lambda';
 const sns = new SNSClient();
 
 export async function handler(event: AWSLambda.SNSEvent) {
-  console.log(JSON.stringify(event));
+  console.log(event);
   for (const record of event.Records) {
     let message = JSON.parse(record.Sns.Message);
     if (message.state.status === 'FAILED') {

--- a/src/image-builders/aws-image-builder/versioner.lambda.ts
+++ b/src/image-builders/aws-image-builder/versioner.lambda.ts
@@ -31,7 +31,7 @@ export function increaseVersion(allVersions: string[]) {
 }
 
 export async function handler(event: AWSLambda.CloudFormationCustomResourceEvent, context: AWSLambda.Context) {
-  console.log(JSON.stringify({ ...event, ResponseURL: '...' }));
+  console.log({ ...event, ResponseURL: '...' });
 
   try {
     const objectType = event.ResourceProperties.ObjectType;

--- a/src/image-builders/build-image.lambda.ts
+++ b/src/image-builders/build-image.lambda.ts
@@ -25,7 +25,7 @@ export interface BuildImageFunctionProperties {
 
 export async function handler(event: AWSLambda.CloudFormationCustomResourceEvent, context: AWSLambda.Context) {
   try {
-    console.log(JSON.stringify({ ...event, ResponseURL: '...' }));
+    console.log({ ...event, ResponseURL: '...' });
 
     const props = event.ResourceProperties as BuildImageFunctionProperties;
 

--- a/src/image-builders/codebuild.ts
+++ b/src/image-builders/codebuild.ts
@@ -9,6 +9,7 @@ import {
   aws_events as events,
   aws_events_targets as events_targets,
   aws_iam as iam,
+  aws_lambda as lambda,
   aws_logs as logs,
   aws_s3_assets as s3_assets,
   aws_sns as sns,
@@ -25,7 +26,7 @@ import { BuildImageFunction } from './build-image-function';
 import { BuildImageFunctionProperties } from './build-image.lambda';
 import { RunnerImageBuilderBase, RunnerImageBuilderProps } from './common';
 import { Architecture, Os, RunnerAmi, RunnerImage, RunnerVersion } from '../providers';
-import { singletonLambda } from '../utils';
+import { singletonLambda, singletonLogGroup, SingletonLogType } from '../utils';
 
 
 export interface CodeBuildRunnerImageBuilderProps {
@@ -344,7 +345,8 @@ export class CodeBuildRunnerImageBuilder extends RunnerImageBuilderBase {
     const crHandler = singletonLambda(BuildImageFunction, this, 'build-image', {
       description: 'Custom resource handler that triggers CodeBuild to build runner images, and cleans-up images on deletion',
       timeout: cdk.Duration.minutes(3),
-      logRetention: logs.RetentionDays.ONE_MONTH,
+      logGroup: singletonLogGroup(this, SingletonLogType.RUNNER_IMAGE_BUILD),
+      logFormat: lambda.LogFormat.JSON,
     });
 
     const policy = new iam.Policy(this, 'CR Policy', {

--- a/src/providers/ami-root-device.lambda.ts
+++ b/src/providers/ami-root-device.lambda.ts
@@ -29,7 +29,7 @@ async function handleAmi(event: AWSLambda.CloudFormationCustomResourceEvent, ami
 
 export async function handler(event: AWSLambda.CloudFormationCustomResourceEvent, context: AWSLambda.Context) {
   try {
-    console.log(JSON.stringify({ ...event, ResponseURL: '...' }));
+    console.log({ ...event, ResponseURL: '...' });
 
     const ami = event.ResourceProperties.Ami as string;
 

--- a/src/providers/common.ts
+++ b/src/providers/common.ts
@@ -3,6 +3,7 @@ import {
   aws_ec2 as ec2,
   aws_ecr as ecr,
   aws_iam as iam,
+  aws_lambda as lambda,
   aws_logs as logs,
   aws_stepfunctions as stepfunctions,
   CustomResource,
@@ -10,7 +11,7 @@ import {
 } from 'aws-cdk-lib';
 import { Construct, IConstruct } from 'constructs';
 import { AmiRootDeviceFunction } from './ami-root-device-function';
-import { singletonLambda } from '../utils';
+import { singletonLambda, singletonLogGroup, SingletonLogType } from '../utils';
 
 /**
  * Defines desired GitHub Actions runner version.
@@ -510,7 +511,8 @@ export function amiRootDevice(scope: Construct, ami?: string) {
   const crHandler = singletonLambda(AmiRootDeviceFunction, scope, 'AMI Root Device Reader', {
     description: 'Custom resource handler that discovers the boot drive device name for a given AMI',
     timeout: cdk.Duration.minutes(1),
-    logRetention: logs.RetentionDays.ONE_MONTH,
+    logGroup: singletonLogGroup(scope, SingletonLogType.RUNNER_IMAGE_BUILD),
+    logFormat: lambda.LogFormat.JSON,
     initialPolicy: [
       new iam.PolicyStatement({
         actions: [

--- a/src/providers/lambda.ts
+++ b/src/providers/lambda.ts
@@ -26,7 +26,7 @@ import {
 } from './common';
 import { UpdateLambdaFunction } from './update-lambda-function';
 import { IRunnerImageBuilder, RunnerImageBuilder, RunnerImageBuilderProps, RunnerImageComponent } from '../image-builders';
-import { singletonLambda } from '../utils';
+import { singletonLambda, singletonLogGroup, SingletonLogType } from '../utils';
 
 export interface LambdaRunnerProviderProps extends RunnerProviderProps {
   /**
@@ -282,6 +282,11 @@ export class LambdaRunnerProvider extends BaseProvider implements IRunnerProvide
       dependable: image._dependable,
     });
 
+    this.logGroup = new logs.LogGroup(this, 'Log', {
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      retention: props?.logRetention ?? RetentionDays.ONE_MONTH,
+    });
+
     this.function = new lambda.DockerImageFunction(
       this,
       'Function',
@@ -296,12 +301,11 @@ export class LambdaRunnerProvider extends BaseProvider implements IRunnerProvide
         timeout: props?.timeout || cdk.Duration.minutes(15),
         memorySize: props?.memorySize || 2048,
         ephemeralStorageSize: props?.ephemeralStorageSize || cdk.Size.gibibytes(10),
-        logRetention: props?.logRetention || RetentionDays.ONE_MONTH,
+        logGroup: this.logGroup,
       },
     );
 
     this.grantPrincipal = this.function.grantPrincipal;
-    this.logGroup = this.function.logGroup;
 
     this.addImageUpdater(image);
   }
@@ -321,7 +325,7 @@ export class LambdaRunnerProvider extends BaseProvider implements IRunnerProvide
    * @param parameters workflow job details
    */
   getStepFunctionTask(parameters: RunnerRuntimeParameters): stepfunctions.IChainable {
-    const invoke = new stepfunctions_tasks.LambdaInvoke(
+    return new stepfunctions_tasks.LambdaInvoke(
       this,
       this.labels.join(', '),
       {
@@ -337,8 +341,6 @@ export class LambdaRunnerProvider extends BaseProvider implements IRunnerProvide
         }),
       },
     );
-
-    return invoke;
   }
 
   private addImageUpdater(image: RunnerImage) {
@@ -348,7 +350,8 @@ export class LambdaRunnerProvider extends BaseProvider implements IRunnerProvide
     const updater = singletonLambda(UpdateLambdaFunction, this, 'update-lambda', {
       description: 'Function that updates a GitHub Actions runner function with the latest image digest after the image has been rebuilt',
       timeout: cdk.Duration.minutes(15),
-      logRetention: logs.RetentionDays.ONE_MONTH,
+      logGroup: singletonLogGroup(this, SingletonLogType.RUNNER_IMAGE_BUILD),
+      logFormat: lambda.LogFormat.JSON,
     });
 
     updater.addToRolePolicy(new iam.PolicyStatement({
@@ -445,7 +448,7 @@ export class LambdaRunnerProvider extends BaseProvider implements IRunnerProvide
       }),
       resourceType: 'Custom::EcrImageDigest',
       installLatestAwsSdk: false, // no need and it takes 60 seconds
-      logRetention: RetentionDays.ONE_MONTH,
+      logGroup: singletonLogGroup(this, SingletonLogType.RUNNER_IMAGE_BUILD),
     });
 
     // mark this resource as retainable, as there is nothing to do on delete

--- a/src/providers/update-lambda.lambda.ts
+++ b/src/providers/update-lambda.lambda.ts
@@ -13,7 +13,7 @@ function sleep(ms: number) {
 }
 
 export async function handler(event: Input) {
-  console.log(JSON.stringify(event));
+  console.log(event);
 
   while (true) {
     try {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,10 @@
-import { aws_iam as iam, aws_lambda as lambda } from 'aws-cdk-lib';
+import { aws_iam as iam, aws_lambda as lambda, aws_logs as logs } from 'aws-cdk-lib';
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
 /**
+ * Initialize or return a singleton Lambda function instance.
+ *
  * @internal
  */
 export function singletonLambda<FunctionType extends lambda.Function>(
@@ -17,6 +19,35 @@ export function singletonLambda<FunctionType extends lambda.Function>(
   }
 
   return new functionType(cdk.Stack.of(scope), constructName, props);
+}
+
+/**
+ * Central log group type.
+ *
+ * @internal
+ */
+export enum SingletonLogType {
+  RUNNER_IMAGE_BUILD = 'Runner Image Build Helpers Log',
+  ORCHESTRATOR = 'Orchestrator Log',
+  SETUP = 'Setup Log',
+}
+
+/**
+ * Initialize or return central log group instance.
+ *
+ * @internal
+ */
+export function singletonLogGroup(scope: Construct, type: SingletonLogType): logs.ILogGroup {
+  const existing = cdk.Stack.of(scope).node.tryFindChild(type);
+  if (existing) {
+    // Just assume this is true
+    return existing as logs.ILogGroup;
+  }
+
+  return new logs.LogGroup(cdk.Stack.of(scope), type, {
+    retention: logs.RetentionDays.ONE_MONTH,
+    removalPolicy: cdk.RemovalPolicy.DESTROY,
+  });
 }
 
 /**

--- a/src/webhook-handler.lambda.ts
+++ b/src/webhook-handler.lambda.ts
@@ -129,7 +129,10 @@ export async function handler(event: AWSLambda.APIGatewayProxyEventV2): Promise<
   const payload = JSON.parse(body);
 
   if (payload.action !== 'queued') {
-    console.log(`Ignoring action "${payload.action}", expecting "queued"`);
+    console.log({
+      notice: `Ignoring action "${payload.action}", expecting "queued"`,
+      job: payload.workflow_job,
+    });
     return {
       statusCode: 200,
       body: 'OK. No runner started (action is not "queued").',
@@ -137,7 +140,10 @@ export async function handler(event: AWSLambda.APIGatewayProxyEventV2): Promise<
   }
 
   if (process.env.REQUIRE_SELF_HOSTED_LABEL === '1' && !payload.workflow_job.labels.includes('self-hosted')) {
-    console.log(`Ignoring labels "${payload.workflow_job.labels}", expecting "self-hosted"`);
+    console.log({
+      notice: `Ignoring labels "${payload.workflow_job.labels}", expecting "self-hosted"`,
+      job: payload.workflow_job,
+    });
     return {
       statusCode: 200,
       body: 'OK. No runner started (no "self-hosted" label).',
@@ -147,7 +153,10 @@ export async function handler(event: AWSLambda.APIGatewayProxyEventV2): Promise<
   // don't start step function unless labels match a runner provider
   const provider = matchLabelsToProvider(payload.workflow_job.labels);
   if (!provider) {
-    console.log(`Ignoring labels "${payload.workflow_job.labels}", as they don't match a supported runner provider`);
+    console.log({
+      notice: `Ignoring labels "${payload.workflow_job.labels}", as they don't match a supported runner provider`,
+      job: payload.workflow_job,
+    });
     return {
       statusCode: 200,
       body: 'OK. No runner started (no provider with matching labels).',
@@ -156,7 +165,10 @@ export async function handler(event: AWSLambda.APIGatewayProxyEventV2): Promise<
 
   // don't start runners for a deployment that's still pending as GitHub will send another event when it's ready
   if (await isDeploymentPending(payload)) {
-    console.log('Ignoring job as its deployment is still pending');
+    console.log({
+      notice: 'Ignoring job as its deployment is still pending',
+      job: payload.workflow_job,
+    });
     return {
       statusCode: 200,
       body: 'OK. No runner started (deployment pending).',
@@ -166,24 +178,28 @@ export async function handler(event: AWSLambda.APIGatewayProxyEventV2): Promise<
   // set execution name which is also used as runner name which are limited to 64 characters
   let executionName = `${payload.repository.full_name.replace('/', '-')}-${getHeader(event, 'x-github-delivery')}`.slice(0, 64);
   // start execution
-  const input = JSON.stringify({
+  const input = {
     owner: payload.repository.owner.login,
     repo: payload.repository.name,
     jobId: payload.workflow_job.id,
     jobUrl: payload.workflow_job.html_url,
     installationId: payload.installation?.id ?? -1, // always pass value because step function can't handle missing input
-    labels: payload.workflow_job.labels,
+    labels: payload.workflow_job.labels.join(','),
     provider: provider,
-  });
+  };
   const execution = await sf.send(new StartExecutionCommand({
     stateMachineArn: process.env.STEP_FUNCTION_ARN,
-    input: input,
+    input: JSON.stringify(input),
     // name is not random so multiple execution of this webhook won't cause multiple builders to start
     name: executionName,
   }));
 
-  console.log(`Started ${execution.executionArn}`);
-  console.log(input);
+  console.log({
+    notice: 'Started orchestrator',
+    execution: execution.executionArn,
+    sfnInput: input,
+    job: payload.workflow_job,
+  });
 
   return {
     statusCode: 202,

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -1,8 +1,9 @@
 import * as cdk from 'aws-cdk-lib';
-import { aws_logs as logs, aws_stepfunctions as stepfunctions } from 'aws-cdk-lib';
+import { aws_lambda as lambda, aws_stepfunctions as stepfunctions } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { LambdaAccess } from './access';
 import { Secrets } from './secrets';
+import { singletonLogGroup, SingletonLogType } from './utils';
 import { WebhookHandlerFunction } from './webhook-handler-function';
 
 /**
@@ -78,8 +79,9 @@ export class GithubWebhookHandler extends Construct {
           SUPPORTED_LABELS: JSON.stringify(props.supportedLabels),
           REQUIRE_SELF_HOSTED_LABEL: props.requireSelfHostedLabel ? '1' : '0',
         },
-        timeout: cdk.Duration.seconds(30),
-        logRetention: logs.RetentionDays.ONE_MONTH,
+        timeout: cdk.Duration.seconds(31),
+        logGroup: singletonLogGroup(this, SingletonLogType.ORCHESTRATOR),
+        logFormat: lambda.LogFormat.JSON,
       },
     );
 

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -1,5 +1,5 @@
 {
-  "version": "35.0.0",
+  "version": "36.0.0",
   "files": {
     "e024e432dbd64a0923f6308842181e502c39dd8287ee2dbae98472ec78a5097f": {
       "source": {
@@ -27,41 +27,28 @@
         }
       }
     },
-    "5d536d3909907c631aa15996d7eee0e12247f88312d888640b63f34a352c5fa4": {
+    "49da49fecc381582a88d129f442ac0d6a461bbfd60d0eb1eb772c61d22e78e60": {
       "source": {
-        "path": "asset.5d536d3909907c631aa15996d7eee0e12247f88312d888640b63f34a352c5fa4.lambda",
+        "path": "asset.49da49fecc381582a88d129f442ac0d6a461bbfd60d0eb1eb772c61d22e78e60.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "5d536d3909907c631aa15996d7eee0e12247f88312d888640b63f34a352c5fa4.zip",
+          "objectKey": "49da49fecc381582a88d129f442ac0d6a461bbfd60d0eb1eb772c61d22e78e60.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555": {
+    "deaec75154c038cd6fec17fd19b905a08bb9a78b97bc2e0fd132505eda22c650": {
       "source": {
-        "path": "asset.5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555",
+        "path": "asset.deaec75154c038cd6fec17fd19b905a08bb9a78b97bc2e0fd132505eda22c650.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555.zip",
-          "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
-        }
-      }
-    },
-    "a080dc61c6f346aa8d265f2519e7e93f1be13ae0c0671e5b1dfa03130ae72795": {
-      "source": {
-        "path": "asset.a080dc61c6f346aa8d265f2519e7e93f1be13ae0c0671e5b1dfa03130ae72795.lambda",
-        "packaging": "zip"
-      },
-      "destinations": {
-        "current_account-current_region": {
-          "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "a080dc61c6f346aa8d265f2519e7e93f1be13ae0c0671e5b1dfa03130ae72795.zip",
+          "objectKey": "deaec75154c038cd6fec17fd19b905a08bb9a78b97bc2e0fd132505eda22c650.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -92,41 +79,41 @@
         }
       }
     },
-    "17c16a3854838fd3ff4bda08146122a6701f33b9c86ae17f415ad0dc47a97544": {
+    "ed6cd104ff5f101d06dae8cb2b87cc6e6d69b9a22055b467ea6cae10ff023023": {
       "source": {
-        "path": "asset.17c16a3854838fd3ff4bda08146122a6701f33b9c86ae17f415ad0dc47a97544",
+        "path": "asset.ed6cd104ff5f101d06dae8cb2b87cc6e6d69b9a22055b467ea6cae10ff023023",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "17c16a3854838fd3ff4bda08146122a6701f33b9c86ae17f415ad0dc47a97544.zip",
+          "objectKey": "ed6cd104ff5f101d06dae8cb2b87cc6e6d69b9a22055b467ea6cae10ff023023.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "1d96057090c75f1428c11ddf65870ca9f79152d00b3ae875b2d8cb2114c365ab": {
+    "aa9b0a3f0625b484074bb9cb369382960e95d5721493cc6f1c6dc46797cd3aea": {
       "source": {
-        "path": "asset.1d96057090c75f1428c11ddf65870ca9f79152d00b3ae875b2d8cb2114c365ab.lambda",
+        "path": "asset.aa9b0a3f0625b484074bb9cb369382960e95d5721493cc6f1c6dc46797cd3aea.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "1d96057090c75f1428c11ddf65870ca9f79152d00b3ae875b2d8cb2114c365ab.zip",
+          "objectKey": "aa9b0a3f0625b484074bb9cb369382960e95d5721493cc6f1c6dc46797cd3aea.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "b1862470ac31c934803dff83368cf5cdec42c544fd77a6e8fc25d6d7e55befa4": {
+    "4a06647157afdd5917965dc4eb5ed09260934ebf02f976202d551d4a9a5cf2e7": {
       "source": {
-        "path": "asset.b1862470ac31c934803dff83368cf5cdec42c544fd77a6e8fc25d6d7e55befa4.lambda",
+        "path": "asset.4a06647157afdd5917965dc4eb5ed09260934ebf02f976202d551d4a9a5cf2e7.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "b1862470ac31c934803dff83368cf5cdec42c544fd77a6e8fc25d6d7e55befa4.zip",
+          "objectKey": "4a06647157afdd5917965dc4eb5ed09260934ebf02f976202d551d4a9a5cf2e7.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -157,41 +144,41 @@
         }
       }
     },
-    "dfe33c6b4de9a62d153ad3025abe39cb85d5fef9d1a6e4b54e79b96cdbfc64ea": {
+    "d90f56ab5772627b156240c90daa136819b2540625a789b227351862f504f8ce": {
       "source": {
-        "path": "asset.dfe33c6b4de9a62d153ad3025abe39cb85d5fef9d1a6e4b54e79b96cdbfc64ea.lambda",
+        "path": "asset.d90f56ab5772627b156240c90daa136819b2540625a789b227351862f504f8ce.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "dfe33c6b4de9a62d153ad3025abe39cb85d5fef9d1a6e4b54e79b96cdbfc64ea.zip",
+          "objectKey": "d90f56ab5772627b156240c90daa136819b2540625a789b227351862f504f8ce.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "97a52dd61d3f204877c7a944f14423bdbdec7587794ab63213506581ffb19976": {
+    "2b3e3110ffb96a7df77acaa663361ec1c03e985af62941397f4806ba6fbde75f": {
       "source": {
-        "path": "asset.97a52dd61d3f204877c7a944f14423bdbdec7587794ab63213506581ffb19976.lambda",
+        "path": "asset.2b3e3110ffb96a7df77acaa663361ec1c03e985af62941397f4806ba6fbde75f.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "97a52dd61d3f204877c7a944f14423bdbdec7587794ab63213506581ffb19976.zip",
+          "objectKey": "2b3e3110ffb96a7df77acaa663361ec1c03e985af62941397f4806ba6fbde75f.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "c4cf998f4a4344b3a5725ca42aeb71e5a87a4d26f4478bf4ac84666d7b306a69": {
+    "e7954c04f03129866fa75a1501b4d61587a381c13cc9b973c0a45c2f208b44d3": {
       "source": {
-        "path": "asset.c4cf998f4a4344b3a5725ca42aeb71e5a87a4d26f4478bf4ac84666d7b306a69.lambda",
+        "path": "asset.e7954c04f03129866fa75a1501b4d61587a381c13cc9b973c0a45c2f208b44d3.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "c4cf998f4a4344b3a5725ca42aeb71e5a87a4d26f4478bf4ac84666d7b306a69.zip",
+          "objectKey": "e7954c04f03129866fa75a1501b4d61587a381c13cc9b973c0a45c2f208b44d3.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -222,20 +209,20 @@
         }
       }
     },
-    "70d775c42043d1c5e737e2362a0d99627e98bd651ac5fd45d7275105bee1b54b": {
+    "f07c60cc451d4f0c652f687a1c8cd6cf21a2a8f6cd7ab6807e6ee06606ea4122": {
       "source": {
-        "path": "asset.70d775c42043d1c5e737e2362a0d99627e98bd651ac5fd45d7275105bee1b54b.lambda",
+        "path": "asset.f07c60cc451d4f0c652f687a1c8cd6cf21a2a8f6cd7ab6807e6ee06606ea4122.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "70d775c42043d1c5e737e2362a0d99627e98bd651ac5fd45d7275105bee1b54b.zip",
+          "objectKey": "f07c60cc451d4f0c652f687a1c8cd6cf21a2a8f6cd7ab6807e6ee06606ea4122.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "420c5007c0ded3fcd493c11ed9455eca37eb3164609edf8e9f05c4b216d3cade": {
+    "017d1177f9ed423de4a06aac51dc14b1646ff59bfe216d9640b41da57ed6466f": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -243,7 +230,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "420c5007c0ded3fcd493c11ed9455eca37eb3164609edf8e9f05c4b216d3cade.json",
+          "objectKey": "017d1177f9ed423de4a06aac51dc14b1646ff59bfe216d9640b41da57ed6466f.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -678,7 +678,6 @@
     }
    },
    "DependsOn": [
-    "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
     "buildimagedcc036c8876b451ea2c1552f9e06e9e173B4162A",
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1ServiceRoleC3DE4837",
     "FargatebuilderCodeBuildBuildFailed1D2D3785",
@@ -1312,7 +1311,6 @@
     }
    },
    "DependsOn": [
-    "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
     "buildimagedcc036c8876b451ea2c1552f9e06e9e173B4162A",
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1ServiceRoleC3DE4837",
     "FargatebuilderarmCodeBuildBuildFailed264992E6",
@@ -1983,7 +1981,6 @@
     }
    },
    "DependsOn": [
-    "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
     "buildimagedcc036c8876b451ea2c1552f9e06e9e173B4162A",
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1ServiceRoleC3DE4837",
     "LambdaImageBuilderx64CodeBuildBuildFailed7E839416",
@@ -2926,7 +2923,6 @@
     "DeleteOnly": true
    },
    "DependsOn": [
-    "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
     "buildimagedcc036c8876b451ea2c1552f9e06e9e173B4162A",
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1ServiceRoleC3DE4837",
     "WindowsImageBuilderCRPolicy81A41F62",
@@ -4659,7 +4655,6 @@
     }
    },
    "DependsOn": [
-    "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
     "buildimagedcc036c8876b451ea2c1552f9e06e9e173B4162A",
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1ServiceRoleC3DE4837",
     "CodeBuildImageBuilderCodeBuildBuildFailed9B205D70",
@@ -5189,7 +5184,6 @@
     }
    },
    "DependsOn": [
-    "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
     "buildimagedcc036c8876b451ea2c1552f9e06e9e173B4162A",
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1ServiceRoleC3DE4837",
     "CodeBuildImageBuilderarmCodeBuildBuildFailed7605ECB2",
@@ -5860,7 +5854,6 @@
     }
    },
    "DependsOn": [
-    "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB",
     "buildimagedcc036c8876b451ea2c1552f9e06e9e173B4162A",
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1ServiceRoleC3DE4837",
     "LambdaImageBuilderzCodeBuildBuildFailedFBCC1CE8",
@@ -8438,6 +8431,14 @@
     "TimeoutInMinutes": 60
    }
   },
+  "RunnerImageBuildHelpersLog13186633": {
+   "Type": "AWS::Logs::LogGroup",
+   "Properties": {
+    "RetentionInDays": 30
+   },
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete"
+  },
   "buildimagedcc036c8876b451ea2c1552f9e06e9e1ServiceRoleC3DE4837": {
    "Type": "AWS::IAM::Role",
    "Properties": {
@@ -8476,7 +8477,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "5d536d3909907c631aa15996d7eee0e12247f88312d888640b63f34a352c5fa4.zip"
+     "S3Key": "49da49fecc381582a88d129f442ac0d6a461bbfd60d0eb1eb772c61d22e78e60.zip"
     },
     "Description": "Custom resource handler that triggers CodeBuild to build runner images, and cleans-up images on deletion",
     "Environment": {
@@ -8485,6 +8486,12 @@
      }
     },
     "Handler": "index.handler",
+    "LoggingConfig": {
+     "LogFormat": "JSON",
+     "LogGroup": {
+      "Ref": "RunnerImageBuildHelpersLog13186633"
+     }
+    },
     "Role": {
      "Fn::GetAtt": [
       "buildimagedcc036c8876b451ea2c1552f9e06e9e1ServiceRoleC3DE4837",
@@ -8496,108 +8503,6 @@
    },
    "DependsOn": [
     "buildimagedcc036c8876b451ea2c1552f9e06e9e1ServiceRoleC3DE4837"
-   ]
-  },
-  "buildimagedcc036c8876b451ea2c1552f9e06e9e1LogRetention13129CEB": {
-   "Type": "Custom::LogRetention",
-   "Properties": {
-    "ServiceToken": {
-     "Fn::GetAtt": [
-      "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-      "Arn"
-     ]
-    },
-    "LogGroupName": {
-     "Fn::Join": [
-      "",
-      [
-       "/aws/lambda/",
-       {
-        "Ref": "buildimagedcc036c8876b451ea2c1552f9e06e9e173B4162A"
-       }
-      ]
-     ]
-    },
-    "RetentionInDays": 30
-   }
-  },
-  "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB": {
-   "Type": "AWS::IAM::Role",
-   "Properties": {
-    "AssumeRolePolicyDocument": {
-     "Statement": [
-      {
-       "Action": "sts:AssumeRole",
-       "Effect": "Allow",
-       "Principal": {
-        "Service": "lambda.amazonaws.com"
-       }
-      }
-     ],
-     "Version": "2012-10-17"
-    },
-    "ManagedPolicyArns": [
-     {
-      "Fn::Join": [
-       "",
-       [
-        "arn:",
-        {
-         "Ref": "AWS::Partition"
-        },
-        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-       ]
-      ]
-     }
-    ]
-   }
-  },
-  "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB": {
-   "Type": "AWS::IAM::Policy",
-   "Properties": {
-    "PolicyDocument": {
-     "Statement": [
-      {
-       "Action": [
-        "logs:PutRetentionPolicy",
-        "logs:DeleteRetentionPolicy"
-       ],
-       "Effect": "Allow",
-       "Resource": "*"
-      }
-     ],
-     "Version": "2012-10-17"
-    },
-    "PolicyName": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
-    "Roles": [
-     {
-      "Ref": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB"
-     }
-    ]
-   }
-  },
-  "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A": {
-   "Type": "AWS::Lambda::Function",
-   "Properties": {
-    "Handler": "index.handler",
-    "Runtime": "nodejs18.x",
-    "Timeout": 900,
-    "Code": {
-     "S3Bucket": {
-      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
-     },
-     "S3Key": "5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555.zip"
-    },
-    "Role": {
-     "Fn::GetAtt": [
-      "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
-      "Arn"
-     ]
-    }
-   },
-   "DependsOn": [
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB"
    ]
   },
   "CodeBuildARMLogs7C7FC5A7": {
@@ -9219,7 +9124,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "a080dc61c6f346aa8d265f2519e7e93f1be13ae0c0671e5b1dfa03130ae72795.zip"
+     "S3Key": "deaec75154c038cd6fec17fd19b905a08bb9a78b97bc2e0fd132505eda22c650.zip"
     },
     "Description": "Custom resource handler that bumps up Image Builder versions",
     "Environment": {
@@ -9228,6 +9133,12 @@
      }
     },
     "Handler": "index.handler",
+    "LoggingConfig": {
+     "LogFormat": "JSON",
+     "LogGroup": {
+      "Ref": "RunnerImageBuildHelpersLog13186633"
+     }
+    },
     "Role": {
      "Fn::GetAtt": [
       "awsimagebuilderversionerdcc036c8876b451ea2c1552f9e06e9e1ServiceRoleE25C1A58",
@@ -9241,29 +9152,6 @@
     "awsimagebuilderversionerdcc036c8876b451ea2c1552f9e06e9e1ServiceRoleDefaultPolicy93D80BBD",
     "awsimagebuilderversionerdcc036c8876b451ea2c1552f9e06e9e1ServiceRoleE25C1A58"
    ]
-  },
-  "awsimagebuilderversionerdcc036c8876b451ea2c1552f9e06e9e1LogRetentionA8337CBD": {
-   "Type": "Custom::LogRetention",
-   "Properties": {
-    "ServiceToken": {
-     "Fn::GetAtt": [
-      "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-      "Arn"
-     ]
-    },
-    "LogGroupName": {
-     "Fn::Join": [
-      "",
-      [
-       "/aws/lambda/",
-       {
-        "Ref": "awsimagebuilderversionerdcc036c8876b451ea2c1552f9e06e9e1591B871E"
-       }
-      ]
-     ]
-    },
-    "RetentionInDays": 30
-   }
   },
   "ECSsecuritygroup76605212": {
    "Type": "AWS::EC2::SecurityGroup",
@@ -11066,6 +10954,41 @@
     ]
    }
   },
+  "LambdaLog2764B04F": {
+   "Type": "AWS::Logs::LogGroup",
+   "Properties": {
+    "RetentionInDays": 30
+   },
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete"
+  },
+  "LambdaLogLogfilter1003281A": {
+   "Type": "AWS::Logs::MetricFilter",
+   "Properties": {
+    "FilterPattern": "[..., marker = \"CDKGHA\", job = \"JOB\", done = \"DONE\", labels, status = \"Succeeded\" || status = \"SucceededWithIssues\" || status = \"Failed\" || status = \"Canceled\" || status = \"Skipped\" || status = \"Abandoned\"]",
+    "LogGroupName": {
+     "Ref": "LambdaLog2764B04F"
+    },
+    "MetricTransformations": [
+     {
+      "Dimensions": [
+       {
+        "Key": "ProviderLabels",
+        "Value": "$labels"
+       },
+       {
+        "Key": "Status",
+        "Value": "$status"
+       }
+      ],
+      "MetricName": "JobCompleted",
+      "MetricNamespace": "GitHubRunners",
+      "MetricValue": "1",
+      "Unit": "Count"
+     }
+    ]
+   }
+  },
   "LambdaFunctionServiceRoleB1826A50": {
    "Type": "AWS::IAM::Role",
    "Properties": {
@@ -11174,6 +11097,11 @@
     "EphemeralStorage": {
      "Size": 10240
     },
+    "LoggingConfig": {
+     "LogGroup": {
+      "Ref": "LambdaLog2764B04F"
+     }
+    },
     "MemorySize": 2048,
     "PackageType": "Image",
     "Role": {
@@ -11187,59 +11115,6 @@
    "DependsOn": [
     "LambdaFunctionServiceRoleB1826A50"
    ]
-  },
-  "LambdaFunctionLogRetentionB6D78D6D": {
-   "Type": "Custom::LogRetention",
-   "Properties": {
-    "ServiceToken": {
-     "Fn::GetAtt": [
-      "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-      "Arn"
-     ]
-    },
-    "LogGroupName": {
-     "Fn::Join": [
-      "",
-      [
-       "/aws/lambda/",
-       {
-        "Ref": "LambdaFunction9233991D"
-       }
-      ]
-     ]
-    },
-    "RetentionInDays": 30
-   }
-  },
-  "LambdaFunctionLogGroupLogGroupfilter60E487A5": {
-   "Type": "AWS::Logs::MetricFilter",
-   "Properties": {
-    "FilterPattern": "[..., marker = \"CDKGHA\", job = \"JOB\", done = \"DONE\", labels, status = \"Succeeded\" || status = \"SucceededWithIssues\" || status = \"Failed\" || status = \"Canceled\" || status = \"Skipped\" || status = \"Abandoned\"]",
-    "LogGroupName": {
-     "Fn::GetAtt": [
-      "LambdaFunctionLogRetentionB6D78D6D",
-      "LogGroupName"
-     ]
-    },
-    "MetricTransformations": [
-     {
-      "Dimensions": [
-       {
-        "Key": "ProviderLabels",
-        "Value": "$labels"
-       },
-       {
-        "Key": "Status",
-        "Value": "$status"
-       }
-      ],
-      "MetricName": "JobCompleted",
-      "MetricNamespace": "GitHubRunners",
-      "MetricValue": "1",
-      "Unit": "Count"
-     }
-    ]
-   }
   },
   "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2": {
    "Type": "AWS::IAM::Role",
@@ -11279,9 +11154,14 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "17c16a3854838fd3ff4bda08146122a6701f33b9c86ae17f415ad0dc47a97544.zip"
+     "S3Key": "ed6cd104ff5f101d06dae8cb2b87cc6e6d69b9a22055b467ea6cae10ff023023.zip"
     },
     "Handler": "index.handler",
+    "LoggingConfig": {
+     "LogGroup": {
+      "Ref": "RunnerImageBuildHelpersLog13186633"
+     }
+    },
     "Role": {
      "Fn::GetAtt": [
       "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
@@ -11294,29 +11174,6 @@
    "DependsOn": [
     "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2"
    ]
-  },
-  "AWS679f53fac002430cb0da5b7982bd2287LogRetentionCE72797A": {
-   "Type": "Custom::LogRetention",
-   "Properties": {
-    "ServiceToken": {
-     "Fn::GetAtt": [
-      "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-      "Arn"
-     ]
-    },
-    "LogGroupName": {
-     "Fn::Join": [
-      "",
-      [
-       "/aws/lambda/",
-       {
-        "Ref": "AWS679f53fac002430cb0da5b7982bd22872D164C4C"
-       }
-      ]
-     ]
-    },
-    "RetentionInDays": 30
-   }
   },
   "updatelambdadcc036c8876b451ea2c1552f9e06e9e1ServiceRoleE163ADCA": {
    "Type": "AWS::IAM::Role",
@@ -11392,7 +11249,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "1d96057090c75f1428c11ddf65870ca9f79152d00b3ae875b2d8cb2114c365ab.zip"
+     "S3Key": "aa9b0a3f0625b484074bb9cb369382960e95d5721493cc6f1c6dc46797cd3aea.zip"
     },
     "Description": "Function that updates a GitHub Actions runner function with the latest image digest after the image has been rebuilt",
     "Environment": {
@@ -11401,6 +11258,12 @@
      }
     },
     "Handler": "index.handler",
+    "LoggingConfig": {
+     "LogFormat": "JSON",
+     "LogGroup": {
+      "Ref": "RunnerImageBuildHelpersLog13186633"
+     }
+    },
     "Role": {
      "Fn::GetAtt": [
       "updatelambdadcc036c8876b451ea2c1552f9e06e9e1ServiceRoleE163ADCA",
@@ -11414,29 +11277,6 @@
     "updatelambdadcc036c8876b451ea2c1552f9e06e9e1ServiceRoleDefaultPolicy1EF644A6",
     "updatelambdadcc036c8876b451ea2c1552f9e06e9e1ServiceRoleE163ADCA"
    ]
-  },
-  "updatelambdadcc036c8876b451ea2c1552f9e06e9e1LogRetentionEF9C436F": {
-   "Type": "Custom::LogRetention",
-   "Properties": {
-    "ServiceToken": {
-     "Fn::GetAtt": [
-      "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-      "Arn"
-     ]
-    },
-    "LogGroupName": {
-     "Fn::Join": [
-      "",
-      [
-       "/aws/lambda/",
-       {
-        "Ref": "updatelambdadcc036c8876b451ea2c1552f9e06e9e180810ABA"
-       }
-      ]
-     ]
-    },
-    "RetentionInDays": 30
-   }
   },
   "LambdaARMImageDigestReaderF3DD55C4": {
    "Type": "Custom::EcrImageDigest",
@@ -11523,6 +11363,41 @@
     "Roles": [
      {
       "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2"
+     }
+    ]
+   }
+  },
+  "LambdaARMLogAA2DA09F": {
+   "Type": "AWS::Logs::LogGroup",
+   "Properties": {
+    "RetentionInDays": 30
+   },
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete"
+  },
+  "LambdaARMLogLogfilterE0BE5E30": {
+   "Type": "AWS::Logs::MetricFilter",
+   "Properties": {
+    "FilterPattern": "[..., marker = \"CDKGHA\", job = \"JOB\", done = \"DONE\", labels, status = \"Succeeded\" || status = \"SucceededWithIssues\" || status = \"Failed\" || status = \"Canceled\" || status = \"Skipped\" || status = \"Abandoned\"]",
+    "LogGroupName": {
+     "Ref": "LambdaARMLogAA2DA09F"
+    },
+    "MetricTransformations": [
+     {
+      "Dimensions": [
+       {
+        "Key": "ProviderLabels",
+        "Value": "$labels"
+       },
+       {
+        "Key": "Status",
+        "Value": "$status"
+       }
+      ],
+      "MetricName": "JobCompleted",
+      "MetricNamespace": "GitHubRunners",
+      "MetricValue": "1",
+      "Unit": "Count"
      }
     ]
    }
@@ -11635,6 +11510,11 @@
     "EphemeralStorage": {
      "Size": 10240
     },
+    "LoggingConfig": {
+     "LogGroup": {
+      "Ref": "LambdaARMLogAA2DA09F"
+     }
+    },
     "MemorySize": 2048,
     "PackageType": "Image",
     "Role": {
@@ -11648,59 +11528,6 @@
    "DependsOn": [
     "LambdaARMFunctionServiceRole136069A0"
    ]
-  },
-  "LambdaARMFunctionLogRetention67E9FEF8": {
-   "Type": "Custom::LogRetention",
-   "Properties": {
-    "ServiceToken": {
-     "Fn::GetAtt": [
-      "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-      "Arn"
-     ]
-    },
-    "LogGroupName": {
-     "Fn::Join": [
-      "",
-      [
-       "/aws/lambda/",
-       {
-        "Ref": "LambdaARMFunctionDD4B5FF7"
-       }
-      ]
-     ]
-    },
-    "RetentionInDays": 30
-   }
-  },
-  "LambdaARMFunctionLogGroupLogGroupfilterD29D06B1": {
-   "Type": "AWS::Logs::MetricFilter",
-   "Properties": {
-    "FilterPattern": "[..., marker = \"CDKGHA\", job = \"JOB\", done = \"DONE\", labels, status = \"Succeeded\" || status = \"SucceededWithIssues\" || status = \"Failed\" || status = \"Canceled\" || status = \"Skipped\" || status = \"Abandoned\"]",
-    "LogGroupName": {
-     "Fn::GetAtt": [
-      "LambdaARMFunctionLogRetention67E9FEF8",
-      "LogGroupName"
-     ]
-    },
-    "MetricTransformations": [
-     {
-      "Dimensions": [
-       {
-        "Key": "ProviderLabels",
-        "Value": "$labels"
-       },
-       {
-        "Key": "Status",
-        "Value": "$status"
-       }
-      ],
-      "MetricName": "JobCompleted",
-      "MetricNamespace": "GitHubRunners",
-      "MetricValue": "1",
-      "Unit": "Count"
-     }
-    ]
-   }
   },
   "FargatesecuritygroupAFCAFD34": {
    "Type": "AWS::EC2::SecurityGroup",
@@ -13269,7 +13096,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "b1862470ac31c934803dff83368cf5cdec42c544fd77a6e8fc25d6d7e55befa4.zip"
+     "S3Key": "4a06647157afdd5917965dc4eb5ed09260934ebf02f976202d551d4a9a5cf2e7.zip"
     },
     "Description": "Delete old GitHub Runner AMIs",
     "Environment": {
@@ -13278,6 +13105,12 @@
      }
     },
     "Handler": "index.handler",
+    "LoggingConfig": {
+     "LogFormat": "JSON",
+     "LogGroup": {
+      "Ref": "RunnerImageBuildHelpersLog13186633"
+     }
+    },
     "Role": {
      "Fn::GetAtt": [
       "deleteamidcc036c8876b451ea2c1552f9e06e9e1ServiceRole1CC58A6F",
@@ -13291,29 +13124,6 @@
     "deleteamidcc036c8876b451ea2c1552f9e06e9e1ServiceRoleDefaultPolicy0C44BF83",
     "deleteamidcc036c8876b451ea2c1552f9e06e9e1ServiceRole1CC58A6F"
    ]
-  },
-  "deleteamidcc036c8876b451ea2c1552f9e06e9e1LogRetention85F808EB": {
-   "Type": "Custom::LogRetention",
-   "Properties": {
-    "ServiceToken": {
-     "Fn::GetAtt": [
-      "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-      "Arn"
-     ]
-    },
-    "LogGroupName": {
-     "Fn::Join": [
-      "",
-      [
-       "/aws/lambda/",
-       {
-        "Ref": "deleteamidcc036c8876b451ea2c1552f9e06e9e1BE713303"
-       }
-      ]
-     ]
-    },
-    "RetentionInDays": 30
-   }
   },
   "EC2SpotLinuxSG8D846B64": {
    "Type": "AWS::EC2::SecurityGroup",
@@ -14003,6 +13813,12 @@
      }
     },
     "Handler": "index.handler",
+    "LoggingConfig": {
+     "LogFormat": "JSON",
+     "LogGroup": {
+      "Ref": "OrchestratorLogFB9610E7"
+     }
+    },
     "Role": {
      "Fn::GetAtt": [
       "runnerstokenretrieverServiceRole6099F71C",
@@ -14016,29 +13832,6 @@
     "runnerstokenretrieverServiceRoleDefaultPolicy24965D29",
     "runnerstokenretrieverServiceRole6099F71C"
    ]
-  },
-  "runnerstokenretrieverLogRetention05A536AD": {
-   "Type": "Custom::LogRetention",
-   "Properties": {
-    "ServiceToken": {
-     "Fn::GetAtt": [
-      "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-      "Arn"
-     ]
-    },
-    "LogGroupName": {
-     "Fn::Join": [
-      "",
-      [
-       "/aws/lambda/",
-       {
-        "Ref": "runnerstokenretrieverD5E8392A"
-       }
-      ]
-     ]
-    },
-    "RetentionInDays": 30
-   }
   },
   "runnersdeleterunnerServiceRole35856967": {
    "Type": "AWS::IAM::Role",
@@ -14129,6 +13922,12 @@
      }
     },
     "Handler": "index.handler",
+    "LoggingConfig": {
+     "LogFormat": "JSON",
+     "LogGroup": {
+      "Ref": "OrchestratorLogFB9610E7"
+     }
+    },
     "Role": {
      "Fn::GetAtt": [
       "runnersdeleterunnerServiceRole35856967",
@@ -14142,29 +13941,6 @@
     "runnersdeleterunnerServiceRoleDefaultPolicyECFB6BF7",
     "runnersdeleterunnerServiceRole35856967"
    ]
-  },
-  "runnersdeleterunnerLogRetention76F47082": {
-   "Type": "Custom::LogRetention",
-   "Properties": {
-    "ServiceToken": {
-     "Fn::GetAtt": [
-      "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-      "Arn"
-     ]
-    },
-    "LogGroupName": {
-     "Fn::Join": [
-      "",
-      [
-       "/aws/lambda/",
-       {
-        "Ref": "runnersdeleterunner7F8D5293"
-       }
-      ]
-     ]
-    },
-    "RetentionInDays": 30
-   }
   },
   "runnersIdleReaperServiceRoleA775758D": {
    "Type": "AWS::IAM::Role",
@@ -14355,7 +14131,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "dfe33c6b4de9a62d153ad3025abe39cb85d5fef9d1a6e4b54e79b96cdbfc64ea.zip"
+     "S3Key": "d90f56ab5772627b156240c90daa136819b2540625a789b227351862f504f8ce.zip"
     },
     "Description": "Stop idle GitHub runners to avoid paying for runners when the job was already canceled",
     "Environment": {
@@ -14370,6 +14146,12 @@
      }
     },
     "Handler": "index.handler",
+    "LoggingConfig": {
+     "LogFormat": "JSON",
+     "LogGroup": {
+      "Ref": "OrchestratorLogFB9610E7"
+     }
+    },
     "Role": {
      "Fn::GetAtt": [
       "runnersIdleReaperServiceRoleA775758D",
@@ -14383,29 +14165,6 @@
     "runnersIdleReaperServiceRoleDefaultPolicyE05BFDF0",
     "runnersIdleReaperServiceRoleA775758D"
    ]
-  },
-  "runnersIdleReaperLogRetention7C122308": {
-   "Type": "Custom::LogRetention",
-   "Properties": {
-    "ServiceToken": {
-     "Fn::GetAtt": [
-      "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-      "Arn"
-     ]
-    },
-    "LogGroupName": {
-     "Fn::Join": [
-      "",
-      [
-       "/aws/lambda/",
-       {
-        "Ref": "runnersIdleReaper6FBF63A3"
-       }
-      ]
-     ]
-    },
-    "RetentionInDays": 30
-   }
   },
   "runnersIdleReaperSqsEventSourcegithubrunnerstestrunnersIdleReaperQueue5E84F4E4B0DB6768": {
    "Type": "AWS::Lambda::EventSourceMapping",
@@ -16523,7 +16282,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "c4cf998f4a4344b3a5725ca42aeb71e5a87a4d26f4478bf4ac84666d7b306a69.zip"
+     "S3Key": "e7954c04f03129866fa75a1501b4d61587a381c13cc9b973c0a45c2f208b44d3.zip"
     },
     "Description": "Handle GitHub webhook and start runner orchestrator",
     "Environment": {
@@ -16546,6 +16305,12 @@
      }
     },
     "Handler": "index.handler",
+    "LoggingConfig": {
+     "LogFormat": "JSON",
+     "LogGroup": {
+      "Ref": "OrchestratorLogFB9610E7"
+     }
+    },
     "Role": {
      "Fn::GetAtt": [
       "runnersWebhookHandlerwebhookhandlerServiceRole03DB58D2",
@@ -16553,35 +16318,12 @@
      ]
     },
     "Runtime": "nodejs18.x",
-    "Timeout": 30
+    "Timeout": 31
    },
    "DependsOn": [
     "runnersWebhookHandlerwebhookhandlerServiceRoleDefaultPolicy1600452C",
     "runnersWebhookHandlerwebhookhandlerServiceRole03DB58D2"
    ]
-  },
-  "runnersWebhookHandlerwebhookhandlerLogRetention0F5ED260": {
-   "Type": "Custom::LogRetention",
-   "Properties": {
-    "ServiceToken": {
-     "Fn::GetAtt": [
-      "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-      "Arn"
-     ]
-    },
-    "LogGroupName": {
-     "Fn::Join": [
-      "",
-      [
-       "/aws/lambda/",
-       {
-        "Ref": "runnersWebhookHandlerwebhookhandler22779A81"
-       }
-      ]
-     ]
-    },
-    "RetentionInDays": 30
-   }
   },
   "runnersWebhookHandlerwebhookhandlerFunctionUrlC8FB3D17": {
    "Type": "AWS::Lambda::Url",
@@ -16750,6 +16492,12 @@
      }
     },
     "Handler": "index.handler",
+    "LoggingConfig": {
+     "LogFormat": "JSON",
+     "LogGroup": {
+      "Ref": "SetupLog8A8B0E5C"
+     }
+    },
     "Role": {
      "Fn::GetAtt": [
       "runnerssetupServiceRole588BFE9A",
@@ -16763,29 +16511,6 @@
     "runnerssetupServiceRoleDefaultPolicy40EF213B",
     "runnerssetupServiceRole588BFE9A"
    ]
-  },
-  "runnerssetupLogRetentionA9A82D27": {
-   "Type": "Custom::LogRetention",
-   "Properties": {
-    "ServiceToken": {
-     "Fn::GetAtt": [
-      "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-      "Arn"
-     ]
-    },
-    "LogGroupName": {
-     "Fn::Join": [
-      "",
-      [
-       "/aws/lambda/",
-       {
-        "Ref": "runnerssetup9896CB59"
-       }
-      ]
-     ]
-    },
-    "RetentionInDays": 30
-   }
   },
   "runnerssetupFunctionUrlB8BC43E8": {
    "Type": "AWS::Lambda::Url",
@@ -17103,6 +16828,12 @@
      }
     },
     "Handler": "index.handler",
+    "LoggingConfig": {
+     "LogFormat": "JSON",
+     "LogGroup": {
+      "Ref": "SetupLog8A8B0E5C"
+     }
+    },
     "Role": {
      "Fn::GetAtt": [
       "runnersstatusServiceRole71A1ADB6",
@@ -17648,10 +17379,7 @@
        ]
       },
       "logGroup": {
-       "Fn::GetAtt": [
-        "LambdaFunctionLogRetentionB6D78D6D",
-        "LogGroupName"
-       ]
+       "Ref": "LambdaLog2764B04F"
       },
       "image": {
        "imageRepository": {
@@ -17721,10 +17449,7 @@
        ]
       },
       "logGroup": {
-       "Fn::GetAtt": [
-        "LambdaARMFunctionLogRetention67E9FEF8",
-        "LogGroupName"
-       ]
+       "Ref": "LambdaARMLogAA2DA09F"
       },
       "image": {
        "imageRepository": {
@@ -18426,29 +18151,6 @@
     ]
    }
   },
-  "runnersstatusLogRetention8EB4A773": {
-   "Type": "Custom::LogRetention",
-   "Properties": {
-    "ServiceToken": {
-     "Fn::GetAtt": [
-      "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-      "Arn"
-     ]
-    },
-    "LogGroupName": {
-     "Fn::Join": [
-      "",
-      [
-       "/aws/lambda/",
-       {
-        "Ref": "runnersstatus1A5771C0"
-       }
-      ]
-     ]
-    },
-    "RetentionInDays": 30
-   }
-  },
   "runnersFailedRunnerImageBuilds233D2237": {
    "Type": "AWS::SNS::Topic"
   },
@@ -18542,7 +18244,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "70d775c42043d1c5e737e2362a0d99627e98bd651ac5fd45d7275105bee1b54b.zip"
+     "S3Key": "f07c60cc451d4f0c652f687a1c8cd6cf21a2a8f6cd7ab6807e6ee06606ea4122.zip"
     },
     "Description": "src/image-builders/aws-image-builder/filter-failed-builds.lambda.ts",
     "Environment": {
@@ -18554,6 +18256,12 @@
      }
     },
     "Handler": "index.handler",
+    "LoggingConfig": {
+     "LogFormat": "JSON",
+     "LogGroup": {
+      "Ref": "RunnerImageBuildHelpersLog13186633"
+     }
+    },
     "Role": {
      "Fn::GetAtt": [
       "runnersImageBuilderBuildsFilterServiceRoleED82BC5F",
@@ -18566,29 +18274,6 @@
     "runnersImageBuilderBuildsFilterServiceRoleDefaultPolicy4525F6C1",
     "runnersImageBuilderBuildsFilterServiceRoleED82BC5F"
    ]
-  },
-  "runnersImageBuilderBuildsFilterLogRetentionD5005098": {
-   "Type": "Custom::LogRetention",
-   "Properties": {
-    "ServiceToken": {
-     "Fn::GetAtt": [
-      "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-      "Arn"
-     ]
-    },
-    "LogGroupName": {
-     "Fn::Join": [
-      "",
-      [
-       "/aws/lambda/",
-       {
-        "Ref": "runnersImageBuilderBuildsFilterD708AA06"
-       }
-      ]
-     ]
-    },
-    "RetentionInDays": 30
-   }
   },
   "runnersImageBuilderBuildsFilterAllowInvokegithubrunnerstestrunnersImageBuilderBuilds109FC9E855AB30DD": {
    "Type": "AWS::Lambda::Permission",
@@ -18626,14 +18311,46 @@
    "Properties": {
     "LogGroupNames": [
      {
-      "Fn::GetAtt": [
-       "runnersWebhookHandlerwebhookhandlerLogRetention0F5ED260",
-       "LogGroupName"
-      ]
+      "Ref": "OrchestratorLogFB9610E7"
      }
     ],
     "Name": "GitHub Runners/Webhook errors",
-    "QueryString": "parse @message /^(?<timestamp>[^\\s]+)\\t(?<requestId>[^\\s]+)\\t(?<level>[^\\s]+)\\t(?<message>.+$)/\n| filter level = \"ERROR\"\n| sort @timestamp desc\n| limit 100"
+    "QueryString": {
+     "Fn::Join": [
+      "",
+      [
+       "filter strcontains(@logStream, \"",
+       {
+        "Ref": "runnersWebhookHandlerwebhookhandler22779A81"
+       },
+       "\")\n| filter level = \"ERROR\"\n| sort @timestamp desc\n| limit 100"
+      ]
+     ]
+    }
+   }
+  },
+  "runnersOrchestrationerrors9EFE206B": {
+   "Type": "AWS::Logs::QueryDefinition",
+   "Properties": {
+    "LogGroupNames": [
+     {
+      "Ref": "OrchestratorLogFB9610E7"
+     }
+    ],
+    "Name": "GitHub Runners/Orchestration errors",
+    "QueryString": "filter level = \"ERROR\"\n| sort @timestamp desc\n| limit 100"
+   }
+  },
+  "runnersRunnerimagebuilderrorsC1D423F8": {
+   "Type": "AWS::Logs::QueryDefinition",
+   "Properties": {
+    "LogGroupNames": [
+     {
+      "Ref": "RunnerImageBuildHelpersLog13186633"
+     }
+    ],
+    "Name": "GitHub Runners/Runner image build errors",
+    "QueryString": "filter strcontains(message, \"error\") or strcontains(message, \"ERROR\") or strcontains(message, \"Error\") or level = \"ERROR\"\n| sort @timestamp desc\n| limit 100"
    }
   },
   "runnersIgnoredwebhooksAD368063": {
@@ -18641,14 +18358,22 @@
    "Properties": {
     "LogGroupNames": [
      {
-      "Fn::GetAtt": [
-       "runnersWebhookHandlerwebhookhandlerLogRetention0F5ED260",
-       "LogGroupName"
-      ]
+      "Ref": "OrchestratorLogFB9610E7"
      }
     ],
     "Name": "GitHub Runners/Ignored webhooks",
-    "QueryString": "parse @message /^(?<timestamp>[^\\s]+)\\t(?<requestId>[^\\s]+)\\t(?<level>[^\\s]+)\\t(?<message>.+$)/\n| filter strcontains(message, \"Ignoring\")\n| sort @timestamp desc\n| limit 100"
+    "QueryString": {
+     "Fn::Join": [
+      "",
+      [
+       "fields @timestamp, message.notice\n| filter strcontains(@logStream, \"",
+       {
+        "Ref": "runnersWebhookHandlerwebhookhandler22779A81"
+       },
+       "\")\n| filter strcontains(message.notice, \"Ignoring\")\n| sort @timestamp desc\n| limit 100"
+      ]
+     ]
+    }
    }
   },
   "runnersIgnoredjobsbasedonlabels120F3D1A": {
@@ -18656,14 +18381,22 @@
    "Properties": {
     "LogGroupNames": [
      {
-      "Fn::GetAtt": [
-       "runnersWebhookHandlerwebhookhandlerLogRetention0F5ED260",
-       "LogGroupName"
-      ]
+      "Ref": "OrchestratorLogFB9610E7"
      }
     ],
     "Name": "GitHub Runners/Ignored jobs based on labels",
-    "QueryString": "parse @message /^(?<timestamp>[^\\s]+)\\t(?<requestId>[^\\s]+)\\t(?<level>[^\\s]+)\\t(?<message>.+$)/\n| filter strcontains(message, \"Ignoring labels\")\n| sort @timestamp desc\n| limit 100"
+    "QueryString": {
+     "Fn::Join": [
+      "",
+      [
+       "fields @timestamp, message.notice\n| filter strcontains(@logStream, \"",
+       {
+        "Ref": "runnersWebhookHandlerwebhookhandler22779A81"
+       },
+       "\")\n| filter strcontains(message.notice, \"Ignoring labels\")\n| sort @timestamp desc\n| limit 100"
+      ]
+     ]
+    }
    }
   },
   "runnersWebhookstartedrunners63776EDF": {
@@ -18671,15 +18404,31 @@
    "Properties": {
     "LogGroupNames": [
      {
-      "Fn::GetAtt": [
-       "runnersWebhookHandlerwebhookhandlerLogRetention0F5ED260",
-       "LogGroupName"
-      ]
+      "Ref": "OrchestratorLogFB9610E7"
      }
     ],
     "Name": "GitHub Runners/Webhook started runners",
-    "QueryString": "fields @timestamp, @message\n| filter jobUrl like /http.*/\n| sort @timestamp desc\n| limit 100"
+    "QueryString": {
+     "Fn::Join": [
+      "",
+      [
+       "fields @timestamp, message.sfnInput.jobUrl, message.sfnInput.labels, message.sfnInput.provider\n| filter strcontains(@logStream, \"",
+       {
+        "Ref": "runnersWebhookHandlerwebhookhandler22779A81"
+       },
+       "\")\n| filter message.sfnInput.jobUrl like /http.*/\n| sort @timestamp desc\n| limit 100"
+      ]
+     ]
+    }
    }
+  },
+  "OrchestratorLogFB9610E7": {
+   "Type": "AWS::Logs::LogGroup",
+   "Properties": {
+    "RetentionInDays": 30
+   },
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete"
   },
   "AMIRootDeviceReaderdcc036c8876b451ea2c1552f9e06e9e1ServiceRole69906A36": {
    "Type": "AWS::IAM::Role",
@@ -18744,7 +18493,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "97a52dd61d3f204877c7a944f14423bdbdec7587794ab63213506581ffb19976.zip"
+     "S3Key": "2b3e3110ffb96a7df77acaa663361ec1c03e985af62941397f4806ba6fbde75f.zip"
     },
     "Description": "Custom resource handler that discovers the boot drive device name for a given AMI",
     "Environment": {
@@ -18753,6 +18502,12 @@
      }
     },
     "Handler": "index.handler",
+    "LoggingConfig": {
+     "LogFormat": "JSON",
+     "LogGroup": {
+      "Ref": "RunnerImageBuildHelpersLog13186633"
+     }
+    },
     "Role": {
      "Fn::GetAtt": [
       "AMIRootDeviceReaderdcc036c8876b451ea2c1552f9e06e9e1ServiceRole69906A36",
@@ -18767,28 +18522,13 @@
     "AMIRootDeviceReaderdcc036c8876b451ea2c1552f9e06e9e1ServiceRole69906A36"
    ]
   },
-  "AMIRootDeviceReaderdcc036c8876b451ea2c1552f9e06e9e1LogRetentionFC67AFCF": {
-   "Type": "Custom::LogRetention",
+  "SetupLog8A8B0E5C": {
+   "Type": "AWS::Logs::LogGroup",
    "Properties": {
-    "ServiceToken": {
-     "Fn::GetAtt": [
-      "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-      "Arn"
-     ]
-    },
-    "LogGroupName": {
-     "Fn::Join": [
-      "",
-      [
-       "/aws/lambda/",
-       {
-        "Ref": "AMIRootDeviceReaderdcc036c8876b451ea2c1552f9e06e9e1C64D247C"
-       }
-      ]
-     ]
-    },
     "RetentionInDays": 30
-   }
+   },
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete"
   }
  },
  "Parameters": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,7 +10,7 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@aws-cdk/asset-awscli-v1@^2.2.201":
+"@aws-cdk/asset-awscli-v1@^2.2.202":
   version "2.2.202"
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.202.tgz#4627201d71f6a5c60db36385ce09cb81005f4b32"
   integrity sha512-JqlF0D4+EVugnG5dAsNZMqhu3HW7ehOXm5SDMxMbXNDMdsF0pxtQKNHRl52z1U9igsHmaFpUgSGjbhAJ+0JONg==
@@ -2950,18 +2950,18 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-aws-cdk-lib@2.110.0:
-  version "2.110.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.110.0.tgz#5af2a933a834b9efe3b99abf2c28adbd93f89547"
-  integrity sha512-4IxjdtaoGjQPqtFyYXG6kOs9t/UTAh06tlGyCPpvhTZNoKNFUkku3H6MArlazpiKtm+dThdF+p5lQLB/kIu/qw==
+aws-cdk-lib@2.123.0:
+  version "2.123.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.123.0.tgz#a03d93f978f709471bd6e86748ae942ad47a806b"
+  integrity sha512-KSfX1ex52N/v25hjOlec1D9iCBLbGpegTR8rB4kYVqdQCdCWbKAwZjo6f38JZqkDlEJn+g249p8xiniq/gDniQ==
   dependencies:
-    "@aws-cdk/asset-awscli-v1" "^2.2.201"
+    "@aws-cdk/asset-awscli-v1" "^2.2.202"
     "@aws-cdk/asset-kubectl-v20" "^2.1.2"
     "@aws-cdk/asset-node-proxy-agent-v6" "^2.0.1"
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
-    fs-extra "^11.1.1"
-    ignore "^5.2.4"
+    fs-extra "^11.2.0"
+    ignore "^5.3.0"
     jsonschema "^1.4.1"
     minimatch "^3.1.2"
     punycode "^2.3.1"
@@ -4292,7 +4292,7 @@ fs-extra@^10.1.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-extra@^11.1.1:
+fs-extra@^11.2.0:
   version "11.2.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.2.0.tgz#e70e17dfad64232287d01929399e0ea7c86b0e5b"
   integrity sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==
@@ -4611,7 +4611,7 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-ignore@^5.2.0, ignore@^5.2.4:
+ignore@^5.2.0, ignore@^5.2.4, ignore@^5.3.0:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.1.tgz#5073e554cd42c5b33b394375f538b8593e34d4ef"
   integrity sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==


### PR DESCRIPTION
Create and share log groups for all of our Lambda functions instead of using the built-in log groups. Switched to structured JSON logging for Lambda functions. This allows for easier debugging with all the relevant logs going to one group. All built-in Log Insights queries created with `createLogsInsightsQueries()` have been updated accordingly and more queries were added.

There are now three shared log groups:
1. **Runner Image Build Helpers Log** for functions related to building runner images like image registration and clean-up
2. **Orchestrator Log** for functions that handle GitHub webhook and triggering runners
3. **Setup Log** for functions that handle initial setup

Resolves #539

BREAKING CHANGE: CDK 2.123.0 and above is required
BREAKING CHANGE: log groups have moved and all Lambda logs have been converted to JSON format