### PR TITLE
fix: Windows Docker image `latest` tag can disappear

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,10 @@ Other useful metrics to track:
 1. Use `GitHubRunners.metricJobCompleted()` to get a metric for the number of completed jobs broken down by labels and job success.
 2. Use `GitHubRunners.metricTime()` to get a metric for the total time a runner is running. This includes the overhead of starting the runner.
 
+## Known Issues
+
+1. Docker images built with AWS Image Builder (by default only Windows Docker images) might not be fully rolled back on deployment failure. If your stack fails to deploy after an image was already built, the new image will stay around. It will be automatically replaced on the next build interval but that might take up to 7 days with default settings (`rebuildInterval`). It's recommended to not leave stacks in `UPDATE_ROLLBACK_COMPLETE` state if you're using Windows Docker images.
+
 ## Getting Help
 
 Need help? We're here for you!

--- a/src/image-builders/aws-image-builder/delete-resources.lambda.ts
+++ b/src/image-builders/aws-image-builder/delete-resources.lambda.ts
@@ -93,6 +93,18 @@ async function deleteResources(props: DeleteResourcesProps) {
       const repo = parts[0];
       const tag = parts[1];
 
+      // skip 'latest' as it's a shared tag across recipe versions.
+      // without this skip, simple recipe upgrades will end up with latest being gone and runners not starting.
+      // old image versions will still point to 'latest' even when a new one replaced it.
+      // on complete stack destruction, ecr.Repository(... emptyOnDelete: true ...) will take care of it.
+      if (tag === 'latest') {
+        console.log({
+          notice: 'Skipping latest tag as it is shared',
+          image,
+        });
+        continue;
+      }
+
       // delete image
       await ecr.send(new BatchDeleteImageCommand({
         repositoryName: repo,

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -29,16 +29,16 @@
         }
       }
     },
-    "61d2ddf38d0094d5e2a132012961e9636df7ab755aca217fd3b11a545cdcde52": {
+    "c8204ff40a1a2de9aebe5c4383623c9db9683a11ff3ba0fcfffa6e3aa388a359": {
       "displayName": "aws-image-builder-delete-resources-dcc036c8-876b-451e-a2c1-552f9e06e9e1/Code",
       "source": {
-        "path": "asset.61d2ddf38d0094d5e2a132012961e9636df7ab755aca217fd3b11a545cdcde52.lambda",
+        "path": "asset.c8204ff40a1a2de9aebe5c4383623c9db9683a11ff3ba0fcfffa6e3aa388a359.lambda",
         "packaging": "zip"
       },
       "destinations": {
-        "current_account-current_region-46822da9": {
+        "current_account-current_region-bd5d96f5": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "61d2ddf38d0094d5e2a132012961e9636df7ab755aca217fd3b11a545cdcde52.zip",
+          "objectKey": "c8204ff40a1a2de9aebe5c4383623c9db9683a11ff3ba0fcfffa6e3aa388a359.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -225,16 +225,16 @@
         }
       }
     },
-    "49ae38fb6a469da763914834afd1fe9f788475b51dd511b0a854eba630922103": {
+    "30f658bf9b57db01a6593ce5c6f0577ef7b1f7114fdc4fa2e04aa79794a3bc35": {
       "displayName": "github-runners-test Template",
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
       },
       "destinations": {
-        "current_account-current_region-5f5a23c3": {
+        "current_account-current_region-f0c49233": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "49ae38fb6a469da763914834afd1fe9f788475b51dd511b0a854eba630922103.json",
+          "objectKey": "30f658bf9b57db01a6593ce5c6f0577ef7b1f7114fdc4fa2e04aa79794a3bc35.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -7705,7 +7705,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "61d2ddf38d0094d5e2a132012961e9636df7ab755aca217fd3b11a545cdcde52.zip"
+     "S3Key": "c8204ff40a1a2de9aebe5c4383623c9db9683a11ff3ba0fcfffa6e3aa388a359.zip"
     },
     "Description": "Custom resource handler that deletes resources of old versions of EC2 Image Builder images",
     "Environment": {


### PR DESCRIPTION
Successful stack deployments that modify the recipe for Docker runner images built using EC2 Image Builder can result in the `latest` tag being removed. This will cause any runners configured to use those images to fail to start. The error is self correcting with the default parameters (`rebuildInterval`), but that may take up to seven days.

This can happen when manually modifying, adding, or removing components. But it may also happen due to unrelated library upgrades that change something internally with the runner image components.

Windows Docker runner images (e.g. for Fargate) are built with EC2 Image Builder by default. Other Docker runner images need to specifically ask to be built with EC2 Image Builder using:

```
FargateRunnerProvider.imageBuilder(stack, 'Image builder with EC2 Image Builder', {
  builderType: RunnerImageBuilderType.AWS_IMAGE_BUILDER,
  // ...
});
```

The issue was with our `DeleteResourcesFunction` custom resource that tried to clean up the old images after the new one was built. It was getting a list of tags from EC2 Image Builder. That list included the `latest` tag even though a new image already took its place.

The fix is to ignore the `latest` tag and never clean it up. When upgrading a recipe, the tag will be replaced and point to the new image. When deleting the entire runner image builder, the tag will be deleted along with the ECR Repository thanks to `emptyOnDelete: true`.

While looking into this issue, I also found a corner case where a failed stack update may leave behind a runner image newer than intended. This happens when the stack rolls back *after* the new image was built. Since this will also resolve itself and not cause complete failure, I chose to keep this one as a known issue.