### PR TITLE
fix: Using dockerSetupCommands fails for AMI builders 

### DIFF
--- a/src/image-builders/aws-image-builder/builder.ts
+++ b/src/image-builders/aws-image-builder/builder.ts
@@ -621,7 +621,7 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
     // generate workflows, if needed
     let workflows: imagebuilder.CfnImagePipeline.WorkflowConfigurationProperty[] | undefined;
     let executionRole: iam.IRole | undefined;
-    if (this.dockerSetupCommands.length > 0) {
+    if (this.dockerSetupCommands.length > 0 && containerRecipeArn) {
       workflows = [{
         workflowArn: generateBuildWorkflowWithDockerSetupCommands(this, 'Build', this.dockerSetupCommands).arn,
       }];


### PR DESCRIPTION
Using `dockerSetupCommands` when building runner AMI should have no effect. But it makes deployments fail with `Build workflow must have output named ImageId to build AMI`

```
github-runners-test | 5:09:36 PM | UPDATE_FAILED        | AWS::ImageBuilder::ImagePipeline               | AMI Linux Builder/AMI Pipeline (AMILinuxBuilderAMIPipelineEC5051DF) Resource handler returned message: "The value supplied for parameter 'workflows' is not valid. Build workflow must have output named ImageId to build AMI. Workflow ARN: arn:aws:imagebuilder:us-east-1:1234567890:workflow/build/github-runners-test-amilinuxbuilder-build-646dcecc/1.0.0/1. (Service: Imagebuilder, Status Code: 400, Request ID: ffd1949e-bc4e-4bc5-8a7e-26cd453cab87) (SDK Attempt Count: 1)" (RequestToken: 6cc14543-ff75-564d-3cb9-6ca7f077e11c, HandlerErrorCode: InvalidRequest)
```

This fix makes sure `dockerSetupCommands` only applies to Docker runner image builds.