### PR TITLE
fix: Fail early for storage size mismatch in EC2

### DIFF
--- a/src/image-builders/aws-image-builder/builder.ts
+++ b/src/image-builders/aws-image-builder/builder.ts
@@ -321,7 +321,7 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
   private infrastructure: imagebuilder.CfnInfrastructureConfiguration | undefined;
   private readonly role: iam.Role;
   private readonly fastLaunchOptions?: FastLaunchOptions;
-  private readonly storageSize?: cdk.Size;
+  public readonly storageSize?: cdk.Size;
   private readonly waitOnDeploy: boolean;
   private readonly dockerSetupCommands: string[];
   private readonly tags: { [key: string]: string };

--- a/src/providers/ec2.ts
+++ b/src/providers/ec2.ts
@@ -25,7 +25,14 @@ import {
   RunnerVersion,
   StorageOptions,
 } from './common';
-import { IRunnerImageBuilder, RunnerImageBuilder, RunnerImageBuilderProps, RunnerImageBuilderType, RunnerImageComponent } from '../image-builders';
+import {
+  AwsImageBuilderRunnerImageBuilder,
+  IRunnerImageBuilder,
+  RunnerImageBuilder,
+  RunnerImageBuilderProps,
+  RunnerImageBuilderType,
+  RunnerImageComponent,
+} from '../image-builders';
 import { MINIMAL_EC2_SSM_SESSION_MANAGER_POLICY_STATEMENT } from '../utils';
 
 // this script is specifically made so `poweroff` is absolutely always called
@@ -390,6 +397,12 @@ export class Ec2RunnerProvider extends BaseProvider implements IRunnerProvider {
       securityGroups: this.securityGroups,
     });
     this.ami = this.amiBuilder.bindAmi();
+
+    if (this.amiBuilder instanceof AwsImageBuilderRunnerImageBuilder) {
+      if (this.amiBuilder.storageSize && this.storageSize.toBytes() < this.amiBuilder.storageSize.toBytes()) {
+        throw new Error(`Runner storage size (${this.storageSize.toGibibytes()} GiB) must be at least the same as the image builder storage size (${this.amiBuilder.storageSize.toGibibytes()} GiB)`);
+      }
+    }
 
     if (!this.ami.architecture.instanceTypeMatch(this.instanceType)) {
       throw new Error(`AMI architecture (${this.ami.architecture.name}) doesn't match runner instance type (${this.instanceType} / ${this.instanceType.architecture})`);


### PR DESCRIPTION
Throw an exception during build time if the EC2 runner storage size is smaller than the AMI size set in the image builder. Before this change, code like this:

```typescript
new GitHubRunners(stack, 'runners', {
  providers: [
    new Ec2RunnerProvider(stack, 'EC2 Linux', {
      imageBuilder: Ec2RunnerProvider.imageBuilder(stack, 'EC2 Linux Builder', {
        awsImageBuilderOptions: {
          storageSize: cdk.Size.gibibytes(100),
        },
      }),
      storageSize: cdk.Size.gibibytes(30),
    }),
  ],
});
```

could result in errors in the step function that are harder to debug:

```
Ec2.Ec2Exception: Volume of size 30GB is smaller than snapshot 'snap-0123456789abc', expect size>= 100GB
```