### PR TITLE
feat: Add userDataCommands to Ec2RunnerProvider

### DIFF
--- a/API.md
+++ b/API.md
@@ -7204,6 +7204,7 @@ const ec2RunnerProviderProps: Ec2RunnerProviderProps = { ... }
 | <code><a href="#@cloudsnorkel/cdk-github-runners.Ec2RunnerProviderProps.property.storageSize">storageSize</a></code> | <code>aws-cdk-lib.Size</code> | Size of volume available for launched runner instances. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.Ec2RunnerProviderProps.property.subnet">subnet</a></code> | <code>aws-cdk-lib.aws_ec2.ISubnet</code> | Subnet where the runner instances will be launched. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.Ec2RunnerProviderProps.property.subnetSelection">subnetSelection</a></code> | <code>aws-cdk-lib.aws_ec2.SubnetSelection</code> | Where to place the network interfaces within the VPC. |
+| <code><a href="#@cloudsnorkel/cdk-github-runners.Ec2RunnerProviderProps.property.userDataCommands">userDataCommands</a></code> | <code>string[]</code> | Additional commands to run on instance start-up, before the runner is registered and started. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.Ec2RunnerProviderProps.property.vpc">vpc</a></code> | <code>aws-cdk-lib.aws_ec2.IVpc</code> | VPC where runner instances will be launched. |
 
 ---
@@ -7444,6 +7445,30 @@ public readonly subnetSelection: SubnetSelection;
 Where to place the network interfaces within the VPC.
 
 Only the first matched subnet will be used.
+
+---
+
+##### `userDataCommands`<sup>Optional</sup> <a name="userDataCommands" id="@cloudsnorkel/cdk-github-runners.Ec2RunnerProviderProps.property.userDataCommands"></a>
+
+```typescript
+public readonly userDataCommands: string[];
+```
+
+- *Type:* string[]
+- *Default:* no additional commands
+
+Additional commands to run on instance start-up, before the runner is registered and started.
+
+Use this to install and configure software that must run on the instance itself and can't be baked into the AMI,
+like security agents that need per-instance registration.
+
+The commands run as root on Linux (bash) and as administrator on Windows (PowerShell). If any command fails, the
+instance will terminate and the job will fail to start, so make sure the commands are reliable or add error
+handling (e.g. `|| true` on Linux).
+
+Note that these commands run every time an instance starts, and therefore delay the start of every job. If the
+software doesn't require per-instance setup, prefer baking it into the AMI with
+{@link Ec2RunnerProvider.imageBuilder} and {@link RunnerImageComponent.custom} for faster job start-up.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -300,6 +300,23 @@ new GitHubRunners(this, 'runners', {
 });
 ```
 
+EC2 runners can additionally run commands on instance start-up, before the runner registers with GitHub and starts the job. This is useful for software that requires per-instance setup and can't simply be baked into the AMI, like security agents that register each instance. The commands run as root on Linux and as administrator on Windows. If any command fails, the instance terminates and the job won't start. Prefer baking software into the AMI with image builder components when possible, as start-up commands delay every job.
+
+```typescript
+const myProvider = new Ec2RunnerProvider(this, 'ec2 runner', {
+   labels: ['my-ec2'],
+   userDataCommands: [
+      'curl -sSL https://example.com/install-agent.sh | bash',
+      'systemctl start my-agent',
+   ],
+});
+
+// create the runner infrastructure
+new GitHubRunners(this, 'runners', {
+   providers: [myProvider],
+});
+```
+
 The runner OS and architecture is determined by the image it is set to use. For example, to create a Fargate runner provider for ARM64 set the `architecture` property for the image builder to `Architecture.ARM64` in the image builder properties.
 
 ```typescript

--- a/src/providers/ec2.ts
+++ b/src/providers/ec2.ts
@@ -57,6 +57,7 @@ defaultLabels="{}"
 export AWS_RETRY_MODE=standard # better retry
 touch /var/log/runner.log
 
+%EXTRA_USER_DATA_COMMANDS%
 heartbeat () {
   while true; do
     SPOT_ACTION=$(curl -s -f -H "X-aws-ec2-metadata-token: $(curl -s -f -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 1" 2>/dev/null)" "http://169.254.169.254/latest/meta-data/spot/instance-action" 2>/dev/null) || true
@@ -120,7 +121,7 @@ else
 fi
 sleep 10  # give cloudwatch agent its default 5 seconds buffer duration to upload logs
 poweroff
-`.replace(/{/g, '\\{').replace(/}/g, '\\}').replace(/\\{\\}/g, '{}');
+`;
 
 // this script is specifically made so `poweroff` is absolutely always called
 // each `{}` is a variable coming from `params` below and their order should match the linux script
@@ -144,6 +145,7 @@ $Env:AWS_RETRY_MODE = "standard"  # better retry
 Set-Service -StartupType Manual AmazonSSMAgent
 Start-Service AmazonSSMAgent
 
+%EXTRA_USER_DATA_COMMANDS%
 $HeartbeatParentPid = $PID
 Start-Job -ScriptBlock {
   while ($true) {
@@ -207,7 +209,21 @@ if ($r -eq 0) {
 Start-Sleep -Seconds 10  # give cloudwatch agent its default 5 seconds buffer duration to upload logs
 Stop-Computer -ComputerName localhost -Force
 </powershell>
-`.replace(/{/g, '\\{').replace(/}/g, '\\}').replace(/\\{\\}/g, '{}');
+`;
+
+const extraUserDataCommandsPlaceholder = '%EXTRA_USER_DATA_COMMANDS%\n';
+
+/**
+ * Prepare a user data template for use with States.Format by escaping `{` and `}` as `\{` and `\}`, and then
+ * restoring the intentional `{}` placeholders. Extra user commands are inserted fully escaped so any braces they
+ * contain (e.g. `${VAR}` in shell) are always treated as literal characters and never as placeholders.
+ */
+function renderUserDataTemplate(template: string, extraCommands: string[]): string {
+  const escapedTemplate = template.replace(/{/g, '\\{').replace(/}/g, '\\}').replace(/\\{\\}/g, '{}');
+  const escapedCommands = extraCommands.map(command => command.replace(/{/g, '\\{').replace(/}/g, '\\}')).join('\n');
+  // use a replacer function so `$` sequences in commands are not treated as special replacement patterns
+  return escapedTemplate.replace(extraUserDataCommandsPlaceholder, () => escapedCommands.length > 0 ? `${escapedCommands}\n` : '');
+}
 
 
 /**
@@ -329,6 +345,24 @@ export interface Ec2RunnerProviderProps extends RunnerProviderProps {
    * @default no max price (you will pay current spot price)
    */
   readonly spotMaxPrice?: string;
+
+  /**
+   * Additional commands to run on instance start-up, before the runner is registered and started.
+   *
+   * Use this to install and configure software that must run on the instance itself and can't be baked into the AMI,
+   * like security agents that need per-instance registration.
+   *
+   * The commands run as root on Linux (bash) and as administrator on Windows (PowerShell). If any command fails, the
+   * instance will terminate and the job will fail to start, so make sure the commands are reliable or add error
+   * handling (e.g. `|| true` on Linux).
+   *
+   * Note that these commands run every time an instance starts, and therefore delay the start of every job. If the
+   * software doesn't require per-instance setup, prefer baking it into the AMI with
+   * {@link Ec2RunnerProvider.imageBuilder} and {@link RunnerImageComponent.custom} for faster job start-up.
+   *
+   * @default no additional commands
+   */
+  readonly userDataCommands?: string[];
 }
 
 /**
@@ -410,6 +444,7 @@ export class Ec2RunnerProvider extends BaseProvider implements IRunnerProvider {
   private readonly subnets: ec2.ISubnet[];
   private readonly securityGroups: ec2.ISecurityGroup[];
   private readonly defaultLabels: boolean;
+  private readonly userDataCommands: string[];
 
   constructor(scope: Construct, id: string, props?: Ec2RunnerProviderProps) {
     super(scope, id, props);
@@ -425,6 +460,7 @@ export class Ec2RunnerProvider extends BaseProvider implements IRunnerProvider {
     this.spot = props?.spot ?? false;
     this.spotMaxPrice = props?.spotMaxPrice;
     this.defaultLabels = props?.defaultLabels ?? true;
+    this.userDataCommands = props?.userDataCommands ?? [];
 
     if (this.subnets.length === 0) {
       cdk.Annotations.of(this).addError('At least one subnet is required');
@@ -475,12 +511,14 @@ export class Ec2RunnerProvider extends BaseProvider implements IRunnerProvider {
   }
 
   private userDataConst() {
-    return this.ami.os.is(Os.WINDOWS) ? 'ec2UserDataWindows' : 'ec2UserDataLinux';
+    const base = this.ami.os.is(Os.WINDOWS) ? 'ec2UserDataWindows' : 'ec2UserDataLinux';
+    // custom commands make the template unique to this provider, so the constant key must be unique too
+    return this.userDataCommands.length > 0 ? `${base}${this.node.addr}` : base;
   }
 
   public stepFunctionConstants(): Record<string, string> {
     const userdataTemplate = this.ami.os.is(Os.WINDOWS) ? windowsUserDataTemplate : linuxUserDataTemplate;
-    return { [this.userDataConst()]: userdataTemplate };
+    return { [this.userDataConst()]: renderUserDataTemplate(userdataTemplate, this.userDataCommands) };
   }
 
   /**

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -3,7 +3,7 @@ import { aws_ec2 as ec2, aws_ecs as ecs, aws_stepfunctions as sfn } from 'aws-cd
 import { Annotations, Match, Template } from 'aws-cdk-lib/assertions';
 import * as autoscaling from 'aws-cdk-lib/aws-autoscaling';
 import { CloudAssembly } from 'aws-cdk-lib/cx-api';
-import { CodeBuildRunnerProvider, Ec2RunnerProvider, EcsRunnerProvider, FargateRunnerProvider, LambdaRunnerProvider } from '../src';
+import { Architecture, CodeBuildRunnerProvider, Ec2RunnerProvider, EcsRunnerProvider, FargateRunnerProvider, GitHubRunners, LambdaRunnerProvider, Os } from '../src';
 
 describe('Providers', () => {
   let app: cdk.App;
@@ -417,6 +417,105 @@ describe('Providers', () => {
       template.hasResourceProperties('AWS::ImageBuilder::InfrastructureConfiguration', Match.objectLike({
         InstanceTypes: ['m6g.large'],
       }));
+    });
+
+    test('No custom user data commands', () => {
+      const vpc = new ec2.Vpc(stack, 'vpc');
+      const sg = new ec2.SecurityGroup(stack, 'sg', { vpc });
+
+      const provider = new Ec2RunnerProvider(stack, 'provider', {
+        vpc,
+        securityGroups: [sg],
+      });
+
+      const consts = provider.stepFunctionConstants();
+      expect(Object.keys(consts)).toEqual(['ec2UserDataLinux']);
+      expect(consts.ec2UserDataLinux).not.toContain('%EXTRA_USER_DATA_COMMANDS%');
+    });
+
+    test('Custom user data commands', () => {
+      const vpc = new ec2.Vpc(stack, 'vpc');
+      const sg = new ec2.SecurityGroup(stack, 'sg', { vpc });
+
+      const provider = new Ec2RunnerProvider(stack, 'provider', {
+        vpc,
+        securityGroups: [sg],
+        userDataCommands: [
+          'curl -sSL https://example.com/install.sh | bash',
+          'echo "braces ${LIKE_THIS} and $& are kept literal"',
+        ],
+      });
+
+      const consts = provider.stepFunctionConstants();
+      const keys = Object.keys(consts);
+      expect(keys).toHaveLength(1);
+      // key must be unique so multiple providers with different commands don't clash in $.consts
+      expect(keys[0]).toMatch(/^ec2UserDataLinux.+/);
+
+      const template = consts[keys[0]];
+      expect(template).not.toContain('%EXTRA_USER_DATA_COMMANDS%');
+      expect(template).toContain('curl -sSL https://example.com/install.sh | bash');
+      // braces in commands must be escaped so States.Format doesn't treat them as placeholders
+      expect(template).toContain('echo "braces $\\{LIKE_THIS\\} and $& are kept literal"');
+      // commands must run before the runner starts
+      expect(template.indexOf('curl -sSL')).toBeLessThan(template.indexOf('heartbeat &'));
+      // intentional placeholders must be preserved
+      expect(template).toContain('TASK_TOKEN="{}"');
+    });
+
+    test('Custom user data commands on Windows', () => {
+      const vpc = new ec2.Vpc(stack, 'vpc');
+      const sg = new ec2.SecurityGroup(stack, 'sg', { vpc });
+
+      const provider = new Ec2RunnerProvider(stack, 'provider', {
+        vpc,
+        securityGroups: [sg],
+        imageBuilder: Ec2RunnerProvider.imageBuilder(stack, 'builder', {
+          vpc,
+          securityGroups: [sg],
+          os: Os.WINDOWS,
+          architecture: Architecture.X86_64,
+        }),
+        userDataCommands: ['Invoke-WebRequest -Uri https://example.com/install.ps1 | Invoke-Expression'],
+      });
+
+      const consts = provider.stepFunctionConstants();
+      const keys = Object.keys(consts);
+      expect(keys).toHaveLength(1);
+      expect(keys[0]).toMatch(/^ec2UserDataWindows.+/);
+
+      const template = consts[keys[0]];
+      expect(template).not.toContain('%EXTRA_USER_DATA_COMMANDS%');
+      expect(template).toContain('Invoke-WebRequest -Uri https://example.com/install.ps1 | Invoke-Expression');
+      expect(template.indexOf('Invoke-WebRequest -Uri https://example.com/install.ps1')).toBeLessThan(template.indexOf('$HeartbeatParentPid'));
+    });
+
+    test('Multiple providers with different user data commands', () => {
+      const vpc = new ec2.Vpc(stack, 'vpc');
+      const sg = new ec2.SecurityGroup(stack, 'sg', { vpc });
+
+      const provider1 = new Ec2RunnerProvider(stack, 'provider 1', {
+        labels: ['one'],
+        vpc,
+        securityGroups: [sg],
+        userDataCommands: ['echo one'],
+      });
+      const provider2 = new Ec2RunnerProvider(stack, 'provider 2', {
+        labels: ['two'],
+        vpc,
+        securityGroups: [sg],
+        userDataCommands: ['echo two'],
+      });
+      const provider3 = new Ec2RunnerProvider(stack, 'provider 3', {
+        labels: ['three'],
+        vpc,
+        securityGroups: [sg],
+      });
+
+      // merging constants of all providers must not throw a duplicate key error
+      expect(() => new GitHubRunners(stack, 'runners', {
+        providers: [provider1, provider2, provider3],
+      })).not.toThrow();
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds a `userDataCommands` prop to `Ec2RunnerProvider` that runs custom commands on instance start-up, before the runner registers with GitHub and starts the job.

Motivation: some software requires per-instance setup and can't simply be baked into the AMI with image builder components — for example security agents (Lacework, in my case) that need to register each instance. Today the EC2 user data template is hard-coded, so there's no supported way to do this.

## Implementation notes

- Commands are inserted into the existing Linux/Windows user data templates via a placeholder, after initial setup and before the heartbeat/runner registration. They run as root on Linux (bash) and administrator on Windows (PowerShell).
- Since the templates go through `States.Format`, braces in user commands are escaped so things like `${VAR}` are treated literally and never as placeholders. The replacement uses a replacer function so `$` sequences in commands aren't mangled by `String.replace` special patterns.
- Providers with custom commands get a unique `$.consts` key (suffixed with `node.addr`) so multiple EC2 providers with different commands don't trip the duplicate-constants check. Providers without custom commands keep sharing the existing `ec2UserDataLinux`/`ec2UserDataWindows` keys.
- The prop docs steer users toward image builder components when per-instance setup isn't required, since start-up commands delay every job.

## Testing

- New unit tests cover: no commands (template unchanged, placeholder removed), Linux and Windows command injection and ordering, brace/`$` escaping, placeholder preservation, and multiple providers with different commands merging into one state machine without duplicate-key errors.
- Full test suite passes (220 tests), jsii compile and eslint clean, `API.md` regenerated with docgen.

Made with [Cursor](https://cursor.com)