### PR TITLE
fix: EbsDeviceVolumeType import error with ESM

### DIFF
--- a/src/providers/common.ts
+++ b/src/providers/common.ts
@@ -9,7 +9,7 @@ import {
   CustomResource,
   Duration,
 } from 'aws-cdk-lib';
-import { EbsDeviceVolumeType } from 'aws-cdk-lib/aws-ec2/lib/volume';
+import { EbsDeviceVolumeType } from 'aws-cdk-lib/aws-ec2';
 import { Construct, IConstruct } from 'constructs';
 import { AmiRootDeviceFunction } from './ami-root-device-function';
 import { singletonLambda, singletonLogGroup, SingletonLogType } from '../utils';


### PR DESCRIPTION
Fix for ESM specific error:

```
node_modules/@cloudsnorkel/cdk-github-runners/lib/providers/common.d.ts:3:37 - error TS2307: Cannot find module 'aws-cdk-lib/aws-ec2/lib/volume' or its corresponding type declarations.

3 import { EbsDeviceVolumeType } from 'aws-cdk-lib/aws-ec2/lib/volume';
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Found 1 error in node_modules/@cloudsnorkel/cdk-github-runners/lib/providers/common.d.ts:3
```

Fixes #647