### PR TITLE
fix: Custom components with assets or tokens caused constant drift

### DIFF
--- a/src/image-builders/components.ts
+++ b/src/image-builders/components.ts
@@ -772,7 +772,7 @@ export abstract class RunnerImageComponent {
 
     // Create a cache key based on component identity and properties
     const stack = cdk.Stack.of(scope);
-    const cacheKey = this._getCacheKey(os, architecture, commands, assets, reboot);
+    const cacheKey = this._getCacheKey(stack, os, architecture, commands, assets, reboot);
 
     // Create a consistent ID based on the cache key to ensure the same component
     // always gets the same ID, regardless of the passed-in id parameter
@@ -810,13 +810,22 @@ export abstract class RunnerImageComponent {
    * Components with the same name, OS, architecture, commands, assets, and reboot flag will share the same key.
    * Returns a hash of all component properties to ensure uniqueness.
    *
+   * The key is built from a *canonical* representation of the inputs so it stays stable across synths
+   * and machines:
+   *  - Commands are resolved through the stack so CDK tokens (e.g. `Ref`/`Fn::GetAtt`) are hashed by
+   *    their stable intrinsic form, not by the `${Token[TOKEN.NN]}` placeholder whose counter changes
+   *    between synths.
+   *  - Assets are hashed by file content (path-independent) rather than by their local source path, so
+   *    the same file produces the same key regardless of where it lives on disk.
+   *
    * @internal
    */
-  private _getCacheKey(os: Os, architecture: Architecture, commands: string[], assets: RunnerImageAsset[], reboot: boolean): string {
-    // Create a hash of the component properties
-    const assetKeys = assets.map(a => `${a.source}:${a.target}`).sort().join('|');
-    const keyData = `${this.name}:${os.name}:${architecture.name}:${commands.join('\n')}:${assetKeys}:${reboot}`;
+  private _getCacheKey(stack: cdk.Stack, os: Os, architecture: Architecture, commands: string[], assets: RunnerImageAsset[], reboot: boolean) {
+    // Create a hash of the component properties. Only tokenized commands are resolved (plain commands
+    // are left as-is so their key is unchanged), and assets are keyed by content instead of path.
+    const commandKeys = commands.map(c => cdk.Token.isUnresolved(c) ? JSON.stringify(stack.resolve(c)) : c).join('\n');
+    const assetKeys = assets.map(a => `${cdk.FileSystem.fingerprint(a.source)}:${a.target}`).sort().join('|');
+    const keyData = `${this.name}:${os.name}:${architecture.name}:${commandKeys}:${assetKeys}:${reboot}`;
     return crypto.createHash('md5').update(keyData).digest('hex');
   }
 }
-

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -225,16 +225,16 @@
         }
       }
     },
-    "5282113eade77dedb5afde9d032a02b643fef8d387b88a3e53c0008de805217f": {
+    "49ae38fb6a469da763914834afd1fe9f788475b51dd511b0a854eba630922103": {
       "displayName": "github-runners-test Template",
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
       },
       "destinations": {
-        "current_account-current_region-f4286a90": {
+        "current_account-current_region-5f5a23c3": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "5282113eade77dedb5afde9d032a02b643fef8d387b88a3e53c0008de805217f.json",
+          "objectKey": "49ae38fb6a469da763914834afd1fe9f788475b51dd511b0a854eba630922103.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -2065,7 +2065,7 @@
      {
       "ComponentArn": {
        "Fn::GetAtt": [
-        "GHRInternalComponentCustomUndefinedWindowsX8664d3f7a4c3acComponent5FD862BB",
+        "GHRInternalComponentCustomUndefinedWindowsX8664e5637be034Component8D6515FA",
         "Arn"
        ]
       }
@@ -2652,7 +2652,7 @@
      {
       "ComponentArn": {
        "Fn::GetAtt": [
-        "GHRInternalComponentCustomUndefinedUbuntuLinuxX8664d28bedb034Component81A79437",
+        "GHRInternalComponentCustomUndefinedUbuntuLinuxX866420ed999f0eComponent2D4BD0B0",
         "Arn"
        ]
       }
@@ -5380,7 +5380,7 @@
      {
       "ComponentArn": {
        "Fn::GetAtt": [
-        "GHRInternalComponentCustomUndefinedUbuntuLinuxARM643b200da124Component670BA366",
+        "GHRInternalComponentCustomUndefinedUbuntuLinuxARM64ef11787edeComponentE759CB67",
         "Arn"
        ]
       }
@@ -5945,7 +5945,7 @@
      {
       "ComponentArn": {
        "Fn::GetAtt": [
-        "GHRInternalComponentCustomUndefinedWindowsX8664d3f7a4c3acComponent5FD862BB",
+        "GHRInternalComponentCustomUndefinedWindowsX8664e5637be034Component8D6515FA",
         "Arn"
        ]
       }
@@ -7589,7 +7589,7 @@
     "Version": "1.0.0"
    }
   },
-  "GHRInternalComponentCustomUndefinedWindowsX8664d3f7a4c3acComponent5FD862BB": {
+  "GHRInternalComponentCustomUndefinedWindowsX8664e5637be034Component8D6515FA": {
    "Type": "AWS::ImageBuilder::Component",
    "Properties": {
     "Data": {
@@ -7605,7 +7605,7 @@
      ]
     },
     "Description": "Custom-Undefined component for Windows/X86_64",
-    "Name": "github-runners-test-GHRInternal--Component-Custom-Undefined-Windows-X86-64-d3f7a4c3ac-4BCD8C61",
+    "Name": "github-runners-test-GHRInternal--Component-Custom-Undefined-Windows-X86-64-e5637be034-84ED5980",
     "Platform": "Windows",
     "Version": "1.0.0"
    }
@@ -13825,7 +13825,7 @@
     "Version": "1.0.0"
    }
   },
-  "GHRInternalComponentCustomUndefinedUbuntuLinuxX8664d28bedb034Component81A79437": {
+  "GHRInternalComponentCustomUndefinedUbuntuLinuxX866420ed999f0eComponent2D4BD0B0": {
    "Type": "AWS::ImageBuilder::Component",
    "Properties": {
     "Data": {
@@ -13841,7 +13841,7 @@
      ]
     },
     "Description": "Custom-Undefined component for Ubuntu Linux/X86_64",
-    "Name": "github-runners-test-GHRInternal--Component-Custom-Undefined-Ubuntu-Linux-X86-64-d28bedb034-19D022C3",
+    "Name": "github-runners-test-GHRInternal--Component-Custom-Undefined-Ubuntu-Linux-X86-64-20ed999f0e-44A3D40D",
     "Platform": "Linux",
     "Version": "1.0.0"
    }
@@ -14508,7 +14508,7 @@
     "Version": "1.0.0"
    }
   },
-  "GHRInternalComponentCustomUndefinedUbuntuLinuxARM643b200da124Component670BA366": {
+  "GHRInternalComponentCustomUndefinedUbuntuLinuxARM64ef11787edeComponentE759CB67": {
    "Type": "AWS::ImageBuilder::Component",
    "Properties": {
     "Data": {
@@ -14524,7 +14524,7 @@
      ]
     },
     "Description": "Custom-Undefined component for Ubuntu Linux/ARM64",
-    "Name": "github-runners-test-GHRInternal--Component-Custom-Undefined-Ubuntu-Linux-ARM64-3b200da124-273B52A1",
+    "Name": "github-runners-test-GHRInternal--Component-Custom-Undefined-Ubuntu-Linux-ARM64-ef11787ede-28F2A0A0",
     "Platform": "Linux",
     "Version": "1.0.0"
    }

--- a/test/imagebuilder.test.ts
+++ b/test/imagebuilder.test.ts
@@ -1,3 +1,6 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import * as cdk from 'aws-cdk-lib';
 import { aws_ec2 as ec2, aws_ecr as ecr, aws_ssm as ssm } from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
@@ -335,13 +338,27 @@ describe('Image Builder', () => {
 describe('Component caching', () => {
   let app: cdk.App;
   let stack: cdk.Stack;
+  const tempDirs: string[] = [];
 
   beforeEach(() => {
     app = new cdk.App();
     stack = new cdk.Stack(app, 'test');
   });
 
+  afterEach(() => {
+    // Remove any temp directories created during the test, even if it failed.
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   afterAll(CloudAssembly.cleanupTemporaryDirectories);
+
+  function tempDir(prefix: string): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    tempDirs.push(dir);
+    return dir;
+  }
 
   test('Components with same name but different commands get different IDs', () => {
     const vpc = new ec2.Vpc(stack, 'vpc');
@@ -406,6 +423,90 @@ describe('Component caching', () => {
     template.resourcePropertiesCountIs('AWS::ImageBuilder::Component', {
       Description: Match.stringLikeRegexp('Custom-SharedComponent.*'),
     }, 1);
+  });
+
+  test('Component with an asset is cached and reused', () => {
+    const vpc = new ec2.Vpc(stack, 'vpc');
+
+    const dir = tempDir('ghr-reuse-');
+    fs.writeFileSync(path.join(dir, 'script.sh'), 'echo cache-me\n');
+
+    const component = RunnerImageComponent.custom({
+      name: 'AssetComponent',
+      assets: [{ source: path.join(dir, 'script.sh'), target: '/home/runner/script.sh' }],
+    });
+
+    const builder1 = Ec2RunnerProvider.imageBuilder(stack, 'builder1', { vpc });
+    const builder2 = Ec2RunnerProvider.imageBuilder(stack, 'builder2', { vpc });
+    builder1.addComponent(component);
+    builder2.addComponent(component);
+    builder1.bindAmi();
+    builder2.bindAmi();
+
+    // Used in two builders but cached and reused -> exactly one component resource.
+    Template.fromStack(stack).resourcePropertiesCountIs('AWS::ImageBuilder::Component', {
+      Description: Match.stringLikeRegexp('Custom-AssetComponent.*'),
+    }, 1);
+  });
+
+  test('Components with the same asset content but different paths get the same ID', () => {
+    const vpc = new ec2.Vpc(stack, 'vpc');
+
+    // Same content, but different file names in different directories.
+    const dir1 = tempDir('ghr-a-');
+    const dir2 = tempDir('ghr-b-');
+    fs.writeFileSync(path.join(dir1, 'alpha.sh'), 'echo same-content\n');
+    fs.writeFileSync(path.join(dir2, 'beta.sh'), 'echo same-content\n');
+
+    const component1 = RunnerImageComponent.custom({
+      name: 'DedupComponent',
+      assets: [{ source: path.join(dir1, 'alpha.sh'), target: '/home/runner/script.sh' }],
+    });
+    const component2 = RunnerImageComponent.custom({
+      name: 'DedupComponent',
+      assets: [{ source: path.join(dir2, 'beta.sh'), target: '/home/runner/script.sh' }],
+    });
+
+    const builder1 = Ec2RunnerProvider.imageBuilder(stack, 'builder1', { vpc });
+    const builder2 = Ec2RunnerProvider.imageBuilder(stack, 'builder2', { vpc });
+    builder1.addComponent(component1);
+    builder2.addComponent(component2);
+    builder1.bindAmi();
+    builder2.bindAmi();
+
+    // The asset hash is content-based, so different file names/paths with identical
+    // content produce the same cache key -> a single shared component resource.
+    Template.fromStack(stack).resourcePropertiesCountIs('AWS::ImageBuilder::Component', {
+      Description: Match.stringLikeRegexp('Custom-DedupComponent.*'),
+    }, 1);
+  });
+
+  test('Component with a tokenized command gets a stable ID', () => {
+    // A command containing a CDK token must produce the same component logical ID even when the
+    // global token counter shifts (e.g. because unrelated tokens were created before it).
+    function tokenizedComponentLogicalId(extraTokens: number): string {
+      const tokenApp = new cdk.App();
+      const tokenStack = new cdk.Stack(tokenApp, 'test');
+      const vpc = new ec2.Vpc(tokenStack, 'vpc');
+      for (let i = 0; i < extraTokens; i++) {
+        cdk.Lazy.string({ produce: () => `extra${i}` });
+      }
+      const tokenValue = cdk.Lazy.string({ produce: () => 'resolved-value' });
+
+      const builder = Ec2RunnerProvider.imageBuilder(tokenStack, 'builder', { vpc });
+      builder.addComponent(RunnerImageComponent.custom({
+        name: 'Tokenized',
+        commands: [`echo ${tokenValue}`],
+      }));
+      builder.bindAmi();
+
+      const components = Template.fromStack(tokenStack).findResources('AWS::ImageBuilder::Component', {
+        Properties: { Description: Match.stringLikeRegexp('Custom-Tokenized.*') },
+      });
+      return Object.keys(components)[0];
+    }
+
+    expect(tokenizedComponentLogicalId(0)).toEqual(tokenizedComponentLogicalId(3));
   });
 });
 


### PR DESCRIPTION
Use `RunnerImageComponent.custom()` could cause `cdk diff` to show a difference even if the content of component hasn't actually changed. This wasted valuable deployment time and made approval pipelines bug you more often than they should.

The first problematic use case that would always generate a diff was using tokens in commands.

```typescript
const vpc: ec2.IVpc;
RunnerImageComponent.custom({
  name: 'write token',
  commands: [`echo ${vpc.vpcId} > /home/runner/vpc.txt`], // vpc.vpcId would become a token and randomize the component id
});
```

The second problematic use case was two different files with the same content. This would manifest when deploying/diffing from different machines where the working directory is different. Diffing the following example from two different directories would give you different results.

```typescript
RunnerImageComponent.custom({
  name: 'full path file',
  assets: [{
    source: path.join(__dirname, 'myfile.txt'), // __dirname would be different and then so will the component id
    target: '/home/runner/myfile.txt',
  }],
});
```

The fix is to resolve tokens and fingerprint file content instead of its path.