### PR TITLE
chore: Reduce build log size

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -744,7 +744,7 @@
       "description": "Run tests",
       "steps": [
         {
-          "exec": "jest --passWithNoTests --updateSnapshot",
+          "exec": "jest --silent --passWithNoTests --updateSnapshot",
           "receiveArgs": true
         },
         {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -126,6 +126,10 @@ const project = new awscdk.AwsCdkConstructLibrary({
       isolatedModules: true,
     },
   },
+  jestOptions: {
+    // too many console.log() lines in EVERY build
+    extraCliOptions: ['--silent'],
+  },
 });
 
 // disable automatic releases, but keep workflow that can be triggered manually

--- a/setup/vite.config.mts
+++ b/setup/vite.config.mts
@@ -1,12 +1,21 @@
-import { defineConfig } from 'vite';
-import { svelte } from '@sveltejs/vite-plugin-svelte';
 import * as path from 'path';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { defineConfig } from 'vite';
 import { viteSingleFile } from 'vite-plugin-singlefile';
 
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [svelte(), viteSingleFile()],
+  css: {
+    preprocessorOptions: {
+      scss: {
+        // Bootstrap 5.3 doesn't support sass modules -- but 6 will
+        quietDeps: true,
+        silenceDeprecations: ['import'],
+      },
+    },
+  },
   resolve: {
     alias: {
       '~bootstrap': path.resolve(__dirname, '..', 'node_modules/bootstrap'),


### PR DESCRIPTION
1. Our unit tests print a lot of log lines. We don't need them unless there is a failure. So we use `jest --silent`.
2. Setup page build produces a lot of warnings due to Bootstrap 5 not having support for sass modules yet. Supress them.