### PR TITLE
fix: Organization level runner registration is supported by PAT too

### DIFF
--- a/SETUP_GITHUB.md
+++ b/SETUP_GITHUB.md
@@ -7,12 +7,12 @@ You will need to make several decisions during setup. Here's a quick guide to he
 ### 1. Authentication Method
 
 **Choose between:**
-- **GitHub App** (recommended) - More fine-grained permissions, easier setup with wizard, better security
-- **Personal Access Token (PAT)** - Simpler but less flexible, requires manual webhook setup
+- **GitHub App** (recommended) - Easier setup with wizard, not tied to a user account, better security
+- **Personal Access Token (PAT)** - Simpler, but tied to a user account, may expire, and requires manual webhook setup
 
 **When to use App:** Almost always. Use PAT only if you have specific constraints that prevent using an app.
 
-**When to use PAT:** If you need a quick setup and don't need fine-grained permissions, or if your organization has policies preventing app creation.
+**When to use PAT:** If you need a quick setup, or if your organization has policies preventing app creation.
 
 > **⚠️ IT/DevOps Help May Be Required:** Installing a GitHub app on repositories or organizations may require repository administrator or organization owner permissions. You may need to coordinate with your IT/devops team to install the app on the desired repositories.
 
@@ -49,13 +49,14 @@ You will need to make several decisions during setup. Here's a quick guide to he
 **When to use Repository-level:**
 - You want better isolation between repositories
 - You want to reduce the risk of jobs being accidentally assigned to the wrong runners
-- You're okay with requiring the `administration` permission
+- You're okay with requiring the `administration` permission (or the `repo` scope for classic tokens)
 
 **When to use Organization-level:**
-- You need to minimize permissions (only requires `organization_self_hosted_runners`)
+- You need to minimize permissions (only requires `organization_self_hosted_runners`, or the `admin:org` scope for classic tokens)
 - You want to use runner groups
 - You fully trust all repositories in your organization
 - You want all repositories to share the same pool of runners
+- Note that organization-level registration is not available for repositories owned by a user account
 
 > **⚠️ IT/DevOps Approval May Be Required:** Organization-level registration affects all repositories in the organization. Your organization may have policies requiring approval before enabling organization-wide runner registration.
 
@@ -147,11 +148,45 @@ Integration with GitHub can be done using an [app](#app-authentication) or [pers
 
 ## Personal Access Token Authentication
 
+Personal access tokens work with both repository-level and organization-level runner registration. Both classic
+tokens and fine-grained tokens are supported. The permissions the token needs depend on the token type and on the
+[registration level](#4-runner-registration-level) you choose.
+
+> **⚠️ Note:** A personal access token is tied to the user that created it. Runners will stop working if the token
+> expires, if it is revoked, or if the user loses access to the repositories or the organization.
+
+### Required Token Permissions
+
+#### Classic Token
+
+| Registration level | Required scopes                                            |
+|--------------------|------------------------------------------------------------|
+| Repository         | `repo`                                                     |
+| Organization       | `admin:org` (or just `manage_runners:org` where available) |
+
+* `repo` is what allows registering and deleting runners on repository level.
+* For organization level, the token owner must be allowed to manage self-hosted runners in the organization (usually an organization owner).
+* Add `repo` on top of `admin:org` if you use [environment protection rules](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments) and want runners to wait for deployment approvals instead of starting immediately.
+
+#### Fine-grained Token
+
+| Registration level | Required permissions                                                                          |
+|--------------------|-----------------------------------------------------------------------------------------------|
+| Repository         | Repository &rarr; Actions: Read and write<br>Repository &rarr; Administration: Read and write |
+| Organization       | Organization &rarr; Self-hosted runners: Read and write                                       |
+
+* Repository &rarr; Deployments: Read-only is optional for both levels. It is only needed if you use [environment protection rules](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments) and want runners to wait for deployment approvals instead of starting immediately.
+* For repository-level registration, the token must have access to **every repository** that will use the runners.
+* For organization-level registration, the token's resource owner must be the organization itself, not your user.
+* Fine-grained tokens must be enabled by the organization, and may require approval by an organization owner.
+
 ### Create Token
 
-1. Go to https://github.com/settings/tokens/new
+1. Decide whether you want a classic token or a fine-grained token
+    a. For a classic token go to https://github.com/settings/tokens/new
+    b. For a fine-grained token go to https://github.com/settings/personal-access-tokens/new, set the resource owner to your user for repository-level registration or to the organization for organization-level registration, and select the repositories that will use the runners
 2. Choose your expiration date (you will need to replace the token if it expires)
-3. Under scopes select `repo`
+3. Select the scopes or permissions listed in [Required Token Permissions](#required-token-permissions) above
 4. Copy the generated token
 
 ### Set Token
@@ -162,14 +197,16 @@ Integration with GitHub can be done using an [app](#app-authentication) or [pers
 2. Choose whether you're integrating with GitHub.com or GitHub Enterprise Server
 3. Next choose Personal Access Token
 4. Enter your personal access token
-5. Click the Setup button
+5. Choose registration level for the runners
+6. Click the Setup button
 
 #### Manually
 
 1. Open the URL in `github.auth.secretUrl` from `status.json` and edit the secret value
 2. If you're using a self-hosted GitHub instance, put its domain in `domain` (e.g. `github.mycompany.com`)
 3. Put the generated token in `personalAuthToken` (**not** `personalAccessToken`)
-4. Ignore all other values
+4. If using organization level registration, add `runnerLevel` with `org` as the value (it defaults to `repo`)
+5. Ignore all other values
 
 ### Setup Webhook
 

--- a/SETUP_GITHUB.md
+++ b/SETUP_GITHUB.md
@@ -183,8 +183,8 @@ tokens and fine-grained tokens are supported. The permissions the token needs de
 ### Create Token
 
 1. Decide whether you want a classic token or a fine-grained token
-    a. For a classic token go to https://github.com/settings/tokens/new
-    b. For a fine-grained token go to https://github.com/settings/personal-access-tokens/new, set the resource owner to your user for repository-level registration or to the organization for organization-level registration, and select the repositories that will use the runners
+    1. For a classic token go to https://github.com/settings/tokens/new
+    2. For a fine-grained token go to https://github.com/settings/personal-access-tokens/new, set the resource owner to your user for repository-level registration or to the organization for organization-level registration, and select the repositories that will use the runners
 2. Choose your expiration date (you will need to replace the token if it expires)
 3. Select the scopes or permissions listed in [Required Token Permissions](#required-token-permissions) above
 4. Copy the generated token

--- a/setup/src/App.svelte
+++ b/setup/src/App.svelte
@@ -13,6 +13,9 @@
   let success: boolean;
   let result: string | undefined;
 
+  // reset registration level whenever the flow that asks for it changes
+  $: auth, appScope, runnerLevel = 'repo';
+
   interface Permissions {
     actions: 'write' | 'read';
     administration?: 'write' | 'read';
@@ -113,6 +116,9 @@
         case 'newApp':
           return postJson('domain', { domain: rightDomain, runnerLevel })
             .then(_ => {
+              (document.getElementById('appform') as HTMLFormElement).submit();
+              return Promise.resolve('Redirecting to GitHub...');
+            }).catch(_ => {
               (document.getElementById('appform') as HTMLFormElement).submit();
               return Promise.resolve('Redirecting to GitHub...');
             });

--- a/setup/src/App.svelte
+++ b/setup/src/App.svelte
@@ -127,6 +127,7 @@
           return postJson('pat', {
             pat: pat,
             domain: rightDomain,
+            runnerLevel,
           });
       }
     }
@@ -304,12 +305,99 @@
         {:else if auth === 'pat'}
           <h2>Personal Access Token</h2>
           <div class="px-3 py-3">
-            <p>The <a href="https://{domain}/settings/tokens">personal access token</a> must have the <code>repo</code>
-              scope enabled. Don't forget to also create a webhook as described in <a
+            <p>Both <a href="https://{domain}/settings/tokens">classic tokens</a> and
+              <a href="https://{domain}/settings/personal-access-tokens">fine-grained tokens</a> are supported. The
+              permissions your token needs depend on the registration level you choose below. Don't forget to also
+              create a webhook as described in <a
                 href="https://github.com/CloudSnorkel/cdk-github-runners/blob/main/SETUP_GITHUB.md">SETUP_GITHUB.md</a>.
             </p>
             <input class="form-control" bind:value={pat}
                    placeholder="Token e.g. ghp_abcdefghijklmnopqrstuvwxyz1234567890">
+          </div>
+          <h2>Registration Level</h2>
+          <div class="px-3 py-3">
+            <p>
+              Would you like runners to be registered on repository level, or on organization level?
+            </p>
+            <p>
+              <em>This determines where runners will be registered dynamically each time they are provisioned.</em>
+            </p>
+            <ul>
+              <li>
+                <strong>Repository level is recommended</strong> because runners are registered to the specific repository
+                where the job started, preventing jobs from being assigned to runners intended for other repositories.
+              </li>
+              <li>
+                Registering runners on organization level means runners are registered to the entire organization, making
+                them available to <strong>ALL repositories in the organization</strong>. This can lead to jobs being routed
+                to runners that weren't intended for them.
+              </li>
+              <li>
+                Organization level requires the token to have access to an organization. It can't be used for repositories
+                owned by a user account.
+              </li>
+              <li>
+                Organization level is <b>required</b> for <a href="https://docs.github.com/en/actions/concepts/runners/runner-groups">runner groups</a>.
+              </li>
+              <li>
+                Do not use organization level registration if you don't fully trust all repositories in your organization.
+              </li>
+              <li>
+                <strong>When in doubt, use the default repository level registration.</strong>
+              </li>
+            </ul>
+            <div class="form-check">
+              <input
+                class="form-check-input"
+                type="radio"
+                bind:group={runnerLevel}
+                value="repo"
+                id="patRepo"
+              />
+              <label class="form-check-label" for="patRepo">Repository</label>
+            </div>
+            <div class="form-check">
+              <input
+                class="form-check-input"
+                type="radio"
+                bind:group={runnerLevel}
+                value="org"
+                id="patOrg"
+              />
+              <label class="form-check-label" for="patOrg">Organization</label>
+            </div>
+          </div>
+
+          <h2>Required Token Permissions</h2>
+          <div class="px-3 py-3">
+            {#if runnerLevel === 'repo'}
+              <p>Classic token scopes:</p>
+              <ul>
+                <li><code>repo</code> (needed to register and delete runners on repository level)</li>
+              </ul>
+              <p>Fine-grained token permissions (the token must have access to every repository that will use the
+                runners):</p>
+              <ul>
+                <li>Repository &rarr; Actions: Read and write</li>
+                <li>Repository &rarr; Administration: Read and write</li>
+                <li>Repository &rarr; Deployments: Read-only (optional, only needed for environment protection rules)</li>
+              </ul>
+            {:else}
+              <p>Classic token scopes:</p>
+              <ul>
+                <li><code>admin:org</code> (or just <code>manage_runners:org</code> where available) to register and
+                  delete runners on organization level
+                </li>
+                <li><code>repo</code> (optional, only needed for environment protection rules)</li>
+              </ul>
+              <p>Fine-grained token permissions (the token's resource owner must be the organization):</p>
+              <ul>
+                <li>Organization &rarr; Self-hosted runners: Read and write</li>
+                <li>Repository &rarr; Deployments: Read-only (optional, only needed for environment protection rules)</li>
+              </ul>
+              <p>Fine-grained tokens must be allowed by the organization, and may require approval by an organization
+                owner.</p>
+            {/if}
           </div>
         {/if}
 

--- a/src/setup.lambda.ts
+++ b/src/setup.lambda.ts
@@ -71,11 +71,17 @@ async function handlePat(event: ApiGatewayEvent): Promise<AWSLambda.APIGatewayPr
     return response(400, 'Invalid personal access token');
   }
 
+  // default to 'repo' for backwards compatibility with older setup pages that didn't ask for a registration level
+  const runnerLevel = body.runnerLevel ?? 'repo';
+  if (runnerLevel !== 'repo' && runnerLevel !== 'org') {
+    return response(400, 'Invalid runner registration level');
+  }
+
   await updateSecretValue(process.env.GITHUB_SECRET_ARN, JSON.stringify(<GitHubSecrets>{
     domain: body.domain,
     appId: -1,
     personalAuthToken: body.pat,
-    runnerLevel: 'repo',
+    runnerLevel,
   }));
   await updateSecretValue(process.env.SETUP_SECRET_ARN, JSON.stringify({ token: '' }));
 

--- a/src/status.lambda.ts
+++ b/src/status.lambda.ts
@@ -264,7 +264,7 @@ export async function handler(event: Partial<AWSLambda.APIGatewayProxyEvent>) {
     } else {
       status.github.auth.personalAuthTokenScopes = scopes.join(', ');
 
-      const runnerLevel = githubSecrets.runnerLevel ?? 'repo';
+      const runnerLevel = githubSecrets.runnerLevel === 'org' ? 'org' : 'repo';
       const requiredScopes = runnerLevel === 'repo' ? ['repo'] : ['admin:org', 'manage_runners:org'];
       if (!requiredScopes.some(s => scopes.includes(s))) {
         status.github.auth.status = `OK, but token has none of the scopes required to register runners on ${runnerLevel} level: ${requiredScopes.join(' or ')}`;

--- a/src/status.lambda.ts
+++ b/src/status.lambda.ts
@@ -156,6 +156,7 @@ export async function handler(event: Partial<AWSLambda.APIGatewayProxyEvent>) {
           installations: [] as AppInstallation[],
         },
         personalAuthToken: '',
+        personalAuthTokenScopes: '',
       },
     },
     providers: await generateProvidersStatus(process.env.STACK_NAME, process.env.LOGICAL_ID),
@@ -244,8 +245,9 @@ export async function handler(event: Partial<AWSLambda.APIGatewayProxyEvent>) {
       return safeReturnValue(event, status);
     }
 
+    let user;
     try {
-      const user = await octokit.request('GET /user');
+      user = await octokit.request('GET /user');
       status.github.auth.personalAuthToken = `username: ${user.data.login}`;
     } catch (e) {
       status.github.auth.status = `Unable to call /user with personal auth token: ${e}`;
@@ -253,6 +255,22 @@ export async function handler(event: Partial<AWSLambda.APIGatewayProxyEvent>) {
     }
 
     status.github.auth.status = 'OK';
+
+    // classic tokens report their scopes in a header, so we can check them against the configured runner level
+    // fine-grained tokens don't report their permissions, so there is nothing to check for them
+    const scopes = String(user.headers['x-oauth-scopes'] ?? '').split(',').map(s => s.trim()).filter(s => s);
+    if (scopes.length == 0) {
+      status.github.auth.personalAuthTokenScopes = 'Unable to check (expected for fine-grained tokens)';
+    } else {
+      status.github.auth.personalAuthTokenScopes = scopes.join(', ');
+
+      const runnerLevel = githubSecrets.runnerLevel ?? 'repo';
+      const requiredScopes = runnerLevel === 'repo' ? ['repo'] : ['admin:org', 'manage_runners:org'];
+      if (!requiredScopes.some(s => scopes.includes(s))) {
+        status.github.auth.status = `OK, but token has none of the scopes required to register runners on ${runnerLevel} level: ${requiredScopes.join(' or ')}`;
+      }
+    }
+
     status.github.webhook.status = 'Unable to verify automatically';
   } else {
     // try authenticating with GitHub app

--- a/src/status.lambda.ts
+++ b/src/status.lambda.ts
@@ -258,10 +258,11 @@ export async function handler(event: Partial<AWSLambda.APIGatewayProxyEvent>) {
 
     // classic tokens report their scopes in a header, so we can check them against the configured runner level
     // fine-grained tokens don't report their permissions, so there is nothing to check for them
-    const scopes = String(user.headers['x-oauth-scopes'] ?? '').split(',').map(s => s.trim()).filter(s => s);
-    if (scopes.length == 0) {
+    const scopesHeader = user.headers['x-oauth-scopes'];
+    if (scopesHeader === undefined) {
       status.github.auth.personalAuthTokenScopes = 'Unable to check (expected for fine-grained tokens)';
     } else {
+      const scopes = String(scopesHeader).split(',').map(s => s.trim()).filter(s => s);
       status.github.auth.personalAuthTokenScopes = scopes.join(', ');
 
       const runnerLevel = githubSecrets.runnerLevel === 'org' ? 'org' : 'repo';

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -197,16 +197,16 @@
         }
       }
     },
-    "bd86e02f687e8f98e4d21acab3c7b4a0187d1bb6c3ff2c184b1b77be0b126512": {
+    "e99361690b22e7dd3b39c52a9d1bdc074d3de60bb54442d93171428e440e2ea1": {
       "displayName": "runners/status/Code",
       "source": {
-        "path": "asset.bd86e02f687e8f98e4d21acab3c7b4a0187d1bb6c3ff2c184b1b77be0b126512.lambda",
+        "path": "asset.e99361690b22e7dd3b39c52a9d1bdc074d3de60bb54442d93171428e440e2ea1.lambda",
         "packaging": "zip"
       },
       "destinations": {
-        "current_account-current_region-fffac0da": {
+        "current_account-current_region-5a26e32d": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "bd86e02f687e8f98e4d21acab3c7b4a0187d1bb6c3ff2c184b1b77be0b126512.zip",
+          "objectKey": "e99361690b22e7dd3b39c52a9d1bdc074d3de60bb54442d93171428e440e2ea1.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -225,16 +225,16 @@
         }
       }
     },
-    "6f7aa64ca9c4c0a8d3ec6b27fa8a0816e2606a302000ffd68281145a3b7d1799": {
+    "170f2185623a8cd803619e4e565b0d2d11e4fce445b591291f01b48aed169ed2": {
       "displayName": "github-runners-test Template",
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
       },
       "destinations": {
-        "current_account-current_region-6b1f26b6": {
+        "current_account-current_region-659186f0": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "6f7aa64ca9c4c0a8d3ec6b27fa8a0816e2606a302000ffd68281145a3b7d1799.json",
+          "objectKey": "170f2185623a8cd803619e4e565b0d2d11e4fce445b591291f01b48aed169ed2.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -183,30 +183,30 @@
         }
       }
     },
-    "db77ca68696d20b77aee7bf6569994a5ba9fff9bc33d7027f1b4aee4262d91c1": {
+    "64f68a35d321b2c89538eb445c3da7daf2ae16e49f363dfaba35229dac1f80cc": {
       "displayName": "runners/setup/Code",
       "source": {
-        "path": "asset.db77ca68696d20b77aee7bf6569994a5ba9fff9bc33d7027f1b4aee4262d91c1.lambda",
+        "path": "asset.64f68a35d321b2c89538eb445c3da7daf2ae16e49f363dfaba35229dac1f80cc.lambda",
         "packaging": "zip"
       },
       "destinations": {
-        "current_account-current_region-dca49e72": {
+        "current_account-current_region-b43595e6": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "db77ca68696d20b77aee7bf6569994a5ba9fff9bc33d7027f1b4aee4262d91c1.zip",
+          "objectKey": "64f68a35d321b2c89538eb445c3da7daf2ae16e49f363dfaba35229dac1f80cc.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "b71d20ee25113b6b7ffade2683dbfa9998462059c840d2c93301dda6b9c5ffa5": {
+    "bd86e02f687e8f98e4d21acab3c7b4a0187d1bb6c3ff2c184b1b77be0b126512": {
       "displayName": "runners/status/Code",
       "source": {
-        "path": "asset.b71d20ee25113b6b7ffade2683dbfa9998462059c840d2c93301dda6b9c5ffa5.lambda",
+        "path": "asset.bd86e02f687e8f98e4d21acab3c7b4a0187d1bb6c3ff2c184b1b77be0b126512.lambda",
         "packaging": "zip"
       },
       "destinations": {
-        "current_account-current_region-66cdbc0c": {
+        "current_account-current_region-fffac0da": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "b71d20ee25113b6b7ffade2683dbfa9998462059c840d2c93301dda6b9c5ffa5.zip",
+          "objectKey": "bd86e02f687e8f98e4d21acab3c7b4a0187d1bb6c3ff2c184b1b77be0b126512.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -225,16 +225,16 @@
         }
       }
     },
-    "8ac381688730a285091bdd1a946591be19365cbac5c079c64a47de61d6683355": {
+    "6f7aa64ca9c4c0a8d3ec6b27fa8a0816e2606a302000ffd68281145a3b7d1799": {
       "displayName": "github-runners-test Template",
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
       },
       "destinations": {
-        "current_account-current_region-dd09b4a2": {
+        "current_account-current_region-6b1f26b6": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "8ac381688730a285091bdd1a946591be19365cbac5c079c64a47de61d6683355.json",
+          "objectKey": "6f7aa64ca9c4c0a8d3ec6b27fa8a0816e2606a302000ffd68281145a3b7d1799.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -183,30 +183,30 @@
         }
       }
     },
-    "64f68a35d321b2c89538eb445c3da7daf2ae16e49f363dfaba35229dac1f80cc": {
+    "86b110d8db39e1c356b5e6c271ca21ea6157756beb7fb526fd6e63700a92659c": {
       "displayName": "runners/setup/Code",
       "source": {
-        "path": "asset.64f68a35d321b2c89538eb445c3da7daf2ae16e49f363dfaba35229dac1f80cc.lambda",
+        "path": "asset.86b110d8db39e1c356b5e6c271ca21ea6157756beb7fb526fd6e63700a92659c.lambda",
         "packaging": "zip"
       },
       "destinations": {
-        "current_account-current_region-b43595e6": {
+        "current_account-current_region-aaa15646": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "64f68a35d321b2c89538eb445c3da7daf2ae16e49f363dfaba35229dac1f80cc.zip",
+          "objectKey": "86b110d8db39e1c356b5e6c271ca21ea6157756beb7fb526fd6e63700a92659c.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "e99361690b22e7dd3b39c52a9d1bdc074d3de60bb54442d93171428e440e2ea1": {
+    "5d740e3dc3643bdd7bf3448b699ece57ee2d99417822aa1f362584171cf8aa50": {
       "displayName": "runners/status/Code",
       "source": {
-        "path": "asset.e99361690b22e7dd3b39c52a9d1bdc074d3de60bb54442d93171428e440e2ea1.lambda",
+        "path": "asset.5d740e3dc3643bdd7bf3448b699ece57ee2d99417822aa1f362584171cf8aa50.lambda",
         "packaging": "zip"
       },
       "destinations": {
-        "current_account-current_region-5a26e32d": {
+        "current_account-current_region-986f3e7e": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "e99361690b22e7dd3b39c52a9d1bdc074d3de60bb54442d93171428e440e2ea1.zip",
+          "objectKey": "5d740e3dc3643bdd7bf3448b699ece57ee2d99417822aa1f362584171cf8aa50.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -225,16 +225,16 @@
         }
       }
     },
-    "170f2185623a8cd803619e4e565b0d2d11e4fce445b591291f01b48aed169ed2": {
+    "c1259dd57e56a3e1c7aad0fc66061aa17dfa1302fb9f3a120dbd45197d5aca75": {
       "displayName": "github-runners-test Template",
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
       },
       "destinations": {
-        "current_account-current_region-659186f0": {
+        "current_account-current_region-316fb42d": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "170f2185623a8cd803619e4e565b0d2d11e4fce445b591291f01b48aed169ed2.json",
+          "objectKey": "c1259dd57e56a3e1c7aad0fc66061aa17dfa1302fb9f3a120dbd45197d5aca75.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -19072,7 +19072,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "db77ca68696d20b77aee7bf6569994a5ba9fff9bc33d7027f1b4aee4262d91c1.zip"
+     "S3Key": "64f68a35d321b2c89538eb445c3da7daf2ae16e49f363dfaba35229dac1f80cc.zip"
     },
     "Description": "Setup GitHub Actions integration with self-hosted runners",
     "Environment": {
@@ -19406,7 +19406,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "b71d20ee25113b6b7ffade2683dbfa9998462059c840d2c93301dda6b9c5ffa5.zip"
+     "S3Key": "bd86e02f687e8f98e4d21acab3c7b4a0187d1bb6c3ff2c184b1b77be0b126512.zip"
     },
     "Description": "Provide user with status about self-hosted GitHub Actions runners",
     "Environment": {

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -19406,7 +19406,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "bd86e02f687e8f98e4d21acab3c7b4a0187d1bb6c3ff2c184b1b77be0b126512.zip"
+     "S3Key": "e99361690b22e7dd3b39c52a9d1bdc074d3de60bb54442d93171428e440e2ea1.zip"
     },
     "Description": "Provide user with status about self-hosted GitHub Actions runners",
     "Environment": {

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -19072,7 +19072,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "64f68a35d321b2c89538eb445c3da7daf2ae16e49f363dfaba35229dac1f80cc.zip"
+     "S3Key": "86b110d8db39e1c356b5e6c271ca21ea6157756beb7fb526fd6e63700a92659c.zip"
     },
     "Description": "Setup GitHub Actions integration with self-hosted runners",
     "Environment": {
@@ -19406,7 +19406,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "e99361690b22e7dd3b39c52a9d1bdc074d3de60bb54442d93171428e440e2ea1.zip"
+     "S3Key": "5d740e3dc3643bdd7bf3448b699ece57ee2d99417822aa1f362584171cf8aa50.zip"
     },
     "Description": "Provide user with status about self-hosted GitHub Actions runners",
     "Environment": {


### PR DESCRIPTION
It should be possible to select organization level registration for personal access tokens (PAT) too. Both classic and fine grained tokens are able to get the right permissions to have it working. This PR documents this ability and enables the selection in the setup wizard.