### PR TITLE
fix: Better Octokit caching for multiple installations

### DIFF
--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -118,54 +118,54 @@
         }
       }
     },
-    "c3f81630fddd0f25167644ca9510a15fcbe2934d68a90f6e19db7584a4e57312": {
+    "d6a3d2bb12fdd35b60e5accb874958b8bffd9e23d36e2e69975acec1c1016520": {
       "source": {
-        "path": "asset.c3f81630fddd0f25167644ca9510a15fcbe2934d68a90f6e19db7584a4e57312.lambda",
+        "path": "asset.d6a3d2bb12fdd35b60e5accb874958b8bffd9e23d36e2e69975acec1c1016520.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "c3f81630fddd0f25167644ca9510a15fcbe2934d68a90f6e19db7584a4e57312.zip",
+          "objectKey": "d6a3d2bb12fdd35b60e5accb874958b8bffd9e23d36e2e69975acec1c1016520.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "ab0c40840faa125cd7214a97d964deff8ea6e3b1c079d483ef1ec2f9acc32ea0": {
+    "e7612af147f372feac47931d7f8edad1e4370c96543925d50d684bc700cade80": {
       "source": {
-        "path": "asset.ab0c40840faa125cd7214a97d964deff8ea6e3b1c079d483ef1ec2f9acc32ea0.lambda",
+        "path": "asset.e7612af147f372feac47931d7f8edad1e4370c96543925d50d684bc700cade80.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "ab0c40840faa125cd7214a97d964deff8ea6e3b1c079d483ef1ec2f9acc32ea0.zip",
+          "objectKey": "e7612af147f372feac47931d7f8edad1e4370c96543925d50d684bc700cade80.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "e864f305ebf028584c5a71d7b25cb22ba379b47d01a8dfc8afabca831dc63628": {
+    "1a9507e0d15c8b15fedf0d41a61026865b173603e2f877a4412031e4c038e718": {
       "source": {
-        "path": "asset.e864f305ebf028584c5a71d7b25cb22ba379b47d01a8dfc8afabca831dc63628.lambda",
+        "path": "asset.1a9507e0d15c8b15fedf0d41a61026865b173603e2f877a4412031e4c038e718.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "e864f305ebf028584c5a71d7b25cb22ba379b47d01a8dfc8afabca831dc63628.zip",
+          "objectKey": "1a9507e0d15c8b15fedf0d41a61026865b173603e2f877a4412031e4c038e718.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "f4e33dde6e4b6972cf8182a12da780a98561fc6b6fbefe86b315121a3054e05e": {
+    "f9c90bee77323ee3cdfd6dbb7b741fa38d893e288aa103c5dbca2453a6898ca3": {
       "source": {
-        "path": "asset.f4e33dde6e4b6972cf8182a12da780a98561fc6b6fbefe86b315121a3054e05e.lambda",
+        "path": "asset.f9c90bee77323ee3cdfd6dbb7b741fa38d893e288aa103c5dbca2453a6898ca3.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "f4e33dde6e4b6972cf8182a12da780a98561fc6b6fbefe86b315121a3054e05e.zip",
+          "objectKey": "f9c90bee77323ee3cdfd6dbb7b741fa38d893e288aa103c5dbca2453a6898ca3.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -209,7 +209,7 @@
         }
       }
     },
-    "a702a22cffd00bb6ea07a299b1aa885e12d54abe2eef888041048fdfd632bd45": {
+    "10916a61ccf6e60c358d9a396ff7066c2191d98f864903a4e1404cea428f7fa6": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -217,7 +217,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "a702a22cffd00bb6ea07a299b1aa885e12d54abe2eef888041048fdfd632bd45.json",
+          "objectKey": "10916a61ccf6e60c358d9a396ff7066c2191d98f864903a4e1404cea428f7fa6.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -16243,7 +16243,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "c3f81630fddd0f25167644ca9510a15fcbe2934d68a90f6e19db7584a4e57312.zip"
+     "S3Key": "d6a3d2bb12fdd35b60e5accb874958b8bffd9e23d36e2e69975acec1c1016520.zip"
     },
     "Description": "Get token from GitHub Actions used to start new self-hosted runner",
     "Environment": {
@@ -16352,7 +16352,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "ab0c40840faa125cd7214a97d964deff8ea6e3b1c079d483ef1ec2f9acc32ea0.zip"
+     "S3Key": "e7612af147f372feac47931d7f8edad1e4370c96543925d50d684bc700cade80.zip"
     },
     "Description": "Delete failed GitHub Actions runner on error",
     "Environment": {
@@ -16576,7 +16576,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "e864f305ebf028584c5a71d7b25cb22ba379b47d01a8dfc8afabca831dc63628.zip"
+     "S3Key": "1a9507e0d15c8b15fedf0d41a61026865b173603e2f877a4412031e4c038e718.zip"
     },
     "Description": "Stop idle GitHub runners to avoid paying for runners when the job was already canceled",
     "Environment": {
@@ -18917,7 +18917,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "f4e33dde6e4b6972cf8182a12da780a98561fc6b6fbefe86b315121a3054e05e.zip"
+     "S3Key": "f9c90bee77323ee3cdfd6dbb7b741fa38d893e288aa103c5dbca2453a6898ca3.zip"
     },
     "Description": "Handle GitHub webhook and start runner orchestrator",
     "Environment": {


### PR DESCRIPTION
The current cache held a single installation id. But the app can be installed on multiple repositories and maybe even organizations. This means that we have to create the Octokit instance more often and waste a few precious milliseconds.