### PR TITLE
fix: Duplicate webhook prevention regression in 0.14.9

### DIFF
--- a/src/webhook-handler.lambda.ts
+++ b/src/webhook-handler.lambda.ts
@@ -90,8 +90,8 @@ function matchLabelsToProvider(labels: string[]) {
  *
  * @internal
  */
-export function generateExecutionName(payload: any): string {
-  const deliveryId = payload.workflow_job?.id || `${Math.random()}`;
+export function generateExecutionName(event: any, payload: any): string {
+  const deliveryId = getHeader(event, 'x-github-delivery') ?? `${Math.random()}`;
   const repoNameTruncated = payload.repository.name.slice(0, 64 - deliveryId.length - 1);
   return `${repoNameTruncated}-${deliveryId}`;
 }
@@ -189,7 +189,7 @@ export async function handler(event: AWSLambda.APIGatewayProxyEventV2): Promise<
   }
 
   // start execution
-  const executionName = generateExecutionName(payload);
+  const executionName = generateExecutionName(event, payload);
   const input = {
     owner: payload.repository.owner.login,
     repo: payload.repository.name,

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -157,15 +157,15 @@
         }
       }
     },
-    "00120244ae5e4345094dc9fcef69d916ba0c883d912b264870bd3b2e3c09b423": {
+    "f4e33dde6e4b6972cf8182a12da780a98561fc6b6fbefe86b315121a3054e05e": {
       "source": {
-        "path": "asset.00120244ae5e4345094dc9fcef69d916ba0c883d912b264870bd3b2e3c09b423.lambda",
+        "path": "asset.f4e33dde6e4b6972cf8182a12da780a98561fc6b6fbefe86b315121a3054e05e.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "00120244ae5e4345094dc9fcef69d916ba0c883d912b264870bd3b2e3c09b423.zip",
+          "objectKey": "f4e33dde6e4b6972cf8182a12da780a98561fc6b6fbefe86b315121a3054e05e.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -209,7 +209,7 @@
         }
       }
     },
-    "78b49f7fe17230cd930cd62cce6fb0459f5b73fc96ff8bc5fb6b5875ba1a6464": {
+    "66bdf80391667760e9feaf24a0d6b14f115823b722a2fb48a50bb87619e0fb8f": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -217,7 +217,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "78b49f7fe17230cd930cd62cce6fb0459f5b73fc96ff8bc5fb6b5875ba1a6464.json",
+          "objectKey": "66bdf80391667760e9feaf24a0d6b14f115823b722a2fb48a50bb87619e0fb8f.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -18917,7 +18917,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "00120244ae5e4345094dc9fcef69d916ba0c883d912b264870bd3b2e3c09b423.zip"
+     "S3Key": "f4e33dde6e4b6972cf8182a12da780a98561fc6b6fbefe86b315121a3054e05e.zip"
     },
     "Description": "Handle GitHub webhook and start runner orchestrator",
     "Environment": {

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -67,7 +67,14 @@ test('Signature verification', () => {
 
   const generatedName = generateExecutionName(
     {
-      workflow_job: { id: 'ea8a0021-6ba6-4986-9102-51c567e55733' },
+      headers: {
+        'content-type': 'application/json',
+        'x-github-event': 'workflow_job',
+        'x-hub-signature-256': 'sha256=57aa67ee965ce46922aa32fe939e794fbb6df5c93809bf46ed24fc13714a0506',
+        'x-github-delivery': 'ea8a0021-6ba6-4986-9102-51c567e55733',
+      },
+    },
+    {
       repository: { name: 'my-repo-name-that-is-very-long-and-should-be-truncated' },
     },
   );


### PR DESCRIPTION
Some code accidentally made its way into to the last release that caused invalid step function execution name. They are supposed to be based on the webhook delivery id, but they were just random. This could cause accidental webhook redeliveries to start too many runners.

See #739