### PR TITLE
feat: Enable using private base Docker images

### DIFF
--- a/API.md
+++ b/API.md
@@ -7794,6 +7794,7 @@ const runnerImageBuilderProps: RunnerImageBuilderProps = { ... }
 | <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerImageBuilderProps.property.builderType">builderType</a></code> | <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerImageBuilderType">RunnerImageBuilderType</a></code> | *No description.* |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerImageBuilderProps.property.codeBuildOptions">codeBuildOptions</a></code> | <code><a href="#@cloudsnorkel/cdk-github-runners.CodeBuildRunnerImageBuilderProps">CodeBuildRunnerImageBuilderProps</a></code> | Options specific to CodeBuild image builder. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerImageBuilderProps.property.components">components</a></code> | <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerImageComponent">RunnerImageComponent</a>[]</code> | Components to install on the image. |
+| <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerImageBuilderProps.property.dockerSetupCommands">dockerSetupCommands</a></code> | <code>string[]</code> | Additional commands to run on the build host before starting the Docker runner image build. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerImageBuilderProps.property.logRemovalPolicy">logRemovalPolicy</a></code> | <code>aws-cdk-lib.RemovalPolicy</code> | Removal policy for logs of image builds. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerImageBuilderProps.property.logRetention">logRetention</a></code> | <code>aws-cdk-lib.aws_logs.RetentionDays</code> | The number of days log events are kept in CloudWatch Logs. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerImageBuilderProps.property.os">os</a></code> | <code><a href="#@cloudsnorkel/cdk-github-runners.Os">Os</a></code> | Image OS. |
@@ -7859,6 +7860,8 @@ public readonly baseDockerImage: string;
 
 Base image from which Docker runner images will be built.
 
+When using private images from a different account or not on ECR, you may need to include additional setup commands with {@link dockerSetupCommands}.
+
 ---
 
 ##### `builderType`<sup>Optional</sup> <a name="builderType" id="@cloudsnorkel/cdk-github-runners.RunnerImageBuilderProps.property.builderType"></a>
@@ -7896,6 +7899,21 @@ public readonly components: RunnerImageComponent[];
 - *Default:* none
 
 Components to install on the image.
+
+---
+
+##### `dockerSetupCommands`<sup>Optional</sup> <a name="dockerSetupCommands" id="@cloudsnorkel/cdk-github-runners.RunnerImageBuilderProps.property.dockerSetupCommands"></a>
+
+```typescript
+public readonly dockerSetupCommands: string[];
+```
+
+- *Type:* string[]
+- *Default:* []
+
+Additional commands to run on the build host before starting the Docker runner image build.
+
+Use this to execute commands such as `docker login` or `aws ecr get-login-password` to pull private base images.
 
 ---
 

--- a/src/image-builders/aws-image-builder/builder.ts
+++ b/src/image-builders/aws-image-builder/builder.ts
@@ -334,7 +334,7 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
     this.instanceType = props?.awsImageBuilderOptions?.instanceType ?? ec2.InstanceType.of(ec2.InstanceClass.M5, ec2.InstanceSize.LARGE);
     this.fastLaunchOptions = props?.awsImageBuilderOptions?.fastLaunchOptions;
     this.waitOnDeploy = props?.waitOnDeploy ?? true;
-    this.dockerSetupCommands = props?.dockerSetupCommands??[];
+    this.dockerSetupCommands = props?.dockerSetupCommands ?? [];
 
     // confirm instance type
     if (!this.architecture.instanceTypeMatch(this.instanceType)) {

--- a/src/image-builders/aws-image-builder/common.ts
+++ b/src/image-builders/aws-image-builder/common.ts
@@ -12,7 +12,7 @@ export abstract class ImageBuilderObjectBase extends cdk.Resource {
     super(scope, id);
   }
 
-  protected generateVersion(type: 'Component' | 'ImageRecipe' | 'ContainerRecipe', name: string, data: any): string {
+  protected generateVersion(type: 'Component' | 'ImageRecipe' | 'ContainerRecipe' | 'Workflow', name: string, data: any): string {
     return new CustomResource(this, 'Version', {
       serviceToken: this.versionFunction().functionArn,
       resourceType: `Custom::ImageBuilder-${type}-Version`,
@@ -34,6 +34,7 @@ export abstract class ImageBuilderObjectBase extends cdk.Resource {
             'imagebuilder:ListComponents',
             'imagebuilder:ListContainerRecipes',
             'imagebuilder:ListImageRecipes',
+            'imagebuilder:ListWorkflows',
           ],
           resources: ['*'],
         }),

--- a/src/image-builders/aws-image-builder/versioner.lambda.ts
+++ b/src/image-builders/aws-image-builder/versioner.lambda.ts
@@ -1,9 +1,13 @@
 import {
   ImagebuilderClient,
-  ListComponentsCommand, ListComponentsResponse,
-  ListContainerRecipesCommand, ListContainerRecipesResponse,
+  ListComponentsCommand,
+  ListComponentsResponse,
+  ListContainerRecipesCommand,
+  ListContainerRecipesResponse,
   ListImageRecipesCommand,
   ListImageRecipesResponse,
+  ListWorkflowsCommand,
+  ListWorkflowsResponse,
 } from '@aws-sdk/client-imagebuilder';
 import * as AWSLambda from 'aws-lambda';
 import { inc, maxSatisfying } from 'semver';
@@ -82,6 +86,20 @@ export async function handler(event: AWSLambda.CloudFormationCustomResourceEvent
                   nextToken: result.nextToken,
                 }));
                 allVersions = allVersions.concat(result.containerRecipeSummaryList!.map(i => i.arn?.split('/').pop() || '1.0.0'));
+              } while (result.nextToken);
+              break;
+            }
+            case 'Workflow': {
+              let result: ListWorkflowsResponse = {};
+              do {
+                result = await ib.send(new ListWorkflowsCommand({
+                  filters: [{
+                    name: 'name',
+                    values: [objectName],
+                  }],
+                  nextToken: result.nextToken,
+                }));
+                allVersions = allVersions.concat(result.workflowVersionList!.map(i => i.arn?.split('/').pop() || '1.0.0'));
               } while (result.nextToken);
               break;
             }

--- a/src/image-builders/aws-image-builder/workflow.ts
+++ b/src/image-builders/aws-image-builder/workflow.ts
@@ -1,0 +1,121 @@
+import { aws_imagebuilder as imagebuilder } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { ImageBuilderObjectBase } from './common';
+import { uniqueImageBuilderName } from '../common';
+
+/**
+ * Properties for Workflow construct.
+ *
+ * @internal
+ */
+export interface WorkflowProperties {
+  /**
+   * Workflow type.
+   */
+  readonly type: 'BUILD' | 'TEST' | 'DISTRIBUTION';
+
+  /**
+   * YAML or JSON data for the workflow.
+   */
+  readonly data: any;
+}
+
+/**
+ * Image builder workflow.
+ *
+ * @internal
+ */
+export class Workflow extends ImageBuilderObjectBase {
+  public readonly arn: string;
+  public readonly name: string;
+  public readonly version: string;
+
+  constructor(scope: Construct, id: string, props: WorkflowProperties) {
+    super(scope, id);
+
+    this.name = uniqueImageBuilderName(this);
+    this.version = this.generateVersion('Workflow', this.name, {
+      type: props.type,
+      data: props.data,
+    });
+
+    const workflow = new imagebuilder.CfnWorkflow(this, 'Workflow', {
+      name: uniqueImageBuilderName(this),
+      version: this.version,
+      type: props.type,
+      data: JSON.stringify(props.data),
+    });
+
+    this.arn = workflow.attrArn;
+  }
+}
+
+/**
+ * Returns a new build workflow based on arn:aws:imagebuilder:us-east-1:aws:workflow/build/build-container/1.0.1/1.
+ *
+ * It adds a DockerSetup step after bootstrapping but before the Docker image is built.
+ *
+ * @internal
+ */
+export function generateBuildWorkflowWithDockerSetupCommands(scope: Construct, id: string, dockerSetupCommands: string[]) {
+  return new Workflow(scope, id, {
+    type: 'BUILD',
+    data: {
+      name: 'build-container',
+      description: 'Workflow to build a container image',
+      schemaVersion: 1,
+      steps: [
+        {
+          name: 'LaunchBuildInstance',
+          action: 'LaunchInstance',
+          onFailure: 'Abort',
+          inputs: {
+            waitFor: 'ssmAgent',
+          },
+        },
+        {
+          name: 'BootstrapBuildInstance',
+          action: 'BootstrapInstanceForContainer',
+          onFailure: 'Abort',
+          if: {
+            stringEquals: 'DOCKER',
+            value: '$.imagebuilder.imageType',
+          },
+          inputs: {
+            'instanceId.$': '$.stepOutputs.LaunchBuildInstance.instanceId',
+          },
+        },
+        {
+          name: 'DockerSetup',
+          action: 'RunCommand',
+          onFailure: 'Abort',
+          if: {
+            stringEquals: 'DOCKER',
+            value: '$.imagebuilder.imageType',
+          },
+          inputs: {
+            'documentName': 'AWS-RunShellScript',
+            'parameters': {
+              commands: dockerSetupCommands,
+            },
+            'instanceId.$': '$.stepOutputs.LaunchBuildInstance.instanceId',
+          },
+        },
+        {
+          name: 'ApplyBuildComponents',
+          action: 'ExecuteComponents',
+          onFailure: 'Abort',
+          inputs: {
+            'instanceId.$': '$.stepOutputs.LaunchBuildInstance.instanceId',
+          },
+        },
+      ],
+      outputs: [
+        {
+          name: 'InstanceId',
+          value: '$.stepOutputs.LaunchBuildInstance.instanceId',
+        },
+      ],
+    },
+  });
+}

--- a/src/image-builders/common.ts
+++ b/src/image-builders/common.ts
@@ -146,9 +146,20 @@ export interface RunnerImageBuilderProps {
   /**
    * Base image from which Docker runner images will be built.
    *
+   * When using private images from a different account or not on ECR, you may need to include additional setup commands with {@link dockerSetupCommands}.
+   *
    * @default public.ecr.aws/lts/ubuntu:22.04 for Os.LINUX_UBUNTU, public.ecr.aws/amazonlinux/amazonlinux:2 for Os.LINUX_AMAZON_2, mcr.microsoft.com/windows/servercore:ltsc2019-amd64 for Os.WINDOWS
    */
   readonly baseDockerImage?: string;
+
+  /**
+   * Additional commands to run on the build host before starting the Docker runner image build.
+   *
+   * Use this to execute commands such as `docker login` or `aws ecr get-login-password` to pull private base images.
+   *
+   * @default []
+   */
+  readonly dockerSetupCommands?: string[];
 
   /**
    * Base AMI from which runner AMIs will be built.

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -27,15 +27,15 @@
         }
       }
     },
-    "deaec75154c038cd6fec17fd19b905a08bb9a78b97bc2e0fd132505eda22c650": {
+    "e11957e91069e38a8e846330a30f318c4bd52e5184eb9e1989f2fb1ee51f792d": {
       "source": {
-        "path": "asset.deaec75154c038cd6fec17fd19b905a08bb9a78b97bc2e0fd132505eda22c650.lambda",
+        "path": "asset.e11957e91069e38a8e846330a30f318c4bd52e5184eb9e1989f2fb1ee51f792d.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "deaec75154c038cd6fec17fd19b905a08bb9a78b97bc2e0fd132505eda22c650.zip",
+          "objectKey": "e11957e91069e38a8e846330a30f318c4bd52e5184eb9e1989f2fb1ee51f792d.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -209,7 +209,7 @@
         }
       }
     },
-    "3d73c0dc4026320310e3840669f8caa904429c36241fe5e00d41a67c7d9b0ef8": {
+    "923def6fb4b4595a3773d4d5d17bbe03ad63ff0a7dd8087e6cc14aed71e5b643": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -217,7 +217,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "3d73c0dc4026320310e3840669f8caa904429c36241fe5e00d41a67c7d9b0ef8.json",
+          "objectKey": "923def6fb4b4595a3773d4d5d17bbe03ad63ff0a7dd8087e6cc14aed71e5b643.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -9125,7 +9125,8 @@
        "Action": [
         "imagebuilder:ListComponents",
         "imagebuilder:ListContainerRecipes",
-        "imagebuilder:ListImageRecipes"
+        "imagebuilder:ListImageRecipes",
+        "imagebuilder:ListWorkflows"
        ],
        "Effect": "Allow",
        "Resource": "*"
@@ -9148,7 +9149,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "deaec75154c038cd6fec17fd19b905a08bb9a78b97bc2e0fd132505eda22c650.zip"
+     "S3Key": "e11957e91069e38a8e846330a30f318c4bd52e5184eb9e1989f2fb1ee51f792d.zip"
     },
     "Description": "Custom resource handler that bumps up Image Builder versions",
     "Environment": {


### PR DESCRIPTION
Add a new `dockerSetupCommands` property to runner image builders that lets you run arbitrary commands before `docker build` is called. Use this property to specify login commands such as `docker login` or `aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 1234567890.dkr.ecr.us-east-1.amazonaws.com`.

For example:

```typescript
const myBuilder = FargateRunnerProvider.imageBuilder(this, 'image builder', {
  baseDockerImage: 'some-private-image:latest',
  dockerSetupCommands: [
    'DOCKER_USER=$(aws ssm get-parameter --name /github-runners/docker-user --query Parameter.Value --output text)',
    'DOCKER_PASS=$(aws ssm get-parameter --name /github-runners/docker-pass --query Parameter.Value --output text)',
    'docker login -u $DOCKER_USER -p $DOCKER_PASS'
  ],
});
ssm.StringParameter.fromStringParameterName(this, 'docker-user', '/github-runners/docker-user').grantRead(myBuilder);
ssm.StringParameter.fromStringParameterName(this, 'docker-user', '/github-runners/docker-password').grantRead(myBuilder);

const myProvider = new FargateRunnerProvider(this, 'fargate runner', {
  labels: ['customized-fargate'],
  imageBuilder: myBuilder,
});

// create the runner infrastructure
new GitHubRunners(this, 'runners', {
  providers: [myProvider],
});
```

Resolves #399