### PR TITLE
fix: Fargate provider storage size setting doesn't work

### DIFF
--- a/src/providers/fargate.ts
+++ b/src/providers/fargate.ts
@@ -435,7 +435,7 @@ export class FargateRunnerProvider extends BaseProvider implements IRunnerProvid
       {
         cpu: props?.cpu ?? 1024,
         memoryLimitMiB: props?.memoryLimitMiB ?? 2048,
-        ephemeralStorageGiB: props?.ephemeralStorageGiB ?? !image.os.is(Os.WINDOWS) ? 25 : undefined,
+        ephemeralStorageGiB: props?.ephemeralStorageGiB ?? (!image.os.is(Os.WINDOWS) ? 25 : undefined),
         runtimePlatform: {
           operatingSystemFamily: os,
           cpuArchitecture: arch,

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -39,7 +39,7 @@ test('CodeBuild provider privileged', () => {
     Environment: {
       PrivilegedMode: true,
     },
-  }), 2/*runners*/+3/*image builders*/);
+  }), 2/*runners*/ + 3/*image builders*/);
 
   template.hasResourceProperties('AWS::CodeBuild::Project', Match.objectLike({
     Environment: {
@@ -73,6 +73,7 @@ test('Fargate provider', () => {
   new FargateRunnerProvider(stack, 'provider', {
     vpc: vpc,
     securityGroups: [sg],
+    ephemeralStorageGiB: 100,
   });
 
   const template = Template.fromStack(stack);
@@ -87,6 +88,7 @@ test('Fargate provider', () => {
         Name: 'runner',
       },
     ],
+    EphemeralStorage: { SizeInGiB: 100 },
   }));
 });
 


### PR DESCRIPTION
- Corrected the logical grouping of the nullish coalescing operator and ternary operator for the ephemeralStorageGiB property.
- Ensured that the ephemeralStorageGiB property is correctly set when provided in the props.
- This fix ensures that the correct storage value is reflected in the synthesized CloudFormation template.
- Prior to this fix the storage value would always be set to 25