### PR TITLE
fix(docs): Runner groups requires registering runners in organization level

### DIFF
--- a/API.md
+++ b/API.md
@@ -6842,7 +6842,7 @@ public readonly group: string;
 GitHub Actions runner group name.
 
 If specified, the runner will be registered with this group name. Setting a runner group can help managing access to self-hosted runners. It
-requires a paid GitHub account.
+requires a paid GitHub account and organization level runner registration.
 
 The group must exist or the runner will not start.
 
@@ -7277,7 +7277,7 @@ public readonly group: string;
 GitHub Actions runner group name.
 
 If specified, the runner will be registered with this group name. Setting a runner group can help managing access to self-hosted runners. It
-requires a paid GitHub account.
+requires a paid GitHub account and organization level runner registration.
 
 The group must exist or the runner will not start.
 
@@ -7672,7 +7672,7 @@ public readonly group: string;
 GitHub Actions runner group name.
 
 If specified, the runner will be registered with this group name. Setting a runner group can help managing access to self-hosted runners. It
-requires a paid GitHub account.
+requires a paid GitHub account and organization level runner registration.
 
 The group must exist or the runner will not start.
 
@@ -8070,7 +8070,7 @@ public readonly group: string;
 GitHub Actions runner group name.
 
 If specified, the runner will be registered with this group name. Setting a runner group can help managing access to self-hosted runners. It
-requires a paid GitHub account.
+requires a paid GitHub account and organization level runner registration.
 
 The group must exist or the runner will not start.
 
@@ -8847,7 +8847,7 @@ public readonly group: string;
 GitHub Actions runner group name.
 
 If specified, the runner will be registered with this group name. Setting a runner group can help managing access to self-hosted runners. It
-requires a paid GitHub account.
+requires a paid GitHub account and organization level runner registration.
 
 The group must exist or the runner will not start.
 

--- a/SETUP_GITHUB.md
+++ b/SETUP_GITHUB.md
@@ -53,6 +53,7 @@ You will need to make several decisions during setup. Here's a quick guide to he
 
 **When to use Organization-level:**
 - You need to minimize permissions (only requires `organization_self_hosted_runners`)
+- You want to use runner groups
 - You fully trust all repositories in your organization
 - You want all repositories to share the same pool of runners
 

--- a/setup/src/App.svelte
+++ b/setup/src/App.svelte
@@ -348,6 +348,9 @@
                 on which repositories to install this app after it's created.
               </li>
               <li>
+                Organization level is <b>required</b> for <a href="https://docs.github.com/en/actions/concepts/runners/runner-groups">runner groups</a>.
+              </li>
+              <li>
                 Do not use organization level registration if you don't fully trust all repositories in your organization.
               </li>
               <li>

--- a/src/providers/codebuild.ts
+++ b/src/providers/codebuild.ts
@@ -64,7 +64,7 @@ export interface CodeBuildRunnerProviderProps extends RunnerProviderProps {
    * GitHub Actions runner group name.
    *
    * If specified, the runner will be registered with this group name. Setting a runner group can help managing access to self-hosted runners. It
-   * requires a paid GitHub account.
+   * requires a paid GitHub account and organization level runner registration.
    *
    * The group must exist or the runner will not start.
    *

--- a/src/providers/ec2.ts
+++ b/src/providers/ec2.ts
@@ -243,7 +243,7 @@ export interface Ec2RunnerProviderProps extends RunnerProviderProps {
    * GitHub Actions runner group name.
    *
    * If specified, the runner will be registered with this group name. Setting a runner group can help managing access to self-hosted runners. It
-   * requires a paid GitHub account.
+   * requires a paid GitHub account and organization level runner registration.
    *
    * The group must exist or the runner will not start.
    *

--- a/src/providers/ecs.ts
+++ b/src/providers/ecs.ts
@@ -60,7 +60,7 @@ export interface EcsRunnerProviderProps extends RunnerProviderProps {
    * GitHub Actions runner group name.
    *
    * If specified, the runner will be registered with this group name. Setting a runner group can help managing access to self-hosted runners. It
-   * requires a paid GitHub account.
+   * requires a paid GitHub account and organization level runner registration.
    *
    * The group must exist or the runner will not start.
    *

--- a/src/providers/fargate.ts
+++ b/src/providers/fargate.ts
@@ -63,7 +63,7 @@ export interface FargateRunnerProviderProps extends RunnerProviderProps {
    * GitHub Actions runner group name.
    *
    * If specified, the runner will be registered with this group name. Setting a runner group can help managing access to self-hosted runners. It
-   * requires a paid GitHub account.
+   * requires a paid GitHub account and organization level runner registration.
    *
    * The group must exist or the runner will not start.
    *

--- a/src/providers/lambda.ts
+++ b/src/providers/lambda.ts
@@ -64,7 +64,7 @@ export interface LambdaRunnerProviderProps extends RunnerProviderProps {
    * GitHub Actions runner group name.
    *
    * If specified, the runner will be registered with this group name. Setting a runner group can help managing access to self-hosted runners. It
-   * requires a paid GitHub account.
+   * requires a paid GitHub account and organization level runner registration.
    *
    * The group must exist or the runner will not start.
    *

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -183,16 +183,16 @@
         }
       }
     },
-    "6af139c1a3c5ec8b21b5783f70e1fabcbfac3f8a00796e936cecf4ec7f932dbd": {
+    "db77ca68696d20b77aee7bf6569994a5ba9fff9bc33d7027f1b4aee4262d91c1": {
       "displayName": "runners/setup/Code",
       "source": {
-        "path": "asset.6af139c1a3c5ec8b21b5783f70e1fabcbfac3f8a00796e936cecf4ec7f932dbd.lambda",
+        "path": "asset.db77ca68696d20b77aee7bf6569994a5ba9fff9bc33d7027f1b4aee4262d91c1.lambda",
         "packaging": "zip"
       },
       "destinations": {
-        "current_account-current_region-e1841bb9": {
+        "current_account-current_region-dca49e72": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "6af139c1a3c5ec8b21b5783f70e1fabcbfac3f8a00796e936cecf4ec7f932dbd.zip",
+          "objectKey": "db77ca68696d20b77aee7bf6569994a5ba9fff9bc33d7027f1b4aee4262d91c1.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -225,16 +225,16 @@
         }
       }
     },
-    "82a7619570ef1cc6d249e42e69a029ac2c401da637aad467966c5065fef67834": {
+    "e1088396661b2eeb397788a0c93491adc0b5437e58ffa5a29d1ccf5073a3c73c": {
       "displayName": "github-runners-test Template",
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
       },
       "destinations": {
-        "current_account-current_region-7f37ea12": {
+        "current_account-current_region-a6241f0d": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "82a7619570ef1cc6d249e42e69a029ac2c401da637aad467966c5065fef67834.json",
+          "objectKey": "e1088396661b2eeb397788a0c93491adc0b5437e58ffa5a29d1ccf5073a3c73c.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -19072,7 +19072,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "6af139c1a3c5ec8b21b5783f70e1fabcbfac3f8a00796e936cecf4ec7f932dbd.zip"
+     "S3Key": "db77ca68696d20b77aee7bf6569994a5ba9fff9bc33d7027f1b4aee4262d91c1.zip"
     },
     "Description": "Setup GitHub Actions integration with self-hosted runners",
     "Environment": {


### PR DESCRIPTION
Trying to specify runner group when using repository registration level results in the runner failing with:

```
Could not find any self-hosted runner group named "GROUP_NAME".
```

The runner will then be re-provisioned over and over again until the step function times out.

For now we just document this behavior. In the future, we should fail the step function early if it detects repository level registration with a defined runner group. Sadly, this is not something that can be detected during deployment as org/repo level is set during setup.