### PR TITLE
fix: Windows EC2 runner logs stopped working

### DIFF
--- a/src/providers/ec2.ts
+++ b/src/providers/ec2.ts
@@ -120,23 +120,23 @@ Start-Job -ScriptBlock {
   }
 }
 function setup_logs () {
-  echo '{
-    "logs": {
-      "log_stream_name": "unknown",
-      "logs_collected": {
-        "files": {
-         "collect_list": [
+  echo "{
+    \`"logs\`": {
+      \`"log_stream_name\`": \`"unknown\`",
+      \`"logs_collected\`": {
+        \`"files\`": {
+         \`"collect_list\`": [
             {
-              "file_path": "/actions/runner.log",
-              "log_group_name": "$logGroupName",
-              "log_stream_name": "$runnerNamePath",
-              "timezone": "UTC"
+              \`"file_path\`": \`"/actions/runner.log\`",
+              \`"log_group_name\`": \`"$logGroupName\`",
+              \`"log_stream_name\`": \`"$runnerNamePath\`",
+              \`"timezone\`": \`"UTC\`"
             }
           ]
         }
       }
     }
-  }' | Out-File -Encoding ASCII $Env:TEMP/log.conf
+  }" | Out-File -Encoding ASCII $Env:TEMP/log.conf
   & "C:/Program Files/Amazon/AmazonCloudWatchAgent/amazon-cloudwatch-agent-ctl.ps1" -a fetch-config -m ec2 -s -c file:$Env:TEMP/log.conf
 }
 function action () {
@@ -156,7 +156,6 @@ function action () {
   }
 
   return 0
-
 }
 setup_logs
 $r = action

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -27,15 +27,15 @@
         }
       }
     },
-    "e11957e91069e38a8e846330a30f318c4bd52e5184eb9e1989f2fb1ee51f792d": {
+    "7dda72d049ee1a780f0ceacddcd4131167d87b353f9fff2084192b577c01941b": {
       "source": {
-        "path": "asset.e11957e91069e38a8e846330a30f318c4bd52e5184eb9e1989f2fb1ee51f792d.lambda",
+        "path": "asset.7dda72d049ee1a780f0ceacddcd4131167d87b353f9fff2084192b577c01941b.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "e11957e91069e38a8e846330a30f318c4bd52e5184eb9e1989f2fb1ee51f792d.zip",
+          "objectKey": "7dda72d049ee1a780f0ceacddcd4131167d87b353f9fff2084192b577c01941b.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -105,41 +105,41 @@
         }
       }
     },
-    "e4ac7e9be9abde086a27b8b2eb2e4b59dde9a52c2cbdef3266d67ceafaf4dafe": {
+    "504d564ea2a6e430371fb905052eeb8336c72ac079819320a701989930887ff8": {
       "source": {
-        "path": "asset.e4ac7e9be9abde086a27b8b2eb2e4b59dde9a52c2cbdef3266d67ceafaf4dafe.lambda",
+        "path": "asset.504d564ea2a6e430371fb905052eeb8336c72ac079819320a701989930887ff8.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "e4ac7e9be9abde086a27b8b2eb2e4b59dde9a52c2cbdef3266d67ceafaf4dafe.zip",
+          "objectKey": "504d564ea2a6e430371fb905052eeb8336c72ac079819320a701989930887ff8.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "16bb1d322fead6e35092941eced41b07006f6ef31dbe6283dbaad26cffb70fa8": {
+    "13fdb64fafad52754d430269cff3dfd8fd4a7008b3e47b3d4b8e21646e637a05": {
       "source": {
-        "path": "asset.16bb1d322fead6e35092941eced41b07006f6ef31dbe6283dbaad26cffb70fa8.lambda",
+        "path": "asset.13fdb64fafad52754d430269cff3dfd8fd4a7008b3e47b3d4b8e21646e637a05.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "16bb1d322fead6e35092941eced41b07006f6ef31dbe6283dbaad26cffb70fa8.zip",
+          "objectKey": "13fdb64fafad52754d430269cff3dfd8fd4a7008b3e47b3d4b8e21646e637a05.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "d90f56ab5772627b156240c90daa136819b2540625a789b227351862f504f8ce": {
+    "c9511f70ac00492def74898c932256f78307408908cc695b3717a7dd627eb8d8": {
       "source": {
-        "path": "asset.d90f56ab5772627b156240c90daa136819b2540625a789b227351862f504f8ce.lambda",
+        "path": "asset.c9511f70ac00492def74898c932256f78307408908cc695b3717a7dd627eb8d8.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "d90f56ab5772627b156240c90daa136819b2540625a789b227351862f504f8ce.zip",
+          "objectKey": "c9511f70ac00492def74898c932256f78307408908cc695b3717a7dd627eb8d8.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -157,41 +157,41 @@
         }
       }
     },
-    "89312fab9eebb39d2c29004774d33b212c37c8fd8b0f0efb6679f51b655cf37a": {
+    "6e98a8cb30b9f206bbd9a2ff9ab8c53a2c1c0154bc9e28205ed66954a2a6cfd7": {
       "source": {
-        "path": "asset.89312fab9eebb39d2c29004774d33b212c37c8fd8b0f0efb6679f51b655cf37a.lambda",
+        "path": "asset.6e98a8cb30b9f206bbd9a2ff9ab8c53a2c1c0154bc9e28205ed66954a2a6cfd7.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "89312fab9eebb39d2c29004774d33b212c37c8fd8b0f0efb6679f51b655cf37a.zip",
+          "objectKey": "6e98a8cb30b9f206bbd9a2ff9ab8c53a2c1c0154bc9e28205ed66954a2a6cfd7.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "5987a611e9168843d79fb39ca673903e4f133351b42b7164b83e23c16c04ccc9": {
+    "8b91411853240d72134e16de3b712eaeab74d7d330c4f75d02228c1c62cb5399": {
       "source": {
-        "path": "asset.5987a611e9168843d79fb39ca673903e4f133351b42b7164b83e23c16c04ccc9.lambda",
+        "path": "asset.8b91411853240d72134e16de3b712eaeab74d7d330c4f75d02228c1c62cb5399.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "5987a611e9168843d79fb39ca673903e4f133351b42b7164b83e23c16c04ccc9.zip",
+          "objectKey": "8b91411853240d72134e16de3b712eaeab74d7d330c4f75d02228c1c62cb5399.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "df8fb3414e77729d9473bb558510fc4443ee14d85587f41e02fa98f06ada9ed6": {
+    "7e43d3b79aefb1051754b4f5c64c78ff9004735b2887924909c0291ce9063911": {
       "source": {
-        "path": "asset.df8fb3414e77729d9473bb558510fc4443ee14d85587f41e02fa98f06ada9ed6.lambda",
+        "path": "asset.7e43d3b79aefb1051754b4f5c64c78ff9004735b2887924909c0291ce9063911.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "df8fb3414e77729d9473bb558510fc4443ee14d85587f41e02fa98f06ada9ed6.zip",
+          "objectKey": "7e43d3b79aefb1051754b4f5c64c78ff9004735b2887924909c0291ce9063911.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -209,7 +209,7 @@
         }
       }
     },
-    "ef0b9a062d46904f9afa9477604b3b1a6ba2c9521223489ccf564176314f55c2": {
+    "7e31d5548fbce527f8c0e4c0bab79dc8ae721e24c4f2934f30d81301929ae02d": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -217,7 +217,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "ef0b9a062d46904f9afa9477604b3b1a6ba2c9521223489ccf564176314f55c2.json",
+          "objectKey": "7e31d5548fbce527f8c0e4c0bab79dc8ae721e24c4f2934f30d81301929ae02d.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -27,15 +27,15 @@
         }
       }
     },
-    "7dda72d049ee1a780f0ceacddcd4131167d87b353f9fff2084192b577c01941b": {
+    "e11957e91069e38a8e846330a30f318c4bd52e5184eb9e1989f2fb1ee51f792d": {
       "source": {
-        "path": "asset.7dda72d049ee1a780f0ceacddcd4131167d87b353f9fff2084192b577c01941b.lambda",
+        "path": "asset.e11957e91069e38a8e846330a30f318c4bd52e5184eb9e1989f2fb1ee51f792d.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "7dda72d049ee1a780f0ceacddcd4131167d87b353f9fff2084192b577c01941b.zip",
+          "objectKey": "e11957e91069e38a8e846330a30f318c4bd52e5184eb9e1989f2fb1ee51f792d.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -105,41 +105,41 @@
         }
       }
     },
-    "504d564ea2a6e430371fb905052eeb8336c72ac079819320a701989930887ff8": {
+    "e4ac7e9be9abde086a27b8b2eb2e4b59dde9a52c2cbdef3266d67ceafaf4dafe": {
       "source": {
-        "path": "asset.504d564ea2a6e430371fb905052eeb8336c72ac079819320a701989930887ff8.lambda",
+        "path": "asset.e4ac7e9be9abde086a27b8b2eb2e4b59dde9a52c2cbdef3266d67ceafaf4dafe.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "504d564ea2a6e430371fb905052eeb8336c72ac079819320a701989930887ff8.zip",
+          "objectKey": "e4ac7e9be9abde086a27b8b2eb2e4b59dde9a52c2cbdef3266d67ceafaf4dafe.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "13fdb64fafad52754d430269cff3dfd8fd4a7008b3e47b3d4b8e21646e637a05": {
+    "16bb1d322fead6e35092941eced41b07006f6ef31dbe6283dbaad26cffb70fa8": {
       "source": {
-        "path": "asset.13fdb64fafad52754d430269cff3dfd8fd4a7008b3e47b3d4b8e21646e637a05.lambda",
+        "path": "asset.16bb1d322fead6e35092941eced41b07006f6ef31dbe6283dbaad26cffb70fa8.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "13fdb64fafad52754d430269cff3dfd8fd4a7008b3e47b3d4b8e21646e637a05.zip",
+          "objectKey": "16bb1d322fead6e35092941eced41b07006f6ef31dbe6283dbaad26cffb70fa8.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "c9511f70ac00492def74898c932256f78307408908cc695b3717a7dd627eb8d8": {
+    "d90f56ab5772627b156240c90daa136819b2540625a789b227351862f504f8ce": {
       "source": {
-        "path": "asset.c9511f70ac00492def74898c932256f78307408908cc695b3717a7dd627eb8d8.lambda",
+        "path": "asset.d90f56ab5772627b156240c90daa136819b2540625a789b227351862f504f8ce.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "c9511f70ac00492def74898c932256f78307408908cc695b3717a7dd627eb8d8.zip",
+          "objectKey": "d90f56ab5772627b156240c90daa136819b2540625a789b227351862f504f8ce.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -157,41 +157,41 @@
         }
       }
     },
-    "6e98a8cb30b9f206bbd9a2ff9ab8c53a2c1c0154bc9e28205ed66954a2a6cfd7": {
+    "89312fab9eebb39d2c29004774d33b212c37c8fd8b0f0efb6679f51b655cf37a": {
       "source": {
-        "path": "asset.6e98a8cb30b9f206bbd9a2ff9ab8c53a2c1c0154bc9e28205ed66954a2a6cfd7.lambda",
+        "path": "asset.89312fab9eebb39d2c29004774d33b212c37c8fd8b0f0efb6679f51b655cf37a.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "6e98a8cb30b9f206bbd9a2ff9ab8c53a2c1c0154bc9e28205ed66954a2a6cfd7.zip",
+          "objectKey": "89312fab9eebb39d2c29004774d33b212c37c8fd8b0f0efb6679f51b655cf37a.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "8b91411853240d72134e16de3b712eaeab74d7d330c4f75d02228c1c62cb5399": {
+    "5987a611e9168843d79fb39ca673903e4f133351b42b7164b83e23c16c04ccc9": {
       "source": {
-        "path": "asset.8b91411853240d72134e16de3b712eaeab74d7d330c4f75d02228c1c62cb5399.lambda",
+        "path": "asset.5987a611e9168843d79fb39ca673903e4f133351b42b7164b83e23c16c04ccc9.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "8b91411853240d72134e16de3b712eaeab74d7d330c4f75d02228c1c62cb5399.zip",
+          "objectKey": "5987a611e9168843d79fb39ca673903e4f133351b42b7164b83e23c16c04ccc9.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "7e43d3b79aefb1051754b4f5c64c78ff9004735b2887924909c0291ce9063911": {
+    "df8fb3414e77729d9473bb558510fc4443ee14d85587f41e02fa98f06ada9ed6": {
       "source": {
-        "path": "asset.7e43d3b79aefb1051754b4f5c64c78ff9004735b2887924909c0291ce9063911.lambda",
+        "path": "asset.df8fb3414e77729d9473bb558510fc4443ee14d85587f41e02fa98f06ada9ed6.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "7e43d3b79aefb1051754b4f5c64c78ff9004735b2887924909c0291ce9063911.zip",
+          "objectKey": "df8fb3414e77729d9473bb558510fc4443ee14d85587f41e02fa98f06ada9ed6.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -209,7 +209,7 @@
         }
       }
     },
-    "d4d31e589c55a993d885b7596244486391ab052b0b28bcab8afdcd20d5c4dd3c": {
+    "ef0b9a062d46904f9afa9477604b3b1a6ba2c9521223489ccf564176314f55c2": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -217,7 +217,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "d4d31e589c55a993d885b7596244486391ab052b0b28bcab8afdcd20d5c4dd3c.json",
+          "objectKey": "ef0b9a062d46904f9afa9477604b3b1a6ba2c9521223489ccf564176314f55c2.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -9149,7 +9149,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "7dda72d049ee1a780f0ceacddcd4131167d87b353f9fff2084192b577c01941b.zip"
+     "S3Key": "e11957e91069e38a8e846330a30f318c4bd52e5184eb9e1989f2fb1ee51f792d.zip"
     },
     "Description": "Custom resource handler that bumps up Image Builder versions",
     "Environment": {
@@ -13831,7 +13831,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "504d564ea2a6e430371fb905052eeb8336c72ac079819320a701989930887ff8.zip"
+     "S3Key": "e4ac7e9be9abde086a27b8b2eb2e4b59dde9a52c2cbdef3266d67ceafaf4dafe.zip"
     },
     "Description": "Get token from GitHub Actions used to start new self-hosted runner",
     "Environment": {
@@ -13940,7 +13940,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "13fdb64fafad52754d430269cff3dfd8fd4a7008b3e47b3d4b8e21646e637a05.zip"
+     "S3Key": "16bb1d322fead6e35092941eced41b07006f6ef31dbe6283dbaad26cffb70fa8.zip"
     },
     "Description": "Delete failed GitHub Actions runner on error",
     "Environment": {
@@ -14164,7 +14164,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "c9511f70ac00492def74898c932256f78307408908cc695b3717a7dd627eb8d8.zip"
+     "S3Key": "d90f56ab5772627b156240c90daa136819b2540625a789b227351862f504f8ce.zip"
     },
     "Description": "Stop idle GitHub runners to avoid paying for runners when the job was already canceled",
     "Environment": {
@@ -16123,7 +16123,7 @@
        {
         "Ref": "EC2Linuxarm64AMIRootDevice3046D37D"
        },
-       "\",\"Ebs\":{\"DeleteOnTermination\":true,\"VolumeSize\":30}}]}},\"ec2, windows, x64 data\":{\"Type\":\"Pass\",\"ResultPath\":\"$.ec2\",\"Parameters\":{\"userdataTemplate\":\"<powershell>\\n$TASK_TOKEN = \\\"{}\\\"\\n$logGroupName=\\\"{}\\\"\\n$runnerNamePath=\\\"{}\\\"\\n$githubDomainPath=\\\"{}\\\"\\n$ownerPath=\\\"{}\\\"\\n$repoPath=\\\"{}\\\"\\n$runnerTokenPath=\\\"{}\\\"\\n$labels=\\\"{}\\\"\\n$registrationURL=\\\"{}\\\"\\n\\nStart-Job -ScriptBlock \\\\{\\n  while (1) \\\\{\\n    aws stepfunctions send-task-heartbeat --task-token \\\"$using:TASK_TOKEN\\\"\\n    sleep 60\\n  \\\\}\\n\\\\}\\nfunction setup_logs () \\\\{\\n  echo '\\\\{\\n    \\\"logs\\\": \\\\{\\n      \\\"log_stream_name\\\": \\\"unknown\\\",\\n      \\\"logs_collected\\\": \\\\{\\n        \\\"files\\\": \\\\{\\n         \\\"collect_list\\\": [\\n            \\\\{\\n              \\\"file_path\\\": \\\"/actions/runner.log\\\",\\n              \\\"log_group_name\\\": \\\"$logGroupName\\\",\\n              \\\"log_stream_name\\\": \\\"$runnerNamePath\\\",\\n              \\\"timezone\\\": \\\"UTC\\\"\\n            \\\\}\\n          ]\\n        \\\\}\\n      \\\\}\\n    \\\\}\\n  \\\\}' | Out-File -Encoding ASCII $Env:TEMP/log.conf\\n  & \\\"C:/Program Files/Amazon/AmazonCloudWatchAgent/amazon-cloudwatch-agent-ctl.ps1\\\" -a fetch-config -m ec2 -s -c file:$Env:TEMP/log.conf\\n\\\\}\\nfunction action () \\\\{\\n  cd /actions\\n  $RunnerVersion = Get-Content RUNNER_VERSION -Raw\\n  if ($RunnerVersion -eq \\\"latest\\\") \\\\{ $RunnerFlags = \\\"\\\" \\\\} else \\\\{ $RunnerFlags = \\\"--disableupdate\\\" \\\\}\\n  ./config.cmd --unattended --url \\\"$\\\\{registrationUrl\\\\}\\\" --token \\\"$\\\\{runnerTokenPath\\\\}\\\" --ephemeral --work _work --labels \\\"$\\\\{labels\\\\},cdkghr:started:$(Get-Date -UFormat +%s)\\\" $RunnerFlags --name \\\"$\\\\{runnerNamePath\\\\}\\\" 2>&1 | Out-File -Encoding ASCII -Append /actions/runner.log\\n\\n  if ($LASTEXITCODE -ne 0) \\\\{ return 1 \\\\}\\n  ./run.cmd 2>&1 | Out-File -Encoding ASCII -Append /actions/runner.log\\n  if ($LASTEXITCODE -ne 0) \\\\{ return 2 \\\\}\\n\\n  $STATUS = Select-String -Path './_diag/*.log' -Pattern 'finish job request for job [0-9a-f\\\\-]+ with result: (.*)' | %\\\\{$_.Matches.Groups[1].Value\\\\} | Select-Object -Last 1\\n\\n  if ($STATUS) \\\\{\\n      echo \\\"CDKGHA JOB DONE $\\\\{labels\\\\} $STATUS\\\" | Out-File -Encoding ASCII -Append /actions/runner.log\\n  \\\\}\\n\\n  return 0\\n\\n\\\\}\\nsetup_logs\\n$r = action\\nif ($r -eq 0) \\\\{\\n  aws stepfunctions send-task-success --task-token \\\"$TASK_TOKEN\\\" --task-output '\\\\{ \\\\}'\\n\\\\} else \\\\{\\n  aws stepfunctions send-task-failure --task-token \\\"$TASK_TOKEN\\\"\\n\\\\}\\nStart-Sleep -Seconds 10  # give cloudwatch agent its default 5 seconds buffer duration to upload logs\\nStop-Computer -ComputerName localhost -Force\\n</powershell>\\n\"},\"Next\":\"ec2, windows, x64 subnet1\"},\"ec2, windows, x64 subnet1\":{\"End\":true,\"Catch\":[{\"ErrorEquals\":[\"Ec2.Ec2Exception\",\"States.Timeout\"],\"ResultPath\":\"$.lastSubnetError\",\"Next\":\"ec2, windows, x64 subnet2\"}],\"Type\":\"Task\",\"Comment\":\"",
+       "\",\"Ebs\":{\"DeleteOnTermination\":true,\"VolumeSize\":30}}]}},\"ec2, windows, x64 data\":{\"Type\":\"Pass\",\"ResultPath\":\"$.ec2\",\"Parameters\":{\"userdataTemplate\":\"<powershell>\\n$TASK_TOKEN = \\\"{}\\\"\\n$logGroupName=\\\"{}\\\"\\n$runnerNamePath=\\\"{}\\\"\\n$githubDomainPath=\\\"{}\\\"\\n$ownerPath=\\\"{}\\\"\\n$repoPath=\\\"{}\\\"\\n$runnerTokenPath=\\\"{}\\\"\\n$labels=\\\"{}\\\"\\n$registrationURL=\\\"{}\\\"\\n\\nStart-Job -ScriptBlock \\\\{\\n  while (1) \\\\{\\n    aws stepfunctions send-task-heartbeat --task-token \\\"$using:TASK_TOKEN\\\"\\n    sleep 60\\n  \\\\}\\n\\\\}\\nfunction setup_logs () \\\\{\\n  echo \\\"\\\\{\\n    `\\\"logs`\\\": \\\\{\\n      `\\\"log_stream_name`\\\": `\\\"unknown`\\\",\\n      `\\\"logs_collected`\\\": \\\\{\\n        `\\\"files`\\\": \\\\{\\n         `\\\"collect_list`\\\": [\\n            \\\\{\\n              `\\\"file_path`\\\": `\\\"/actions/runner.log`\\\",\\n              `\\\"log_group_name`\\\": `\\\"$logGroupName`\\\",\\n              `\\\"log_stream_name`\\\": `\\\"$runnerNamePath`\\\",\\n              `\\\"timezone`\\\": `\\\"UTC`\\\"\\n            \\\\}\\n          ]\\n        \\\\}\\n      \\\\}\\n    \\\\}\\n  \\\\}\\\" | Out-File -Encoding ASCII $Env:TEMP/log.conf\\n  & \\\"C:/Program Files/Amazon/AmazonCloudWatchAgent/amazon-cloudwatch-agent-ctl.ps1\\\" -a fetch-config -m ec2 -s -c file:$Env:TEMP/log.conf\\n\\\\}\\nfunction action () \\\\{\\n  cd /actions\\n  $RunnerVersion = Get-Content RUNNER_VERSION -Raw\\n  if ($RunnerVersion -eq \\\"latest\\\") \\\\{ $RunnerFlags = \\\"\\\" \\\\} else \\\\{ $RunnerFlags = \\\"--disableupdate\\\" \\\\}\\n  ./config.cmd --unattended --url \\\"$\\\\{registrationUrl\\\\}\\\" --token \\\"$\\\\{runnerTokenPath\\\\}\\\" --ephemeral --work _work --labels \\\"$\\\\{labels\\\\},cdkghr:started:$(Get-Date -UFormat +%s)\\\" $RunnerFlags --name \\\"$\\\\{runnerNamePath\\\\}\\\" 2>&1 | Out-File -Encoding ASCII -Append /actions/runner.log\\n\\n  if ($LASTEXITCODE -ne 0) \\\\{ return 1 \\\\}\\n  ./run.cmd 2>&1 | Out-File -Encoding ASCII -Append /actions/runner.log\\n  if ($LASTEXITCODE -ne 0) \\\\{ return 2 \\\\}\\n\\n  $STATUS = Select-String -Path './_diag/*.log' -Pattern 'finish job request for job [0-9a-f\\\\-]+ with result: (.*)' | %\\\\{$_.Matches.Groups[1].Value\\\\} | Select-Object -Last 1\\n\\n  if ($STATUS) \\\\{\\n      echo \\\"CDKGHA JOB DONE $\\\\{labels\\\\} $STATUS\\\" | Out-File -Encoding ASCII -Append /actions/runner.log\\n  \\\\}\\n\\n  return 0\\n\\\\}\\nsetup_logs\\n$r = action\\nif ($r -eq 0) \\\\{\\n  aws stepfunctions send-task-success --task-token \\\"$TASK_TOKEN\\\" --task-output '\\\\{ \\\\}'\\n\\\\} else \\\\{\\n  aws stepfunctions send-task-failure --task-token \\\"$TASK_TOKEN\\\"\\n\\\\}\\nStart-Sleep -Seconds 10  # give cloudwatch agent its default 5 seconds buffer duration to upload logs\\nStop-Computer -ComputerName localhost -Force\\n</powershell>\\n\"},\"Next\":\"ec2, windows, x64 subnet1\"},\"ec2, windows, x64 subnet1\":{\"End\":true,\"Catch\":[{\"ErrorEquals\":[\"Ec2.Ec2Exception\",\"States.Timeout\"],\"ResultPath\":\"$.lastSubnetError\",\"Next\":\"ec2, windows, x64 subnet2\"}],\"Type\":\"Task\",\"Comment\":\"",
        {
         "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
        },
@@ -16315,7 +16315,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "6e98a8cb30b9f206bbd9a2ff9ab8c53a2c1c0154bc9e28205ed66954a2a6cfd7.zip"
+     "S3Key": "89312fab9eebb39d2c29004774d33b212c37c8fd8b0f0efb6679f51b655cf37a.zip"
     },
     "Description": "Handle GitHub webhook and start runner orchestrator",
     "Environment": {
@@ -16498,7 +16498,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "8b91411853240d72134e16de3b712eaeab74d7d330c4f75d02228c1c62cb5399.zip"
+     "S3Key": "5987a611e9168843d79fb39ca673903e4f133351b42b7164b83e23c16c04ccc9.zip"
     },
     "Description": "Setup GitHub Actions integration with self-hosted runners",
     "Environment": {
@@ -16808,7 +16808,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "7e43d3b79aefb1051754b4f5c64c78ff9004735b2887924909c0291ce9063911.zip"
+     "S3Key": "df8fb3414e77729d9473bb558510fc4443ee14d85587f41e02fa98f06ada9ed6.zip"
     },
     "Description": "Provide user with status about self-hosted GitHub Actions runners",
     "Environment": {

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -9149,7 +9149,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "e11957e91069e38a8e846330a30f318c4bd52e5184eb9e1989f2fb1ee51f792d.zip"
+     "S3Key": "7dda72d049ee1a780f0ceacddcd4131167d87b353f9fff2084192b577c01941b.zip"
     },
     "Description": "Custom resource handler that bumps up Image Builder versions",
     "Environment": {
@@ -13831,7 +13831,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "e4ac7e9be9abde086a27b8b2eb2e4b59dde9a52c2cbdef3266d67ceafaf4dafe.zip"
+     "S3Key": "504d564ea2a6e430371fb905052eeb8336c72ac079819320a701989930887ff8.zip"
     },
     "Description": "Get token from GitHub Actions used to start new self-hosted runner",
     "Environment": {
@@ -13940,7 +13940,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "16bb1d322fead6e35092941eced41b07006f6ef31dbe6283dbaad26cffb70fa8.zip"
+     "S3Key": "13fdb64fafad52754d430269cff3dfd8fd4a7008b3e47b3d4b8e21646e637a05.zip"
     },
     "Description": "Delete failed GitHub Actions runner on error",
     "Environment": {
@@ -14164,7 +14164,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "d90f56ab5772627b156240c90daa136819b2540625a789b227351862f504f8ce.zip"
+     "S3Key": "c9511f70ac00492def74898c932256f78307408908cc695b3717a7dd627eb8d8.zip"
     },
     "Description": "Stop idle GitHub runners to avoid paying for runners when the job was already canceled",
     "Environment": {
@@ -16315,7 +16315,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "89312fab9eebb39d2c29004774d33b212c37c8fd8b0f0efb6679f51b655cf37a.zip"
+     "S3Key": "6e98a8cb30b9f206bbd9a2ff9ab8c53a2c1c0154bc9e28205ed66954a2a6cfd7.zip"
     },
     "Description": "Handle GitHub webhook and start runner orchestrator",
     "Environment": {
@@ -16498,7 +16498,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "5987a611e9168843d79fb39ca673903e4f133351b42b7164b83e23c16c04ccc9.zip"
+     "S3Key": "8b91411853240d72134e16de3b712eaeab74d7d330c4f75d02228c1c62cb5399.zip"
     },
     "Description": "Setup GitHub Actions integration with self-hosted runners",
     "Environment": {
@@ -16808,7 +16808,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "df8fb3414e77729d9473bb558510fc4443ee14d85587f41e02fa98f06ada9ed6.zip"
+     "S3Key": "7e43d3b79aefb1051754b4f5c64c78ff9004735b2887924909c0291ce9063911.zip"
     },
     "Description": "Provide user with status about self-hosted GitHub Actions runners",
     "Environment": {


### PR DESCRIPTION
The single quote prevented variable substitution. The configuration file contained literally `$logGroupName`. I'm not sure how this ever worked. Maybe the PowerShell version just got upgraded in the base AMI?

Fixes #564