### PR TITLE
chore: Resolve isolatedModules deprecation warning

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -119,8 +119,8 @@ const project = new awscdk.AwsCdkConstructLibrary({
   },
   workflowPackageCache: true,
   pullRequestTemplate: false,
-  tsJestOptions: {
-    transformOptions: {
+  tsconfigDev: {
+    compilerOptions: {
       // massively increased unit tests speed
       // side-effect: disable type checking in unit test code
       isolatedModules: true,

--- a/package.json
+++ b/package.json
@@ -191,8 +191,7 @@
       "^.+\\.[t]sx?$": [
         "ts-jest",
         {
-          "tsconfig": "tsconfig.dev.json",
-          "isolatedModules": true
+          "tsconfig": "tsconfig.dev.json"
         }
       ]
     }

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -23,7 +23,8 @@
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "stripInternal": true,
-    "target": "ES2020"
+    "target": "ES2020",
+    "isolatedModules": true
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
```
ts-jest[config] (WARN)                                                                                                                                                                                                
    The "ts-jest" config option "isolatedModules" is deprecated and will be removed in v30.0.0. Please use "isolatedModules: true" in .../cdk-github-runners/tsconfig.dev.json instead, see https://www.typescriptlang.org/tsconfig/#isolatedModules      
```