### PR TITLE
fix: "No package docker available" on AL2

### DIFF
--- a/src/image-builders/components.ts
+++ b/src/image-builders/components.ts
@@ -386,8 +386,8 @@ export abstract class RunnerImageComponent {
           ];
         } else if (os.is(Os.LINUX_AMAZON_2)) {
           return [
-            'yum install -y docker',
-            'sudo usermod -a -G docker runner',
+            'amazon-linux-extras install docker',
+            'usermod -a -G docker runner',
             'curl -sfLo /usr/bin/docker-compose https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s | tr \'[:upper:]\' \'[:lower:]\')-$(uname -m)',
             'chmod +x /usr/bin/docker-compose',
             'ln -s /usr/bin/docker-compose /usr/libexec/docker/cli-plugins/docker-compose',
@@ -395,7 +395,7 @@ export abstract class RunnerImageComponent {
         } else if (os.is(Os.LINUX_AMAZON_2023)) {
           return [
             'dnf install -y docker',
-            'sudo usermod -a -G docker runner',
+            'usermod -a -G docker runner',
             'curl -sfLo /usr/bin/docker-compose https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s | tr \'[:upper:]\' \'[:lower:]\')-$(uname -m)',
             'chmod +x /usr/bin/docker-compose',
             'ln -s /usr/bin/docker-compose /usr/libexec/docker/cli-plugins/docker-compose',


### PR DESCRIPTION
Installing Docker on Amazon Linux 2 based images failed with:

```
4.636 No package docker available.
4.879 Error: Nothing to do
------
Dockerfile:19
--------------------
17 |
18 |     COPY component5-Docker.sh /tmp
19 | >>> RUN /tmp/component5-Docker.sh
20 |
21 |     COPY component6-GithubRunner.sh /tmp
--------------------
ERROR: failed to solve: process "/bin/sh -c /tmp/component5-Docker.sh" did not complete successfully: exit code: 1
```

Fixes #646