### PR TITLE
fix: Idle runner reaper can fail with multiple installations

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -652,6 +652,7 @@ export class GitHubRunners extends Construct implements ec2.IConnectable {
 
     reaper.addEventSource(new lambda_event_sources.SqsEventSource(queue, {
       reportBatchItemFailures: true,
+      maxBatchingWindow: cdk.Duration.minutes(1),
     }));
 
     this.secrets.github.grantRead(reaper);

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -209,7 +209,7 @@
         }
       }
     },
-    "740ac2c8f02f43f4d66300fb9fd41b121392f69b0de039d8cfc0da9e8e084043": {
+    "404ffbb7e9a7061d5cf74a38cbbe2c53c9bacb7c6df81eac2157aa39d3213766": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -217,7 +217,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "740ac2c8f02f43f4d66300fb9fd41b121392f69b0de039d8cfc0da9e8e084043.json",
+          "objectKey": "404ffbb7e9a7061d5cf74a38cbbe2c53c9bacb7c6df81eac2157aa39d3213766.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -144,15 +144,15 @@
         }
       }
     },
-    "18e628820d6a7c938349a3dd7b437e0e1a8ef229dbbf7db7bdf8939ab272a353": {
+    "f15601e571741096c07e7b2e77420948fce7c3f22e7612119706ebbedab808ba": {
       "source": {
-        "path": "asset.18e628820d6a7c938349a3dd7b437e0e1a8ef229dbbf7db7bdf8939ab272a353.lambda",
+        "path": "asset.f15601e571741096c07e7b2e77420948fce7c3f22e7612119706ebbedab808ba.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "18e628820d6a7c938349a3dd7b437e0e1a8ef229dbbf7db7bdf8939ab272a353.zip",
+          "objectKey": "f15601e571741096c07e7b2e77420948fce7c3f22e7612119706ebbedab808ba.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -209,7 +209,7 @@
         }
       }
     },
-    "571743c5ef6f89ec11ae42b251b94498d247afc2adfbde31fcde48da582edd59": {
+    "740ac2c8f02f43f4d66300fb9fd41b121392f69b0de039d8cfc0da9e8e084043": {
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
@@ -217,7 +217,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "571743c5ef6f89ec11ae42b251b94498d247afc2adfbde31fcde48da582edd59.json",
+          "objectKey": "740ac2c8f02f43f4d66300fb9fd41b121392f69b0de039d8cfc0da9e8e084043.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -16576,7 +16576,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "18e628820d6a7c938349a3dd7b437e0e1a8ef229dbbf7db7bdf8939ab272a353.zip"
+     "S3Key": "f15601e571741096c07e7b2e77420948fce7c3f22e7612119706ebbedab808ba.zip"
     },
     "Description": "Stop idle GitHub runners to avoid paying for runners when the job was already canceled",
     "Environment": {

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -16625,7 +16625,8 @@
     },
     "FunctionResponseTypes": [
      "ReportBatchItemFailures"
-    ]
+    ],
+    "MaximumBatchingWindowInSeconds": 60
    }
   },
   "runnersIdleReaperQueue117EFB9F": {


### PR DESCRIPTION
When the GitHub app is installed on multiple repos and/or organization, they can each get a different installation id. Idle reaper handler kept one Octokit instance with the first installation id it found in its input. Octokit cannot be shared. We need a different one for each installation id. That means that if multiple jobs came in around the same time, idle reaper would fail to get data on some of them.

This issue could lead to runners being left behind when the app is installed on multiple repos.