### PR TITLE
feat(ec2): add github tags

### DIFF
--- a/src/providers/ec2.ts
+++ b/src/providers/ec2.ts
@@ -490,6 +490,10 @@ export class Ec2RunnerProvider extends BaseProvider implements IRunnerProvider {
               {
                 Key: 'GitHubRunners:OwnerPath',
                 Value: parameters.ownerPath,
+              },
+              {
+                Key: 'GitHubRunners:RepoPath',
+                Value: parameters.repoPath,
               }],
             },
             {

--- a/src/providers/ec2.ts
+++ b/src/providers/ec2.ts
@@ -486,6 +486,10 @@ export class Ec2RunnerProvider extends BaseProvider implements IRunnerProvider {
               Tags: [{
                 Key: 'GitHubRunners:Provider',
                 Value: this.node.path,
+              },
+              {
+                Key: 'GitHubRunners:OwnerPath',
+                Value: parameters.ownerPath,
               }],
             },
             {


### PR DESCRIPTION
this will attach the `owner` and `repo` to the ec2 instance.
Will be helpful to filter costs by owners and repositories in cost explorer.

If `organization runners` are registered it might be that a runner with provider-tag will be used for another repository.
This could lead to wrong assumptions in cost explorer.
This is expected and needs to be handled with a custom implementation. (custom hook at ec2 startup, lambda/stepfunction on ec2 startup).