### PR TITLE
fix: Changing base image of an existing image builder can break storage size setting

### DIFF
--- a/API.md
+++ b/API.md
@@ -9285,6 +9285,7 @@ const runnerAmi: RunnerAmi = { ... }
 | <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerAmi.property.launchTemplate">launchTemplate</a></code> | <code>aws-cdk-lib.aws_ec2.ILaunchTemplate</code> | Launch template pointing to the latest AMI. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerAmi.property.os">os</a></code> | <code><a href="#@cloudsnorkel/cdk-github-runners.Os">Os</a></code> | OS type of the image. |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerAmi.property.runnerVersion">runnerVersion</a></code> | <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerVersion">RunnerVersion</a></code> | Installed runner version. |
+| <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerAmi.property.cacheKey">cacheKey</a></code> | <code>string</code> | Set this to a value that changes whenever the AMI changes (the AMI id or any version string works). |
 | <code><a href="#@cloudsnorkel/cdk-github-runners.RunnerAmi.property.logGroup">logGroup</a></code> | <code>aws-cdk-lib.aws_logs.LogGroup</code> | Log group where image builds are logged. |
 
 ---
@@ -9336,6 +9337,23 @@ public readonly runnerVersion: RunnerVersion;
 - *Type:* <a href="#@cloudsnorkel/cdk-github-runners.RunnerVersion">RunnerVersion</a>
 
 Installed runner version.
+
+---
+
+##### `cacheKey`<sup>Optional</sup> <a name="cacheKey" id="@cloudsnorkel/cdk-github-runners.RunnerAmi.property.cacheKey"></a>
+
+```typescript
+public readonly cacheKey: string;
+```
+
+- *Type:* string
+
+Set this to a value that changes whenever the AMI changes (the AMI id or any version string works).
+
+It's used to know when the AMI's root device name needs to be looked up again. If left empty, the root
+device name is looked up once and reused. That's fine as long as the AMI's root device never changes.
+
+This value may be used for other things in the future that require knowing when the AMI changed.
 
 ---
 

--- a/src/image-builders/aws-image-builder/builder.ts
+++ b/src/image-builders/aws-image-builder/builder.ts
@@ -821,6 +821,7 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
       os: this.os,
       logGroup: log,
       runnerVersion: RunnerVersion.specific('unknown'),
+      cacheKey: recipe.version, // re-evaluate AMI whenever the recipe changes
     };
 
     this.amiCleaner(recipe, stackName, builderName);

--- a/src/providers/common.ts
+++ b/src/providers/common.ts
@@ -272,6 +272,16 @@ export interface RunnerAmi {
    * @deprecated open a ticket if you need this
    */
   readonly runnerVersion: RunnerVersion;
+
+  /**
+   * Set this to a value that changes whenever the AMI changes (the AMI id or any version string works).
+   *
+   * It's used to know when the AMI's root device name needs to be looked up again. If left empty, the root
+   * device name is looked up once and reused. That's fine as long as the AMI's root device never changes.
+   *
+   * This value may be used for other things in the future that require knowing when the AMI changed.
+   */
+  readonly cacheKey?: string;
 }
 
 /**
@@ -696,7 +706,7 @@ export abstract class BaseProvider extends Construct {
  *
  * @internal
  */
-export function amiRootDevice(scope: Construct, ami?: string) {
+export function amiRootDevice(scope: Construct, ami?: string, cacheKey?: string) {
   const crHandler = singletonLambda(AmiRootDeviceFunction, scope, 'AMI Root Device Reader', {
     description: 'Custom resource handler that discovers the boot drive device name for a given AMI',
     timeout: cdk.Duration.minutes(1),
@@ -720,6 +730,7 @@ export function amiRootDevice(scope: Construct, ami?: string) {
     resourceType: 'Custom::AmiRootDevice',
     properties: {
       Ami: ami ?? '',
+      CacheKey: cacheKey,
     },
   });
 }

--- a/src/providers/ec2.ts
+++ b/src/providers/ec2.ts
@@ -521,8 +521,11 @@ export class Ec2RunnerProvider extends BaseProvider implements IRunnerProvider {
     const instanceProfile = new iam.CfnInstanceProfile(this, 'Instance Profile', {
       roles: [this.role.roleName],
     });
-    const rootDeviceResource = amiRootDevice(this, this.ami.launchTemplate.launchTemplateId);
-    rootDeviceResource.node.addDependency(this.amiBuilder);
+    const rootDeviceResource = amiRootDevice(this, this.ami.launchTemplate.launchTemplateId, this.ami.cacheKey);
+    if (Construct.isConstruct(this.amiBuilder)) {
+      // if the user didn't create a static image builder and it's a real construct, we need to wait for it
+      rootDeviceResource.node.addDependency(this.amiBuilder);
+    }
     const subnetRunners = this.subnets.map(subnet => {
       return new stepfunctions_tasks.CallAwsService(this, subnet.subnetId, {
         stateName: generateStateName(this, subnet.subnetId),

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -225,16 +225,16 @@
         }
       }
     },
-    "c08f612540061e1880e0e30b3625ba36318ff19cd03e41f6c568fe125830de45": {
+    "a5805d74188044c46872805de2702acd21514d3777e6fbd123000e583d824b33": {
       "displayName": "github-runners-test Template",
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
       },
       "destinations": {
-        "current_account-current_region-0fdcb5d8": {
+        "current_account-current_region-8769b817": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "c08f612540061e1880e0e30b3625ba36318ff19cd03e41f6c568fe125830de45.json",
+          "objectKey": "a5805d74188044c46872805de2702acd21514d3777e6fbd123000e583d824b33.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -14184,6 +14184,12 @@
     },
     "Ami": {
      "Ref": "AMILinuxBuilderLaunchtemplateA29452C4"
+    },
+    "CacheKey": {
+     "Fn::GetAtt": [
+      "AMILinuxBuilderAmiRecipe7C7ED6C7",
+      "Version"
+     ]
     }
    },
    "DependsOn": [
@@ -14510,6 +14516,12 @@
     },
     "Ami": {
      "Ref": "AMILinuxBuilderLaunchtemplateA29452C4"
+    },
+    "CacheKey": {
+     "Fn::GetAtt": [
+      "AMILinuxBuilderAmiRecipe7C7ED6C7",
+      "Version"
+     ]
     }
    },
    "DependsOn": [
@@ -14689,6 +14701,12 @@
     },
     "Ami": {
      "Ref": "AMILinuxBuilderLaunchtemplateA29452C4"
+    },
+    "CacheKey": {
+     "Fn::GetAtt": [
+      "AMILinuxBuilderAmiRecipe7C7ED6C7",
+      "Version"
+     ]
     }
    },
    "DependsOn": [
@@ -14868,6 +14886,12 @@
     },
     "Ami": {
      "Ref": "AMILinuxarm64BuilderLaunchtemplate8F5EFF44"
+    },
+    "CacheKey": {
+     "Fn::GetAtt": [
+      "AMILinuxarm64BuilderAmiRecipe6A6ED38F",
+      "Version"
+     ]
     }
    },
    "DependsOn": [
@@ -15157,6 +15181,12 @@
     },
     "Ami": {
      "Ref": "WindowsEC2BuilderLaunchtemplate0A66E9C2"
+    },
+    "CacheKey": {
+     "Fn::GetAtt": [
+      "WindowsEC2BuilderAmiRecipe41A137FF",
+      "Version"
+     ]
     }
    },
    "DependsOn": [

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -3,7 +3,17 @@ import { aws_ec2 as ec2, aws_ecs as ecs, aws_stepfunctions as sfn } from 'aws-cd
 import { Annotations, Match, Template } from 'aws-cdk-lib/assertions';
 import * as autoscaling from 'aws-cdk-lib/aws-autoscaling';
 import { CloudAssembly } from 'aws-cdk-lib/cx-api';
-import { CodeBuildRunnerProvider, Ec2RunnerProvider, EcsRunnerProvider, FargateRunnerProvider, LambdaRunnerProvider } from '../src';
+import {
+  Architecture,
+  CodeBuildRunnerProvider,
+  Ec2RunnerProvider,
+  EcsRunnerProvider,
+  FargateRunnerProvider,
+  IRunnerImageBuilder,
+  LambdaRunnerProvider,
+  Os,
+  RunnerVersion,
+} from '../src';
 
 describe('Providers', () => {
   let app: cdk.App;
@@ -418,5 +428,96 @@ describe('Providers', () => {
         InstanceTypes: ['m6g.large'],
       }));
     });
+  });
+
+  test('root device resolution re-runs when the AMI recipe changes (issue #962)', () => {
+    const vpc = new ec2.Vpc(stack, 'vpc');
+    const sg = new ec2.SecurityGroup(stack, 'sg', { vpc });
+
+    const provider = new Ec2RunnerProvider(stack, 'provider', {
+      vpc,
+      securityGroups: [sg],
+    });
+
+    // amiRootDevice() is created inside getStepFunctionTask(), not the constructor, so we have to build it.
+    const task = provider.getStepFunctionTask({
+      runnerTokenPath: '$.runner.token',
+      runnerNamePath: '$$.Execution.Name',
+      ownerPath: '$.owner',
+      repoPath: '$.repo',
+      registrationUrl: 'https://github.com',
+      githubDomainPath: 'github.com',
+      labelsPath: '$.labels',
+      addCatchAndCleanUp: (state: sfn.State | sfn.StateMachineFragment | sfn.Parallel, next?: sfn.IChainable) => {
+        (state as sfn.TaskStateBase | sfn.Parallel).addCatch(next ?? new sfn.Pass(stack, 'Cleanup'), {
+          errors: [sfn.Errors.ALL],
+          resultPath: '$.error',
+        });
+      },
+    });
+    new sfn.StateMachine(stack, 'sm', { definitionBody: sfn.DefinitionBody.fromChainable(task) });
+
+    const template = Template.fromStack(stack);
+
+    // The provider sizes the root volume by device name, so it must re-resolve the AMI's root device
+    // whenever a new AMI is built. CacheKey is wired to the recipe version so the custom resource re-runs
+    // on a recipe change (e.g. a base OS switch that moves the root device) instead of freezing at the
+    // first deploy — the #962 bug.
+    template.hasResourceProperties('Custom::AmiRootDevice', Match.objectLike({
+      CacheKey: {
+        'Fn::GetAtt': [Match.stringLikeRegexp('AmiRecipe'), 'Version'],
+      },
+    }));
+  });
+
+  test('externally-provided AMI resolves root device once (no cacheKey, no build dependency)', () => {
+    const vpc = new ec2.Vpc(stack, 'vpc');
+    const sg = new ec2.SecurityGroup(stack, 'sg', { vpc });
+
+    // object-literal builder pointing at an existing AMI — the interface explicitly allows this
+    const byoBuilder: IRunnerImageBuilder = {
+      bindDockerImage() { throw new Error('not used'); },
+      bindAmi() {
+        return {
+          launchTemplate: ec2.LaunchTemplate.fromLaunchTemplateAttributes(stack, 'byo-lt', { launchTemplateId: 'lt-01234567' }),
+          architecture: Architecture.X86_64,
+          os: Os.LINUX_UBUNTU_2404,
+          runnerVersion: RunnerVersion.latest(),
+          // no cacheKey
+        };
+      },
+    };
+
+    const provider = new Ec2RunnerProvider(stack, 'byo', {
+      vpc,
+      securityGroups: [sg],
+      imageBuilder: byoBuilder,
+      instanceType: ec2.InstanceType.of(ec2.InstanceClass.M5, ec2.InstanceSize.LARGE),
+    });
+
+    // must not throw: the object-literal builder isn't a construct, so addDependency is skipped
+    const task = provider.getStepFunctionTask({
+      runnerTokenPath: '$.runner.token',
+      runnerNamePath: '$$.Execution.Name',
+      ownerPath: '$.owner',
+      repoPath: '$.repo',
+      registrationUrl: 'https://github.com',
+      githubDomainPath: 'github.com',
+      labelsPath: '$.labels',
+      addCatchAndCleanUp: (state: sfn.State | sfn.StateMachineFragment | sfn.Parallel, next?: sfn.IChainable) => {
+        (state as sfn.TaskStateBase | sfn.Parallel).addCatch(next ?? new sfn.Pass(stack, 'CleanupByo'), {
+          errors: [sfn.Errors.ALL],
+          resultPath: '$.error',
+        });
+      },
+    });
+    new sfn.StateMachine(stack, 'sm-byo', { definitionBody: sfn.DefinitionBody.fromChainable(task) });
+
+    const template = Template.fromStack(stack);
+
+    // no version to key on → resolve once, exactly like before the fix
+    template.hasResourceProperties('Custom::AmiRootDevice', Match.objectLike({
+      CacheKey: Match.absent(),
+    }));
   });
 });


### PR DESCRIPTION
When changing the OS of a runner image builder, the resulting AMI boot device name can change. Ubuntu, for example, uses `/dev/sda1` while Amazon Linux uses `/dev/xvda`. We need to know the right name to be able to set the boot drive size. If we use the wrong name, EC2 will add a secondary drive with the size we set while everything will be expecting the boot drive to be larger than it is. This is exactly what happened in #962 when the user changed the OS without creating a new image builder object. They changed:

```typescript
new Ec2RunnerProvider(stack, 'EC2 Linux', {
  labels: ['ec2', 'linux', 'x64'],
  imageBuilder: Ec2RunnerProvider.imageBuilder(stack, 'Builder', {
    os: Os.LINUX_AMAZON_2023,
  }),
  storageSize: cdk.Size.gibibytes(40),
});
```

to:

```typescript
new Ec2RunnerProvider(stack, 'EC2 Linux', {
  labels: ['ec2', 'linux', 'x64'],
  imageBuilder: Ec2RunnerProvider.imageBuilder(stack, 'Builder', {
    os: Os.LINUX_UBUNTU,
  }),
  storageSize: cdk.Size.gibibytes(40),
});
```

This resulted in the provider starting new runner instances with the wrong boot device name. We didn't read the device boot name again from the AMI after the change.

The fix is to read the boot device name again after every image recipe change.

There is still a small window between the time the image is built and the step function gets updated with the new boot device name. If a job is started during that time, it may still get a runner but with the wrong storage configuration. It's best to create a whole new image builder instead (e.g. by modifying the image builder construct identifier from `'Builder'` to `'Builder 2'`).

Fixed #962