### PR TITLE
chore: support setting placementStrategy for ECS runners

### DIFF
--- a/API.md
+++ b/API.md
@@ -6184,6 +6184,7 @@ const ecsRunnerProviderProps: EcsRunnerProviderProps = { ... }
 | <code><a href="#@cloudsnorkel/cdk-github-runners.EcsRunnerProviderProps.property.memoryLimitMiB">memoryLimitMiB</a></code> | <code>number</code> | The amount (in MiB) of memory used by the task. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.EcsRunnerProviderProps.property.memoryReservationMiB">memoryReservationMiB</a></code> | <code>number</code> | The soft limit (in MiB) of memory to reserve for the container. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.EcsRunnerProviderProps.property.minInstances">minInstances</a></code> | <code>number</code> | The minimum number of instances to run in the cluster. |
+| <code><a href="#@cloudsnorkel/cdk-github-runners.EcsRunnerProviderProps.property.placementStrategy">placementStrategy</a></code> | <code>aws-cdk-lib.aws_ecs.CfnService.PlacementStrategyProperty[]</code> | ECS placement strategies to pass to the RunTask state as-is. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.EcsRunnerProviderProps.property.securityGroups">securityGroups</a></code> | <code>aws-cdk-lib.aws_ec2.ISecurityGroup[]</code> | Security groups to assign to the task. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.EcsRunnerProviderProps.property.spot">spot</a></code> | <code>boolean</code> | Use spot capacity. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.EcsRunnerProviderProps.property.spotMaxPrice">spotMaxPrice</a></code> | <code>string</code> | Maximum price for spot instances. |
@@ -6417,6 +6418,21 @@ public readonly minInstances: number;
 The minimum number of instances to run in the cluster.
 
 Only used when creating a new cluster.
+
+---
+
+##### `placementStrategy`<sup>Optional</sup> <a name="placementStrategy" id="@cloudsnorkel/cdk-github-runners.EcsRunnerProviderProps.property.placementStrategy"></a>
+
+```typescript
+public readonly placementStrategy: PlacementStrategyProperty[];
+```
+
+- *Type:* aws-cdk-lib.aws_ecs.CfnService.PlacementStrategyProperty[]
+- *Default:* undefined (no placement strategy passed)
+
+ECS placement strategies to pass to the RunTask state as-is.
+
+Example: [{ type: 'binpack', field: 'cpu' }]
 
 ---
 


### PR DESCRIPTION
### Summary
Expose optional `placementStrategy` on `EcsRunnerProvider` and forward it to the Step Functions `RunTask` parameters, enabling strategies like `binpack` for ECS EC2 runners. No breaking changes.


Refs: 
- https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-strategies.html
- https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html#API_RunTask_RequestSyntax

### Motivation
- Current ECS runners launched via Step Functions can’t influence task placement.
- Lack of placement control may reduce bin packing efficiency and increase cost and start-up contention.
- ECS supports `PlacementStrategy` on `RunTask`; this surfaces it in the provider API.

### What’s changed
- **API**: `EcsRunnerProviderProps` gains `placementStrategy?: aws_ecs.CfnService.PlacementStrategyProperty[]`.
- **Implementation**: Thread the property through to the custom launch target and emit `Parameters.PlacementStrategy` as `{ Type, Field }` for `RunTask`.
- **Docs**: Update `API.md` for the new prop with example.
- **Tests**: Add assertion that the synthesized state machine includes the requested `PlacementStrategy`.

### Implementation details
- Only applied for ECS EC2 capacity providers (where placement strategies are relevant).
- Default is `undefined` → no change to existing stacks.
- Strategy entries are passed through as-is; shape matches ECS/Step Functions.

### Example
```ts
new EcsRunnerProvider(this, 'EcsProvider', {
  vpc,
  labels: ['ecs-placement'],
  placementStrategy: [{ type: 'binpack', field: 'cpu' }],
});
```

The synthesized Step Functions task includes:
```json
"PlacementStrategy": [{ "Type": "binpack", "Field": "cpu" }]
```

### Files
- `src/providers/ecs.ts`: add prop; wire through to launch target; set RunTask `Parameters.PlacementStrategy`.
- `test/providers.test.ts`: new test "passes PlacementStrategy to RunTask".
- `API.md`: document `placementStrategy`.

### Backward compatibility
- **No breaking changes**. Property is optional; default preserves existing behavior.

### Linked issue
Closes #777

### Checklist
- [x] Unit tests added/updated
- [x] API documented
- [x] No breaking changes
- [x] Conventional commit title
- [x] `npm run test` ✅
- [x] `npm run build` ✅