### PR TITLE
chore: Clarification on newer images being left behind + test

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ Other useful metrics to track:
 
 ## Known Issues
 
-1. Docker images built with AWS Image Builder (by default only Windows Docker images) might not be fully rolled back on deployment failure. If your stack fails to deploy after an image was already built, the new image will stay around. It will be automatically replaced on the next build interval but that might take up to 7 days with default settings (`rebuildInterval`). It's recommended to not leave stacks in `UPDATE_ROLLBACK_COMPLETE` state if you're using Windows Docker images.
+1. Runner images built during a failed deployment are not rolled back. If your stack fails to deploy after an image was already built, the new image will stay in use. The image will be automatically replaced on the next build interval, but that might take up to 7 days with default settings (`rebuildInterval`). It's recommended to not leave stacks in `UPDATE_ROLLBACK_COMPLETE` state. Deploying again with the configuration you want will rebuild the images and get everything back in sync.
 
 ## Getting Help
 
@@ -689,3 +689,4 @@ Thanks to our generous sponsors who helped make this project possible!
 [17]: https://github.com/CloudSnorkel/cdk-github-runners/pulls
 [18]: https://github.com/CloudSnorkel/cdk-github-runners/discussions
 [20]: https://discord.gg/vdrTUTqQKv
+[21]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-continueupdaterollback.html

--- a/README.md
+++ b/README.md
@@ -689,4 +689,3 @@ Thanks to our generous sponsors who helped make this project possible!
 [17]: https://github.com/CloudSnorkel/cdk-github-runners/pulls
 [18]: https://github.com/CloudSnorkel/cdk-github-runners/discussions
 [20]: https://discord.gg/vdrTUTqQKv
-[21]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-continueupdaterollback.html

--- a/TESTING.md
+++ b/TESTING.md
@@ -53,7 +53,7 @@ Integration tests check the happy paths. We should also test the unhappy paths m
 * Stolen runner detection
   * Confirm a new runner is created when an unknown job is assigned to one of our runners
 * Other tests to be automated in the future
-  * Go to `default.integ.ts` and enable the test flags at the top
+  * Go to [`default.integ.ts`](test/default.integ.ts) and enable the test flags at the top
 
 The two retries scenarios can be tested with the following test cases: 
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -52,6 +52,8 @@ Integration tests check the happy paths. We should also test the unhappy paths m
   * Confirm failed runner doesn't stay registered in GitHub
 * Stolen runner detection
   * Confirm a new runner is created when an unknown job is assigned to one of our runners
+* Other tests to be automated in the future
+  * Go to `default.integ.ts` and enable the test flags at the top
 
 The two retries scenarios can be tested with the following test cases: 
 

--- a/test/default.integ.ts
+++ b/test/default.integ.ts
@@ -28,7 +28,7 @@ import {
 } from '../src';
 
 // turn this on to test what happens if a stack fails deploying after an image was already built.
-// we have an open issue where the new version of the image remains until the next automatic build.
+// we have an open issue where the new version of the image remains until the next scheduled build.
 // after failing to deploy, run the integration tests. any provider that fails is using the new image which doesn't match the rolled back stack.
 const testDeploymentFailureAfterImageBuilt = false;
 

--- a/test/default.integ.ts
+++ b/test/default.integ.ts
@@ -101,7 +101,7 @@ const fargateArm64Builder = FargateRunnerProvider.imageBuilder(stack, 'Fargate b
 fargateArm64Builder.addComponent(extraFilesComponentLinux);
 fargateArm64Builder.addComponent(envComponent);
 
-const lambdaImageBuilder = LambdaRunnerProvider.imageBuilder(stack, 'Lambda Image Builder x64 2', {
+const lambdaImageBuilder = LambdaRunnerProvider.imageBuilder(stack, 'Lambda Image Builder x64', {
   architecture: Architecture.X86_64,
 });
 lambdaImageBuilder.addComponent(extraFilesComponentLinux);

--- a/test/default.integ.ts
+++ b/test/default.integ.ts
@@ -5,7 +5,15 @@
  */
 
 import * as cdk from 'aws-cdk-lib';
-import { aws_codebuild as codebuild, aws_ec2 as ec2, aws_ecs as ecs, aws_lambda as lambda, aws_logs as logs } from 'aws-cdk-lib';
+import {
+  aws_cloudformation as cloudformation,
+  aws_codebuild as codebuild,
+  aws_ec2 as ec2,
+  aws_ecs as ecs,
+  aws_lambda as lambda,
+  aws_logs as logs,
+} from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 import {
   Architecture,
   CodeBuildRunnerProvider,
@@ -18,6 +26,11 @@ import {
   Os,
   RunnerImageComponent,
 } from '../src';
+
+// turn this on to test what happens if a stack fails deploying after an image was already built.
+// we have an open issue where the new version of the image remains until the next automatic build.
+// after failing to deploy, run the integration tests. any provider that fails is using the new image which doesn't match the rolled back stack.
+const testDeploymentFailureAfterImageBuilt = false;
 
 const app = new cdk.App();
 const stack = new cdk.Stack(app, 'github-runners-test');
@@ -47,7 +60,7 @@ const sg = new ec2.SecurityGroup(stack, 'SG', {
 
 const extraFilesComponentLinux = RunnerImageComponent.custom({
   commands: [
-    'touch /custom-file',
+    testDeploymentFailureAfterImageBuilt ? 'echo skipping custom-file' : 'touch /custom-file',
     'mkdir /custom-dir',
     'mv FUNDING.yml /custom-dir',
   ],
@@ -60,7 +73,7 @@ const extraFilesComponentLinux = RunnerImageComponent.custom({
 });
 const extraFilesComponentWindows = RunnerImageComponent.custom({
   commands: [
-    'New-Item -ItemType file -Path / -Name custom-file',
+    testDeploymentFailureAfterImageBuilt ? 'echo skipping custom-file' : 'New-Item -ItemType file -Path / -Name custom-file',
     'New-Item -ItemType directory -Path / -Name custom-dir',
     'Move-Item FUNDING.yml /custom-dir',
   ],
@@ -88,7 +101,7 @@ const fargateArm64Builder = FargateRunnerProvider.imageBuilder(stack, 'Fargate b
 fargateArm64Builder.addComponent(extraFilesComponentLinux);
 fargateArm64Builder.addComponent(envComponent);
 
-const lambdaImageBuilder = LambdaRunnerProvider.imageBuilder(stack, 'Lambda Image Builder x64', {
+const lambdaImageBuilder = LambdaRunnerProvider.imageBuilder(stack, 'Lambda Image Builder x64 2', {
   architecture: Architecture.X86_64,
 });
 lambdaImageBuilder.addComponent(extraFilesComponentLinux);
@@ -405,5 +418,32 @@ runners.metricJobCompleted();
 runners.failedImageBuildsTopic();
 runners.metricStolenRunners();
 runners.createLogsInsightsQueries();
+
+if (testDeploymentFailureAfterImageBuilt) {
+  const rollbackTestHandle = new cloudformation.CfnWaitConditionHandle(stack, 'Rollback Test Handle');
+  const rollbackTestFailure = new cloudformation.CfnWaitCondition(stack, 'Rollback Test Failure', {
+    handle: rollbackTestHandle.ref,
+    timeout: '60', // nobody ever signals this, so it times out and fails the update
+    count: 1,
+  });
+  for (const dependency of [
+    fargateX64Builder,
+    fargateArm64Builder,
+    lambdaImageBuilder,
+    windowsImageBuilder,
+    amiX64Builder,
+    codeBuildImageBuilder,
+    codeBuildUbuntu2404ImageBuilder,
+    codeBuildArm64ImageBuilder,
+    lambdaArm64ImageBuilder,
+    ec2ImageBuilder,
+    ec2WindowsImageBuilder,
+    runners,
+  ]) {
+    if (Construct.isConstruct(dependency)) {
+      rollbackTestFailure.node.addDependency(dependency);
+    }
+  }
+}
 
 app.synth();


### PR DESCRIPTION
It's not just Docker, not just Windows, and not just EC2 Image Builder. It's all of them. Added a test to prove it.