### PR TITLE
feat: Component for job startup/completed hooks

### DIFF
--- a/API.md
+++ b/API.md
@@ -11727,7 +11727,7 @@ A component that runs a script after every job the runner executes.
 
 Point this at a local script file. It is copied into the image, made executable, and the runner is
 configured to run it after each job using the
-[`ACTIONS_RUNNER_HOOK_JOB_COMPLETED`](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job)
+[`ACTIONS_RUNNER_HOOK_JOB_COMPLETED`](https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/run-scripts)
 environment variable. GitHub passes job context to the script as environment variables such as `GITHUB_REPOSITORY` and `GITHUB_RUN_ID`.
 
 Must be used after the {@link githubRunner} component.
@@ -11752,7 +11752,7 @@ A component that runs a script before every job the runner executes.
 
 Point this at a local script file. It is copied into the image, made executable, and the runner is
 configured to run it before each job using the
-[`ACTIONS_RUNNER_HOOK_JOB_STARTED`](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job)
+[`ACTIONS_RUNNER_HOOK_JOB_STARTED`](https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/run-scripts)
 environment variable. GitHub passes job context to the script as environment variables such as `GITHUB_REPOSITORY` and `GITHUB_RUN_ID`.
 
 Must be used after the {@link githubRunner} component.

--- a/API.md
+++ b/API.md
@@ -11511,6 +11511,8 @@ Returns true if the image builder should be rebooted after this component is ins
 | <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerImageComponent.git">git</a></code> | A component to install Git. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerImageComponent.githubCli">githubCli</a></code> | A component to install the GitHub CLI. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerImageComponent.githubRunner">githubRunner</a></code> | A component to install the GitHub Actions Runner. |
+| <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerImageComponent.jobCompletedHook">jobCompletedHook</a></code> | A component that runs a script after every job the runner executes. |
+| <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerImageComponent.jobStartedHook">jobStartedHook</a></code> | A component that runs a script before every job the runner executes. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerImageComponent.lambdaEntrypoint">lambdaEntrypoint</a></code> | A component to set up the required Lambda entrypoint for Lambda runners. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerImageComponent.requiredPackages">requiredPackages</a></code> | A component to install the required packages for the runner. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerImageComponent.runnerUser">runnerUser</a></code> | A component to prepare the required runner user. |
@@ -11710,6 +11712,56 @@ This is the actual executable that connects to GitHub to ask for jobs and then e
 The version of the runner to install.
 
 Usually you would set this to latest.
+
+---
+
+##### `jobCompletedHook` <a name="jobCompletedHook" id="@cloudsnorkel/cdk-github-runners.RunnerImageComponent.jobCompletedHook"></a>
+
+```typescript
+import { RunnerImageComponent } from '@cloudsnorkel/cdk-github-runners'
+
+RunnerImageComponent.jobCompletedHook(sourcePath: string)
+```
+
+A component that runs a script after every job the runner executes.
+
+Point this at a local script file. It is copied into the image, made executable, and the runner is
+configured to run it after each job using the
+[`ACTIONS_RUNNER_HOOK_JOB_COMPLETED`](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job)
+environment variable. GitHub passes job context to the script as environment variables such as `GITHUB_REPOSITORY` and `GITHUB_RUN_ID`.
+
+Must be used after the {@link githubRunner} component.
+
+###### `sourcePath`<sup>Required</sup> <a name="sourcePath" id="@cloudsnorkel/cdk-github-runners.RunnerImageComponent.jobCompletedHook.parameter.sourcePath"></a>
+
+- *Type:* string
+
+path to a local script file to run after every job.
+
+---
+
+##### `jobStartedHook` <a name="jobStartedHook" id="@cloudsnorkel/cdk-github-runners.RunnerImageComponent.jobStartedHook"></a>
+
+```typescript
+import { RunnerImageComponent } from '@cloudsnorkel/cdk-github-runners'
+
+RunnerImageComponent.jobStartedHook(sourcePath: string)
+```
+
+A component that runs a script before every job the runner executes.
+
+Point this at a local script file. It is copied into the image, made executable, and the runner is
+configured to run it before each job using the
+[`ACTIONS_RUNNER_HOOK_JOB_STARTED`](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job)
+environment variable. GitHub passes job context to the script as environment variables such as `GITHUB_REPOSITORY` and `GITHUB_RUN_ID`.
+
+Must be used after the {@link githubRunner} component.
+
+###### `sourcePath`<sup>Required</sup> <a name="sourcePath" id="@cloudsnorkel/cdk-github-runners.RunnerImageComponent.jobStartedHook.parameter.sourcePath"></a>
+
+- *Type:* string
+
+path to a local script file to run before every job.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -541,6 +541,7 @@ We provide comprehensive examples in the [`examples/`](examples/) folder to help
 
 ### Customization
 - **[Add Software](examples/typescript/add-software/)** - Add custom software to runner images (also available in [Python](examples/python/add-software/))
+- **[Job Hooks](examples/typescript/job-hooks/)** - Run a script before every job using GitHub Actions runner hooks (also available in [Python](examples/python/job-hooks/))
 - **[GPU](examples/typescript/gpu/)** - GPU support with NVIDIA drivers across EC2, CodeBuild, and ECS (also available in [Python](examples/python/gpu/))
 
 ### Enterprise & Monitoring

--- a/examples/python/job-hooks/README.md
+++ b/examples/python/job-hooks/README.md
@@ -1,0 +1,31 @@
+# Job Hooks Example
+
+This example demonstrates how to run a script before every job using [GitHub Actions runner hooks](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job).
+
+## What This Example Shows
+
+- How to run a script **before every job** and **after every job**
+- How to bake hook scripts into the runner image as versioned assets (instead of echoing them into files at deploy time)
+- How to wire the scripts up with the `ACTIONS_RUNNER_HOOK_JOB_STARTED` and `ACTIONS_RUNNER_HOOK_JOB_COMPLETED` environment variables
+
+## Why Runner Hooks?
+
+GitHub's self-hosted runner can run a script before or after every job. Point `ACTIONS_RUNNER_HOOK_JOB_STARTED` (or `ACTIONS_RUNNER_HOOK_JOB_COMPLETED`) at a script and the runner executes it around each job. GitHub passes job context to the hook as environment variables like `$GITHUB_REPOSITORY` and `$GITHUB_RUN_ID`.
+
+This is useful for anything that needs to happen once per job, for example logging job metadata, sending a notification, preparing or cleaning the workspace, or gating jobs. It's a supported, portable mechanism that works across all providers (EC2, ECS, Fargate, CodeBuild, Lambda).
+
+> **Note:** Runner hooks run per job. If instead you want software installed or a service running on the runner itself, add it to the image (see the [Add Software](../add-software/) example) or configure a systemd unit as part of the image build.
+
+## How It Works
+
+1. The hook scripts live in [`job-started.sh`](job-started.sh) and [`job-completed.sh`](job-completed.sh) -- real, lintable, version-controlled files.
+2. `RunnerImageComponent.job_started_hook(...)` and `RunnerImageComponent.job_completed_hook(...)` each take a path to a local script. They copy it into the image, mark it executable, and set the matching `ACTIONS_RUNNER_HOOK_JOB_STARTED` / `ACTIONS_RUNNER_HOOK_JOB_COMPLETED` environment variable for you.
+
+If you only need one of the hooks, add just that component.
+
+## Setup
+
+1. Edit [`job-started.sh`](job-started.sh) and [`job-completed.sh`](job-completed.sh) to run your own per-job commands
+2. Deploy the stack: `cdk deploy`
+3. Follow the setup instructions in the main [README.md](../../../README.md) to configure GitHub integration
+4. Use the `ec2` label in your workflows -- the hook runs automatically before each job

--- a/examples/python/job-hooks/app.py
+++ b/examples/python/job-hooks/app.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""
+Example: Run a script before every job using GitHub Actions runner hooks.
+
+GitHub's self-hosted runner can run a script before (or after) every job by
+setting the ACTIONS_RUNNER_HOOK_JOB_STARTED (or ACTIONS_RUNNER_HOOK_JOB_COMPLETED)
+environment variable. This is handy for anything that needs to happen once per
+job, such as logging job metadata, sending notifications, or preparing the
+workspace.
+
+The hook script is added to the runner image as an asset, so it's versioned
+alongside this stack instead of being echoed into a file at deploy time.
+"""
+
+import os
+
+import aws_cdk as cdk
+from aws_cdk import Stack, aws_ec2 as ec2
+from cloudsnorkel.cdk_github_runners import (
+    GitHubRunners,
+    Ec2RunnerProvider,
+    RunnerImageComponent,
+)
+
+
+class JobHooksStack(Stack):
+    def __init__(self, scope, construct_id, **kwargs):
+        super().__init__(scope, construct_id, **kwargs)
+
+        # Note: Creating a VPC is not required. Providers can use the default VPC or an existing VPC.
+        # We create one here to make this example self-contained and testable.
+        # Create a VPC with public and private subnets
+        vpc = ec2.Vpc(
+            self, "VPC",
+            max_azs=2,
+            subnet_configuration=[
+                ec2.SubnetConfiguration(
+                    name="Public",
+                    subnet_type=ec2.SubnetType.PUBLIC,
+                    cidr_mask=24
+                ),
+                ec2.SubnetConfiguration(
+                    name="Private",
+                    subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS,
+                    cidr_mask=24
+                )
+            ]
+        )
+
+        # Create an image builder so we can add the hook scripts.
+        image_builder = Ec2RunnerProvider.image_builder(
+            self, "ImageBuilder",
+            vpc=vpc,
+        )
+
+        # Point the runner at local script files. Each helper copies the script into
+        # the image, marks it executable, and sets the matching environment variable
+        # so the runner runs it before/after every job. The scripts live in real,
+        # version-controlled files instead of being echoed into the image.
+        # See https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job
+        image_builder.add_component(
+            RunnerImageComponent.job_started_hook(os.path.join(os.path.dirname(__file__), "job-started.sh"))
+        )
+        image_builder.add_component(
+            RunnerImageComponent.job_completed_hook(os.path.join(os.path.dirname(__file__), "job-completed.sh"))
+        )
+
+        # Create an EC2 provider using the custom image.
+        ec2_provider = Ec2RunnerProvider(
+            self, "Ec2Provider",
+            labels=["ec2", "linux", "x64"],
+            vpc=vpc,
+            image_builder=image_builder
+        )
+
+        # Create the GitHub runners infrastructure
+        GitHubRunners(
+            self, "GitHubRunners",
+            providers=[ec2_provider]
+        )
+
+
+app = cdk.App()
+JobHooksStack(app, "job-hooks-example")
+app.synth()

--- a/examples/python/job-hooks/cdk.json
+++ b/examples/python/job-hooks/cdk.json
@@ -1,0 +1,66 @@
+{
+    "app": "python app.py",
+    "watch": {
+        "include": [
+            "**"
+        ],
+        "exclude": [
+            "README.md",
+            "cdk*.json",
+            "requirements*.txt",
+            "source.bat",
+            "**/__pycache__",
+            "**/.venv"
+        ]
+    },
+    "context": {
+        "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+        "@aws-cdk/core:checkSecretUsage": true,
+        "@aws-cdk/core:target-partitions": [
+            "aws",
+            "aws-cn"
+        ],
+        "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+        "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+        "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+        "@aws-cdk/aws-iam:minimizePolicies": true,
+        "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+        "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+        "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+        "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+        "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+        "@aws-cdk/core:enablePartitionLiterals": true,
+        "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
+        "@aws-cdk/aws-iam:standardizedServicePrincipals": true,
+        "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
+        "@aws-cdk/aws-iam:importedRoleStackSafeDefaultPolicyName": true,
+        "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
+        "@aws-cdk/aws-route53-patters:useCertificate": true,
+        "@aws-cdk/customresources:installLatestAwsSdkDefault": false,
+        "@aws-cdk/aws-rds:databaseProxyUniqueResourceName": true,
+        "@aws-cdk/aws-codedeploy:removeAlarmsFromDeploymentGroup": true,
+        "@aws-cdk/aws-apigateway:authorizerChangeDeploymentLogicalId": true,
+        "@aws-cdk/aws-ec2:launchTemplateDefaultUserData": true,
+        "@aws-cdk/aws-secretsmanager:useAttachedSecretResourcePolicyForSecretTargetAttachments": true,
+        "@aws-cdk/aws-redshift:columnId": true,
+        "@aws-cdk/aws-stepfunctions-tasks:enableLogging": true,
+        "@aws-cdk/aws-ec2:restrictDefaultSecurityGroup": true,
+        "@aws-cdk/aws-apigateway:requestValidatorUniqueId": true,
+        "@aws-cdk/aws-kms:aliasNameRef": true,
+        "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true,
+        "@aws-cdk/core:includePrefixInUniqueNameGeneration": true,
+        "@aws-cdk/aws-efs:denyAnonymousAccess": true,
+        "@aws-cdk/aws-opensearchservice:enableLogging": true,
+        "@aws-cdk/aws-lambda:useLatestRuntimeVersion": true,
+        "@aws-cdk/aws-ecs:enableExecuteCommandLogging": true,
+        "@aws-cdk/aws-route53resolver:addedDnsRecordLimit": true,
+        "@aws-cdk/aws-stepfunctions:enableLogging": true,
+        "@aws-cdk/aws-ec2:ebsDefaultGp3Volume": true,
+        "@aws-cdk/aws-ecs:removeDefaultDeploymentAlarm": false,
+        "@aws-cdk/aws-rds:auroraClusterChangeScopeOfInstanceParameterGroupWithEachParameters": true,
+        "@aws-cdk/aws-appsync:useArnForSourceApiAssociationIdentifier": true,
+        "@aws-cdk/aws-rds:preventRenderingDeprecatedCredentials": true,
+        "@aws-cdk/aws-codepipeline-actions:useNewDefaultBranchForSourceAction": true,
+        "@aws-cdk/aws-s3:autoDeletePolicyForObjects": true
+    }
+}

--- a/examples/python/job-hooks/job-completed.sh
+++ b/examples/python/job-hooks/job-completed.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# GitHub Actions job completed hook.
+#
+# The self-hosted runner executes this script after every job it runs, because
+# we point the ACTIONS_RUNNER_HOOK_JOB_COMPLETED environment variable at it. Use
+# it for anything that should happen once per job after it finishes -- for
+# example cleaning the workspace, flushing logs, or sending a notification.
+#
+# GitHub passes job context to the hook as environment variables. See:
+# https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job
+
+set -euo pipefail
+
+echo "Running job completed hook for ${GITHUB_REPOSITORY:-unknown} run ${GITHUB_RUN_ID:-unknown}"
+
+# Put your own per-job cleanup commands here.
+
+echo "Job completed hook finished"

--- a/examples/python/job-hooks/job-started.sh
+++ b/examples/python/job-hooks/job-started.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# GitHub Actions job started hook.
+#
+# The self-hosted runner executes this script before every job it runs, because
+# we point the ACTIONS_RUNNER_HOOK_JOB_STARTED environment variable at it. Use
+# it for anything that should happen once per job -- for example logging job
+# metadata, sending a notification, or preparing the workspace.
+#
+# GitHub passes job context to the hook as environment variables. See:
+# https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job
+
+set -euo pipefail
+
+echo "Running job started hook for ${GITHUB_REPOSITORY:-unknown} run ${GITHUB_RUN_ID:-unknown}"
+
+# Put your own per-job commands here.
+
+echo "Job started hook finished"

--- a/examples/python/job-hooks/requirements.txt
+++ b/examples/python/job-hooks/requirements.txt
@@ -1,0 +1,3 @@
+aws-cdk-lib>=2.155.0
+constructs>=10.0.5
+cloudsnorkel.cdk-github-runners

--- a/examples/typescript/job-hooks/README.md
+++ b/examples/typescript/job-hooks/README.md
@@ -1,0 +1,31 @@
+# Job Hooks Example
+
+This example demonstrates how to run a script before every job using [GitHub Actions runner hooks](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job).
+
+## What This Example Shows
+
+- How to run a script **before every job** and **after every job**
+- How to bake hook scripts into the runner image as versioned assets (instead of echoing them into files at deploy time)
+- How to wire the scripts up with the `ACTIONS_RUNNER_HOOK_JOB_STARTED` and `ACTIONS_RUNNER_HOOK_JOB_COMPLETED` environment variables
+
+## Why Runner Hooks?
+
+GitHub's self-hosted runner can run a script before or after every job. Point `ACTIONS_RUNNER_HOOK_JOB_STARTED` (or `ACTIONS_RUNNER_HOOK_JOB_COMPLETED`) at a script and the runner executes it around each job. GitHub passes job context to the hook as environment variables like `$GITHUB_REPOSITORY` and `$GITHUB_RUN_ID`.
+
+This is useful for anything that needs to happen once per job, for example logging job metadata, sending a notification, preparing or cleaning the workspace, or gating jobs. It's a supported, portable mechanism that works across all providers (EC2, ECS, Fargate, CodeBuild, Lambda).
+
+> **Note:** Runner hooks run per job. If instead you want software installed or a service running on the runner itself, add it to the image (see the [Add Software](../add-software/) example) or configure a systemd unit as part of the image build.
+
+## How It Works
+
+1. The hook scripts live in [`job-started.sh`](job-started.sh) and [`job-completed.sh`](job-completed.sh) -- real, lintable, version-controlled files.
+2. `RunnerImageComponent.jobStartedHook(...)` and `RunnerImageComponent.jobCompletedHook(...)` each take a path to a local script. They copy it into the image, mark it executable, and set the matching `ACTIONS_RUNNER_HOOK_JOB_STARTED` / `ACTIONS_RUNNER_HOOK_JOB_COMPLETED` environment variable for you.
+
+If you only need one of the hooks, add just that component.
+
+## Setup
+
+1. Edit [`job-started.sh`](job-started.sh) and [`job-completed.sh`](job-completed.sh) to run your own per-job commands
+2. Deploy the stack: `cdk deploy`
+3. Follow the setup instructions in the main [README.md](../../../README.md) to configure GitHub integration
+4. Use the `ec2` label in your workflows -- the hook runs automatically before each job

--- a/examples/typescript/job-hooks/app.ts
+++ b/examples/typescript/job-hooks/app.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Example: Run a script before every job using GitHub Actions runner hooks.
+ *
+ * GitHub's self-hosted runner can run a script before (or after) every job by
+ * setting the ACTIONS_RUNNER_HOOK_JOB_STARTED (or ACTIONS_RUNNER_HOOK_JOB_COMPLETED)
+ * environment variable. This is handy for anything that needs to happen once per
+ * job, such as logging job metadata, sending notifications, or preparing the
+ * workspace.
+ *
+ * The hook script is added to the runner image as an asset, so it's versioned
+ * alongside this stack instead of being echoed into a file at deploy time.
+ */
+
+import * as path from 'path';
+import { App, Stack } from 'aws-cdk-lib';
+import { Vpc, SubnetType } from 'aws-cdk-lib/aws-ec2';
+import {
+  GitHubRunners,
+  Ec2RunnerProvider,
+  RunnerImageComponent,
+} from '@cloudsnorkel/cdk-github-runners';
+
+class JobHooksStack extends Stack {
+  constructor(scope: App, id: string) {
+    super(scope, id);
+
+    // Note: Creating a VPC is not required. Providers can use the default VPC or an existing VPC.
+    // We create one here to make this example self-contained and testable.
+    // Create a VPC with public and private subnets
+    const vpc = new Vpc(this, 'VPC', {
+      maxAzs: 2,
+      subnetConfiguration: [
+        {
+          name: 'Public',
+          subnetType: SubnetType.PUBLIC,
+          cidrMask: 24,
+        },
+        {
+          name: 'Private',
+          subnetType: SubnetType.PRIVATE_WITH_EGRESS,
+          cidrMask: 24,
+        },
+      ],
+    });
+
+    // Create an image builder so we can add the hook scripts.
+    const imageBuilder = Ec2RunnerProvider.imageBuilder(this, 'ImageBuilder', {
+      vpc: vpc,
+    });
+
+    // Point the runner at local script files. Each helper copies the script into
+    // the image, marks it executable, and sets the matching environment variable
+    // so the runner runs it before/after every job. The scripts live in real,
+    // version-controlled files instead of being echoed into the image.
+    // See https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job
+    imageBuilder.addComponent(
+      RunnerImageComponent.jobStartedHook(path.join(__dirname, 'job-started.sh')),
+    );
+    imageBuilder.addComponent(
+      RunnerImageComponent.jobCompletedHook(path.join(__dirname, 'job-completed.sh')),
+    );
+
+    // Create an EC2 provider using the custom image.
+    const ec2Provider = new Ec2RunnerProvider(this, 'Ec2Provider', {
+      labels: ['ec2', 'linux', 'x64'],
+      vpc: vpc,
+      imageBuilder: imageBuilder,
+    });
+
+    // Create the GitHub runners infrastructure
+    new GitHubRunners(this, 'GitHubRunners', {
+      providers: [ec2Provider],
+    });
+  }
+}
+
+const app = new App();
+new JobHooksStack(app, 'job-hooks-example');
+app.synth();

--- a/examples/typescript/job-hooks/cdk.json
+++ b/examples/typescript/job-hooks/cdk.json
@@ -1,0 +1,66 @@
+{
+    "app": "npx ts-node app.ts",
+    "watch": {
+        "include": [
+            "**"
+        ],
+        "exclude": [
+            "README.md",
+            "cdk*.json",
+            "**/*.d.ts",
+            "**/*.js",
+            "**/__pycache__",
+            "**/.venv"
+        ]
+    },
+    "context": {
+        "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+        "@aws-cdk/core:checkSecretUsage": true,
+        "@aws-cdk/core:target-partitions": [
+            "aws",
+            "aws-cn"
+        ],
+        "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+        "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+        "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+        "@aws-cdk/aws-iam:minimizePolicies": true,
+        "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+        "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+        "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+        "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+        "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+        "@aws-cdk/core:enablePartitionLiterals": true,
+        "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
+        "@aws-cdk/aws-iam:standardizedServicePrincipals": true,
+        "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
+        "@aws-cdk/aws-iam:importedRoleStackSafeDefaultPolicyName": true,
+        "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
+        "@aws-cdk/aws-route53-patters:useCertificate": true,
+        "@aws-cdk/customresources:installLatestAwsSdkDefault": false,
+        "@aws-cdk/aws-rds:databaseProxyUniqueResourceName": true,
+        "@aws-cdk/aws-codedeploy:removeAlarmsFromDeploymentGroup": true,
+        "@aws-cdk/aws-apigateway:authorizerChangeDeploymentLogicalId": true,
+        "@aws-cdk/aws-ec2:launchTemplateDefaultUserData": true,
+        "@aws-cdk/aws-secretsmanager:useAttachedSecretResourcePolicyForSecretTargetAttachments": true,
+        "@aws-cdk/aws-redshift:columnId": true,
+        "@aws-cdk/aws-stepfunctions-tasks:enableLogging": true,
+        "@aws-cdk/aws-ec2:restrictDefaultSecurityGroup": true,
+        "@aws-cdk/aws-apigateway:requestValidatorUniqueId": true,
+        "@aws-cdk/aws-kms:aliasNameRef": true,
+        "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true,
+        "@aws-cdk/core:includePrefixInUniqueNameGeneration": true,
+        "@aws-cdk/aws-efs:denyAnonymousAccess": true,
+        "@aws-cdk/aws-opensearchservice:enableLogging": true,
+        "@aws-cdk/aws-lambda:useLatestRuntimeVersion": true,
+        "@aws-cdk/aws-ecs:enableExecuteCommandLogging": true,
+        "@aws-cdk/aws-route53resolver:addedDnsRecordLimit": true,
+        "@aws-cdk/aws-stepfunctions:enableLogging": true,
+        "@aws-cdk/aws-ec2:ebsDefaultGp3Volume": true,
+        "@aws-cdk/aws-ecs:removeDefaultDeploymentAlarm": false,
+        "@aws-cdk/aws-rds:auroraClusterChangeScopeOfInstanceParameterGroupWithEachParameters": true,
+        "@aws-cdk/aws-appsync:useArnForSourceApiAssociationIdentifier": true,
+        "@aws-cdk/aws-rds:preventRenderingDeprecatedCredentials": true,
+        "@aws-cdk/aws-codepipeline-actions:useNewDefaultBranchForSourceAction": true,
+        "@aws-cdk/aws-s3:autoDeletePolicyForObjects": true
+    }
+}

--- a/examples/typescript/job-hooks/job-completed.sh
+++ b/examples/typescript/job-hooks/job-completed.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# GitHub Actions job completed hook.
+#
+# The self-hosted runner executes this script after every job it runs, because
+# we point the ACTIONS_RUNNER_HOOK_JOB_COMPLETED environment variable at it. Use
+# it for anything that should happen once per job after it finishes -- for
+# example cleaning the workspace, flushing logs, or sending a notification.
+#
+# GitHub passes job context to the hook as environment variables. See:
+# https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job
+
+set -euo pipefail
+
+echo "Running job completed hook for ${GITHUB_REPOSITORY:-unknown} run ${GITHUB_RUN_ID:-unknown}"
+
+# Put your own per-job cleanup commands here.
+
+echo "Job completed hook finished"

--- a/examples/typescript/job-hooks/job-started.sh
+++ b/examples/typescript/job-hooks/job-started.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# GitHub Actions job started hook.
+#
+# The self-hosted runner executes this script before every job it runs, because
+# we point the ACTIONS_RUNNER_HOOK_JOB_STARTED environment variable at it. Use
+# it for anything that should happen once per job -- for example logging job
+# metadata, sending a notification, or preparing the workspace.
+#
+# GitHub passes job context to the hook as environment variables. See:
+# https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job
+
+set -euo pipefail
+
+echo "Running job started hook for ${GITHUB_REPOSITORY:-unknown} run ${GITHUB_RUN_ID:-unknown}"
+
+# Put your own per-job commands here.
+
+echo "Job started hook finished"

--- a/examples/typescript/job-hooks/package.json
+++ b/examples/typescript/job-hooks/package.json
@@ -1,0 +1,21 @@
+{
+    "name": "job-hooks-example",
+    "version": "1.0.0",
+    "description": "Example: Run a script before every job using GitHub Actions runner hooks",
+    "main": "app.js",
+    "scripts": {
+        "build": "tsc",
+        "watch": "tsc -w",
+        "cdk": "cdk"
+    },
+    "dependencies": {
+        "aws-cdk-lib": "^2.155.0",
+        "constructs": "^10.0.5",
+        "@cloudsnorkel/cdk-github-runners": "*"
+    },
+    "devDependencies": {
+        "typescript": "~5.6.0",
+        "@types/node": "^20.0.0",
+        "aws-cdk": "^2.155.0"
+    }
+}

--- a/src/image-builders/components.ts
+++ b/src/image-builders/components.ts
@@ -745,13 +745,11 @@ export abstract class RunnerImageComponent {
   }
 
   private static jobHook(name: string, envVar: string, sourcePath: string): RunnerImageComponent {
-    const filename = path.basename(sourcePath);
-
     const scriptPath = (os: Os): string => {
       if (os.isIn(Os._ALL_LINUX_VERSIONS)) {
-        return `/home/runner/${filename}`;
+        return `/home/runner/${envVar}.sh`;
       } else if (os.is(Os.WINDOWS)) {
-        return `C:\\actions\\${filename}`;
+        return `C:\\actions\\${envVar}.ps1`;
       }
       throw new Error(`Unsupported OS for job hook component: ${os.name}`);
     };

--- a/src/image-builders/components.ts
+++ b/src/image-builders/components.ts
@@ -713,6 +713,77 @@ export abstract class RunnerImageComponent {
   }
 
   /**
+   * A component that runs a script before every job the runner executes.
+   *
+   * Point this at a local script file. It is copied into the image, made executable, and the runner is
+   * configured to run it before each job using the
+   * [`ACTIONS_RUNNER_HOOK_JOB_STARTED`](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job)
+   * environment variable. GitHub passes job context to the script as environment variables such as `GITHUB_REPOSITORY` and `GITHUB_RUN_ID`.
+   *
+   * Must be used after the {@link githubRunner} component.
+   *
+   * @param sourcePath path to a local script file to run before every job
+   */
+  static jobStartedHook(sourcePath: string): RunnerImageComponent {
+    return RunnerImageComponent.jobHook('JobStartedHook', 'ACTIONS_RUNNER_HOOK_JOB_STARTED', sourcePath);
+  }
+
+  /**
+   * A component that runs a script after every job the runner executes.
+   *
+   * Point this at a local script file. It is copied into the image, made executable, and the runner is
+   * configured to run it after each job using the
+   * [`ACTIONS_RUNNER_HOOK_JOB_COMPLETED`](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job)
+   * environment variable. GitHub passes job context to the script as environment variables such as `GITHUB_REPOSITORY` and `GITHUB_RUN_ID`.
+   *
+   * Must be used after the {@link githubRunner} component.
+   *
+   * @param sourcePath path to a local script file to run after every job
+   */
+  static jobCompletedHook(sourcePath: string): RunnerImageComponent {
+    return RunnerImageComponent.jobHook('JobCompletedHook', 'ACTIONS_RUNNER_HOOK_JOB_COMPLETED', sourcePath);
+  }
+
+  private static jobHook(name: string, envVar: string, sourcePath: string): RunnerImageComponent {
+    const filename = path.basename(sourcePath);
+
+    const scriptPath = (os: Os): string => {
+      if (os.isIn(Os._ALL_LINUX_VERSIONS)) {
+        return `/home/runner/${filename}`;
+      } else if (os.is(Os.WINDOWS)) {
+        return `C:\\actions\\${filename}`;
+      }
+      throw new Error(`Unsupported OS for job hook component: ${os.name}`);
+    };
+
+    return new class extends RunnerImageComponent {
+      name = name;
+
+      getAssets(os: Os, _architecture: Architecture): RunnerImageAsset[] {
+        return [{
+          source: sourcePath,
+          target: scriptPath(os),
+        }];
+      }
+
+      getCommands(os: Os, _architecture: Architecture): string[] {
+        const target = scriptPath(os);
+        if (os.isIn(Os._ALL_LINUX_VERSIONS)) {
+          return [
+            `chmod +x '${target}'`,
+            `echo '${envVar}=${target}' >> /home/runner/.env`,
+          ];
+        } else if (os.is(Os.WINDOWS)) {
+          return [
+            `Add-Content -Path C:\\actions\\.env -Value '${envVar}=${target}'`,
+          ];
+        }
+        throw new Error(`Unsupported OS for job hook component: ${os.name}`);
+      }
+    }();
+  }
+
+  /**
    * Component name.
    *
    * Used to identify component in image build logs, and for {@link IConfigurableRunnerImageBuilder.removeComponent}

--- a/src/image-builders/components.ts
+++ b/src/image-builders/components.ts
@@ -717,7 +717,7 @@ export abstract class RunnerImageComponent {
    *
    * Point this at a local script file. It is copied into the image, made executable, and the runner is
    * configured to run it before each job using the
-   * [`ACTIONS_RUNNER_HOOK_JOB_STARTED`](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job)
+   * [`ACTIONS_RUNNER_HOOK_JOB_STARTED`](https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/run-scripts)
    * environment variable. GitHub passes job context to the script as environment variables such as `GITHUB_REPOSITORY` and `GITHUB_RUN_ID`.
    *
    * Must be used after the {@link githubRunner} component.
@@ -725,7 +725,7 @@ export abstract class RunnerImageComponent {
    * @param sourcePath path to a local script file to run before every job
    */
   static jobStartedHook(sourcePath: string): RunnerImageComponent {
-    return RunnerImageComponent.jobHook('JobStartedHook', 'ACTIONS_RUNNER_HOOK_JOB_STARTED', sourcePath);
+    return RunnerImageComponent.jobHook('Job-Started-Hook', 'ACTIONS_RUNNER_HOOK_JOB_STARTED', sourcePath);
   }
 
   /**
@@ -733,7 +733,7 @@ export abstract class RunnerImageComponent {
    *
    * Point this at a local script file. It is copied into the image, made executable, and the runner is
    * configured to run it after each job using the
-   * [`ACTIONS_RUNNER_HOOK_JOB_COMPLETED`](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job)
+   * [`ACTIONS_RUNNER_HOOK_JOB_COMPLETED`](https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/run-scripts)
    * environment variable. GitHub passes job context to the script as environment variables such as `GITHUB_REPOSITORY` and `GITHUB_RUN_ID`.
    *
    * Must be used after the {@link githubRunner} component.
@@ -741,7 +741,7 @@ export abstract class RunnerImageComponent {
    * @param sourcePath path to a local script file to run after every job
    */
   static jobCompletedHook(sourcePath: string): RunnerImageComponent {
-    return RunnerImageComponent.jobHook('JobCompletedHook', 'ACTIONS_RUNNER_HOOK_JOB_COMPLETED', sourcePath);
+    return RunnerImageComponent.jobHook('Job-Completed-Hook', 'ACTIONS_RUNNER_HOOK_JOB_COMPLETED', sourcePath);
   }
 
   private static jobHook(name: string, envVar: string, sourcePath: string): RunnerImageComponent {

--- a/test/components.test.ts
+++ b/test/components.test.ts
@@ -193,6 +193,55 @@ test('Environment variable escaping', () => {
   ]);
 });
 
+describe('Job hooks', () => {
+  test('jobStartedHook copies script and sets env var on Linux', () => {
+    const comp = RunnerImageComponent.jobStartedHook('/local/path/job-started.sh');
+
+    const assets = comp.getAssets(Os.LINUX_UBUNTU_2204, Architecture.X86_64);
+    expect(assets).toStrictEqual([{
+      source: '/local/path/job-started.sh',
+      target: '/home/runner/job-started.sh',
+    }]);
+
+    const commands = comp.getCommands(Os.LINUX_UBUNTU_2204, Architecture.X86_64);
+    expect(commands).toStrictEqual([
+      'chmod +x \'/home/runner/job-started.sh\'',
+      'echo \'ACTIONS_RUNNER_HOOK_JOB_STARTED=/home/runner/job-started.sh\' >> /home/runner/.env',
+    ]);
+  });
+
+  test('jobCompletedHook uses the completed env var', () => {
+    const comp = RunnerImageComponent.jobCompletedHook('/local/path/job-completed.sh');
+
+    const commands = comp.getCommands(Os.LINUX_AMAZON_2, Architecture.X86_64);
+    expect(commands).toStrictEqual([
+      'chmod +x \'/home/runner/job-completed.sh\'',
+      'echo \'ACTIONS_RUNNER_HOOK_JOB_COMPLETED=/home/runner/job-completed.sh\' >> /home/runner/.env',
+    ]);
+  });
+
+  test('job hook works on Windows', () => {
+    const comp = RunnerImageComponent.jobStartedHook('/local/path/job-started.ps1');
+
+    const assets = comp.getAssets(Os.WINDOWS, Architecture.X86_64);
+    expect(assets).toStrictEqual([{
+      source: '/local/path/job-started.ps1',
+      target: 'C:\\actions\\job-started.ps1',
+    }]);
+
+    const commands = comp.getCommands(Os.WINDOWS, Architecture.X86_64);
+    expect(commands).toStrictEqual([
+      'Add-Content -Path C:\\actions\\.env -Value \'ACTIONS_RUNNER_HOOK_JOB_STARTED=C:\\actions\\job-started.ps1\'',
+    ]);
+  });
+
+  test('job hook preserves the source file name', () => {
+    const comp = RunnerImageComponent.jobStartedHook('/some/dir/my-setup.sh');
+    const assets = comp.getAssets(Os.LINUX_UBUNTU_2204, Architecture.X86_64);
+    expect(assets[0].target).toBe('/home/runner/my-setup.sh');
+  });
+});
+
 test('Environment variable should not contain newlines', () => {
   expect(() => {
     RunnerImageComponent.environmentVariables({

--- a/test/components.test.ts
+++ b/test/components.test.ts
@@ -200,13 +200,13 @@ describe('Job hooks', () => {
     const assets = comp.getAssets(Os.LINUX_UBUNTU_2204, Architecture.X86_64);
     expect(assets).toStrictEqual([{
       source: '/local/path/job-started.sh',
-      target: '/home/runner/job-started.sh',
+      target: '/home/runner/ACTIONS_RUNNER_HOOK_JOB_STARTED.sh',
     }]);
 
     const commands = comp.getCommands(Os.LINUX_UBUNTU_2204, Architecture.X86_64);
     expect(commands).toStrictEqual([
-      'chmod +x \'/home/runner/job-started.sh\'',
-      'echo \'ACTIONS_RUNNER_HOOK_JOB_STARTED=/home/runner/job-started.sh\' >> /home/runner/.env',
+      'chmod +x \'/home/runner/ACTIONS_RUNNER_HOOK_JOB_STARTED.sh\'',
+      'echo \'ACTIONS_RUNNER_HOOK_JOB_STARTED=/home/runner/ACTIONS_RUNNER_HOOK_JOB_STARTED.sh\' >> /home/runner/.env',
     ]);
   });
 
@@ -215,8 +215,8 @@ describe('Job hooks', () => {
 
     const commands = comp.getCommands(Os.LINUX_AMAZON_2, Architecture.X86_64);
     expect(commands).toStrictEqual([
-      'chmod +x \'/home/runner/job-completed.sh\'',
-      'echo \'ACTIONS_RUNNER_HOOK_JOB_COMPLETED=/home/runner/job-completed.sh\' >> /home/runner/.env',
+      'chmod +x \'/home/runner/ACTIONS_RUNNER_HOOK_JOB_COMPLETED.sh\'',
+      'echo \'ACTIONS_RUNNER_HOOK_JOB_COMPLETED=/home/runner/ACTIONS_RUNNER_HOOK_JOB_COMPLETED.sh\' >> /home/runner/.env',
     ]);
   });
 
@@ -226,19 +226,13 @@ describe('Job hooks', () => {
     const assets = comp.getAssets(Os.WINDOWS, Architecture.X86_64);
     expect(assets).toStrictEqual([{
       source: '/local/path/job-started.ps1',
-      target: 'C:\\actions\\job-started.ps1',
+      target: 'C:\\actions\\ACTIONS_RUNNER_HOOK_JOB_STARTED.ps1',
     }]);
 
     const commands = comp.getCommands(Os.WINDOWS, Architecture.X86_64);
     expect(commands).toStrictEqual([
-      'Add-Content -Path C:\\actions\\.env -Value \'ACTIONS_RUNNER_HOOK_JOB_STARTED=C:\\actions\\job-started.ps1\'',
+      'Add-Content -Path C:\\actions\\.env -Value \'ACTIONS_RUNNER_HOOK_JOB_STARTED=C:\\actions\\ACTIONS_RUNNER_HOOK_JOB_STARTED.ps1\'',
     ]);
-  });
-
-  test('job hook preserves the source file name', () => {
-    const comp = RunnerImageComponent.jobStartedHook('/some/dir/my-setup.sh');
-    const assets = comp.getAssets(Os.LINUX_UBUNTU_2204, Architecture.X86_64);
-    expect(assets[0].target).toBe('/home/runner/my-setup.sh');
   });
 });
 


### PR DESCRIPTION
Make it easier to run a script before a job starts or after a job ends. This feature uses `ACTIONS_RUNNER_HOOK_JOB_STARTED` and `ACTIONS_RUNNER_HOOK_JOB_COMPLETED`. These are standard hooks available to GitHub self-hosted runners. They are environment variables pointing to a shell script. When set, the runner will execute those scripts as steps before a job starts and after it ends respectively.

Output from the scrips will show up in "Set up runner" and "Complete runner" steps in the job itself.

<img width="470" height="131" alt="image" src="https://github.com/user-attachments/assets/cf9d607d-2fa1-4e6d-ad05-e350633e0125" />

All of the runners we create are ephemeral so these scripts will only run once per runner. 

This PR makes this feature a bit more accessible by exposing it in `RunnerImageComponent.jobStartedHook()` and `RunnerImageComponent.jobCompletedHook()`.

The scripts have access to all the usual [environment variables](https://docs.github.com/en/actions/reference/workflows-and-actions/variables#default-environment-variables). More information about the feature is available in [GitHub's documentation](https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/run-scripts).

```typescript
const imageBuilder = Ec2RunnerProvider.imageBuilder(this, 'ImageBuilder');

imageBuilder.addComponent(
  RunnerImageComponent.jobStartedHook(path.join(__dirname, 'job-started.sh')),
);
imageBuilder.addComponent(
  RunnerImageComponent.jobCompletedHook(path.join(__dirname, 'job-completed.sh')),
);

const ec2Provider = new Ec2RunnerProvider(this, 'Ec2Provider', {
  labels: ['ec2', 'linux', 'x64'],
  imageBuilder: imageBuilder,
});

// Create the GitHub runners infrastructure
new GitHubRunners(this, 'GitHubRunners', {
  providers: [ec2Provider],
});
```

Related #762
Related #954