### PR TITLE
fix: Lambda runner deployments can't be rolled back

### DIFF
--- a/src/image-builders/codebuild-deprecated.ts
+++ b/src/image-builders/codebuild-deprecated.ts
@@ -363,7 +363,7 @@ export class CodeBuildImageBuilder extends Construct implements IRunnerImageBuil
       os: this.os,
       logGroup,
       runnerVersion: this.props.runnerVersion ?? RunnerVersion.latest(),
-      _dependable: cr.ref,
+      _dependable: cr,
     };
     return this.boundImage;
   }

--- a/src/image-builders/codebuild.ts
+++ b/src/image-builders/codebuild.ts
@@ -391,7 +391,7 @@ export class CodeBuildRunnerImageBuilder extends RunnerImageBuilderBase {
     }));
 
     let waitHandleRef = 'unspecified';
-    let waitDependable = '';
+    let waitDependable: cloudformation.CfnWaitCondition | undefined;
 
     if (this.waitOnDeploy) {
       // Wait handle lets us wait for longer than an hour for the image build to complete.
@@ -405,7 +405,7 @@ export class CodeBuildRunnerImageBuilder extends RunnerImageBuilderBase {
         count: 1,
       });
       waitHandleRef = handle.ref;
-      waitDependable = wait.ref;
+      waitDependable = wait;
     }
 
     const cr = new CustomResource(this, 'Builder', {
@@ -425,7 +425,7 @@ export class CodeBuildRunnerImageBuilder extends RunnerImageBuilderBase {
     cr.node.addDependency(crHandler.role!);
     cr.node.addDependency(crHandler);
 
-    return waitDependable; // user needs to wait on wait handle which is triggered when the image is built
+    return waitDependable; // user needs to wait on the wait condition which is signaled when the image is built
   }
 
   private rebuildImageOnSchedule(project: codebuild.Project, rebuildInterval?: Duration) {

--- a/src/image-builders/static.ts
+++ b/src/image-builders/static.ts
@@ -1,5 +1,5 @@
 import { aws_ecr as ecr } from 'aws-cdk-lib';
-import { Construct } from 'constructs';
+import { Construct, DependencyGroup } from 'constructs';
 import { BaseContainerImage } from './aws-image-builder/base-image';
 import { CodeBuildRunnerImageBuilder } from './codebuild';
 import { IRunnerImageBuilder } from './common';
@@ -26,7 +26,9 @@ export class StaticRunnerImage {
           architecture,
           os,
           runnerVersion: RunnerVersion.latest(),
-          _dependable: repository,
+          // the image already exists, so there is nothing to wait for. we still need a dependable, or
+          // providers that require one (like Lambda) will refuse to use this image.
+          _dependable: new DependencyGroup(),
         };
       },
 

--- a/src/image-builders/static.ts
+++ b/src/image-builders/static.ts
@@ -26,7 +26,7 @@ export class StaticRunnerImage {
           architecture,
           os,
           runnerVersion: RunnerVersion.latest(),
-          _dependable: repository.repositoryArn,
+          _dependable: repository,
         };
       },
 

--- a/src/providers/common.ts
+++ b/src/providers/common.ts
@@ -11,7 +11,7 @@ import {
   Duration,
 } from 'aws-cdk-lib';
 import { EbsDeviceVolumeType } from 'aws-cdk-lib/aws-ec2';
-import { Construct, IConstruct } from 'constructs';
+import { Construct, IConstruct, IDependable } from 'constructs';
 import { AmiRootDeviceFunction } from './ami-root-device-function';
 import { singletonLambda, singletonLogGroup, SingletonLogType } from '../utils';
 
@@ -235,11 +235,11 @@ export interface RunnerImage {
   readonly runnerVersion: RunnerVersion;
 
   /**
-   * A dependable string that can be waited on to ensure the image is ready.
+   * A dependable that can be waited on to ensure the image is ready.
    *
    * @internal
    */
-  readonly _dependable?: string;
+  readonly _dependable?: IDependable;
 }
 
 /**

--- a/src/providers/lambda.ts
+++ b/src/providers/lambda.ts
@@ -304,8 +304,10 @@ export class LambdaRunnerProvider extends BaseProvider implements IRunnerProvide
       // references the ref anymore. keep exporting it, so upgrades don't fail with "export cannot be deleted as it is
       // in use". TODO deprecated hack - remove in a future version once everyone has upgraded.
       if (Construct.isConstruct(image._dependable) && cloudformation.CfnWaitCondition.isCfnWaitCondition(image._dependable)) {
-        if (cdk.Stack.of(image._dependable) !== cdk.Stack.of(this)) {
-          cdk.Stack.of(image._dependable).exportValue(image._dependable.ref);
+        if (cdk.Stack.of(image._dependable) !== cdk.Stack.of(this)) { // cross-stack
+          if (!cdk.Stack.of(image._dependable).nestedStackParent) { // not a nested stack
+            cdk.Stack.of(image._dependable).exportValue(image._dependable.ref);
+          }
         }
       }
     }

--- a/src/providers/lambda.ts
+++ b/src/providers/lambda.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import * as cdk from 'aws-cdk-lib';
 import {
+  aws_cloudformation as cloudformation,
   aws_ec2 as ec2,
   aws_events as events,
   aws_events_targets as events_targets,
@@ -9,13 +10,13 @@ import {
   aws_logs as logs,
   aws_stepfunctions as stepfunctions,
   aws_stepfunctions_tasks as stepfunctions_tasks,
-  custom_resources as cr,
 } from 'aws-cdk-lib';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
 import {
   Architecture,
   BaseProvider,
+  generateStateName,
   IRunnerProvider,
   IRunnerProviderStatus,
   IRunnerRuntimeParameters,
@@ -23,7 +24,6 @@ import {
   RunnerImage,
   RunnerProviderProps,
   RunnerVersion,
-  generateStateName,
 } from './common';
 import { UpdateLambdaFunction } from './update-lambda-function';
 import { IRunnerImageBuilder, RunnerImageBuilder, RunnerImageBuilderProps, RunnerImageComponent } from '../image-builders';
@@ -270,26 +270,6 @@ export class LambdaRunnerProvider extends BaseProvider implements IRunnerProvide
       cdk.Annotations.of(this).addError('Lambda provider can only work with images built by CodeBuild and not AWS Image Builder. `waitOnDeploy: false` is also not supported.');
     }
 
-    // get image digest and make sure to get it every time the lambda function might be updated
-    // pass all variables that may change and cause a function update
-    // if we don't get the latest digest, the update may fail as a new image was already built outside the stack on a schedule
-    // we automatically delete old images, so we must always get the latest digest
-    const imageDigest = this.imageDigest(image, {
-      version: 1, // bump this for any non-user changes like description or defaults
-      labels: this.labels,
-      architecture: architecture.name,
-      vpc: this.vpc?.vpcId,
-      securityGroups: this.securityGroups?.map(sg => sg.securityGroupId),
-      vpcSubnets: props?.subnetSelection?.subnets?.map(s => s.subnetId),
-      timeout: props?.timeout?.toSeconds(),
-      memorySize: props?.memorySize,
-      ephemeralStorageSize: props?.ephemeralStorageSize?.toKibibytes(),
-      logRetention: props?.logRetention?.toFixed(),
-      // update on image build too to avoid conflict of the scheduled updater and any other CDK updates like VPC
-      // this also helps with rollbacks as it will always get the right digest and prevent rollbacks using deleted images from failing
-      dependable: image._dependable,
-    });
-
     this.logGroup = new logs.LogGroup(this, 'Log', {
       removalPolicy: cdk.RemovalPolicy.DESTROY,
       retention: props?.logRetention ?? RetentionDays.ONE_MONTH,
@@ -300,8 +280,10 @@ export class LambdaRunnerProvider extends BaseProvider implements IRunnerProvide
       'Function',
       {
         description: `GitHub Actions runner for labels ${this.labels}`,
-        // CDK requires "sha256:" literal prefix -- https://github.com/aws/aws-cdk/blob/ba91ca45ad759ab5db6da17a62333e2bc11e1075/packages/%40aws-cdk/aws-ecr/lib/repository.ts#L184
-        code: lambda.DockerImageCode.fromEcr(image.imageRepository, { tagOrDigest: `sha256:${imageDigest}` }),
+        // we point to `latest` (or the tag the user chose) which is always the right image tag for the latest build
+        // but lambda "locks in" the image digest when the function is created
+        // we have this.imageUpdater() to update the function with the latest image digest whenever the image is rebuilt
+        code: lambda.DockerImageCode.fromEcr(image.imageRepository, { tagOrDigest: image.imageTag }),
         architecture,
         vpc: this.vpc,
         securityGroups: this.securityGroups,
@@ -312,6 +294,21 @@ export class LambdaRunnerProvider extends BaseProvider implements IRunnerProvide
         logGroup: this.logGroup,
       },
     );
+
+    // the image must exist before the function is created, or Lambda won't be able to resolve the tag
+    if (image._dependable) {
+      this.function.node.addDependency(image._dependable);
+
+      // we used to pass the wait condition ref around as a string, which created a cross-stack export when the image
+      // builder and the provider were in separate stacks. we now depend on the wait condition itself, so nothing
+      // references the ref anymore. keep exporting it, so upgrades don't fail with "export cannot be deleted as it is
+      // in use". TODO deprecated hack - remove in a future version once everyone has upgraded.
+      if (Construct.isConstruct(image._dependable) && cloudformation.CfnWaitCondition.isCfnWaitCondition(image._dependable)) {
+        if (cdk.Stack.of(image._dependable) !== cdk.Stack.of(this)) {
+          cdk.Stack.of(image._dependable).exportValue(image._dependable.ref);
+        }
+      }
+    }
 
     this.grantPrincipal = this.function.grantPrincipal;
 
@@ -355,8 +352,15 @@ export class LambdaRunnerProvider extends BaseProvider implements IRunnerProvide
   }
 
   private addImageUpdater(image: RunnerImage) {
-    // Lambda needs to be pointing to a specific image digest and not just a tag.
-    // Whenever we update the tag to a new digest, we need to update the lambda.
+    // Lambda resolves the image tag when the function is created or updated, and then sticks to that image.
+    // Lambda doesn't automatically follow the tag on image push.
+    // whenever a new image is pushed, we have to explicitly tell the function to use it.
+
+    // corner case issue: if the user updates the function and its code on the same deploy, both CloudFormation and our rule here will try to update
+    // the function at the same time. both retry. our updater retries for 15 minutes times 3 Lambda retries. if for whatever reason CloudFormation
+    // takes longer than that, the updater will fail and the function will be left with the old image. the image should be automatically updated on
+    // the next scheduled image update and the function will be updated with the latest image. this is a rare case and should not happen often, but it
+    // is possible.
 
     const updater = singletonLambda(UpdateLambdaFunction, this, 'update-lambda', {
       description: 'Function that updates a GitHub Actions runner function with the latest image digest after the image has been rebuilt',
@@ -417,64 +421,6 @@ export class LambdaRunnerProvider extends BaseProvider implements IRunnerProvide
         imageBuilderLogGroup: this.image.logGroup?.logGroupName,
       },
     };
-  }
-
-  private imageDigest(image: RunnerImage, variableSettings: any): string {
-    // describe ECR image to get its digest
-    // the physical id is random so the resource always runs and always gets the latest digest, even if a scheduled build replaced the stack image
-    const reader = new cr.AwsCustomResource(this, 'Image Digest Reader', {
-      onCreate: {
-        service: 'ECR',
-        action: 'describeImages',
-        parameters: {
-          repositoryName: image.imageRepository.repositoryName,
-          imageIds: [
-            {
-              imageTag: image.imageTag,
-            },
-          ],
-        },
-        physicalResourceId: cr.PhysicalResourceId.of('ImageDigest'),
-      },
-      onUpdate: {
-        service: 'ECR',
-        action: 'describeImages',
-        parameters: {
-          repositoryName: image.imageRepository.repositoryName,
-          imageIds: [
-            {
-              imageTag: image.imageTag,
-            },
-          ],
-        },
-        physicalResourceId: cr.PhysicalResourceId.of('ImageDigest'),
-      },
-      onDelete: {
-        // this will NOT be called thanks to RemovalPolicy.RETAIN below
-        // we only use this to force the custom resource to be called again and get a new digest
-        service: 'fake',
-        action: 'fake',
-        parameters: variableSettings,
-      },
-      policy: cr.AwsCustomResourcePolicy.fromSdkCalls({
-        resources: [image.imageRepository.repositoryArn],
-      }),
-      resourceType: 'Custom::EcrImageDigest',
-      installLatestAwsSdk: false, // no need and it takes 60 seconds
-      logGroup: singletonLogGroup(this, SingletonLogType.RUNNER_IMAGE_BUILD),
-    });
-
-    // mark this resource as retainable, as there is nothing to do on delete
-    const res = reader.node.tryFindChild('Resource') as cdk.CustomResource | undefined;
-    if (res) {
-      // don't actually call the fake onDelete above
-      res.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN);
-    } else {
-      throw new Error('Resource not found in AwsCustomResource. Report this bug at https://github.com/CloudSnorkel/cdk-github-runners/issues.');
-    }
-
-    // return only the digest because CDK expects 'sha256:' literal above
-    return cdk.Fn.split(':', reader.getResponseField('imageDetails.0.imageDigest'), 2)[1];
   }
 }
 

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -169,20 +169,6 @@
         }
       }
     },
-    "56f7467bbde8a5efebcf57ae9e460027607099bab9f844669dcf5d800172ee5a": {
-      "displayName": "AWS679f53fac002430cb0da5b7982bd2287/Code",
-      "source": {
-        "path": "asset.56f7467bbde8a5efebcf57ae9e460027607099bab9f844669dcf5d800172ee5a",
-        "packaging": "zip"
-      },
-      "destinations": {
-        "current_account-current_region-f3c562d4": {
-          "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "56f7467bbde8a5efebcf57ae9e460027607099bab9f844669dcf5d800172ee5a.zip",
-          "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
-        }
-      }
-    },
     "74442a2c5f7ea4e19a15bb651ae93ff9e9faa65f51f5f9fc77851f4f24a80a64": {
       "displayName": "update-lambda-dcc036c8-876b-451e-a2c1-552f9e06e9e1/Code",
       "source": {
@@ -323,16 +309,16 @@
         }
       }
     },
-    "db4fcca773c104b1be6c9ea8aeaeb477f02c564b3154c8567cea47530968bd99": {
+    "cf12b4f449fac9269a34b2cee0f6af950d0597a2ffb15e8a6e82ce184e9adb40": {
       "displayName": "github-runners-test Template",
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
       },
       "destinations": {
-        "current_account-current_region-dbbe14fe": {
+        "current_account-current_region-522e1c9c": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "db4fcca773c104b1be6c9ea8aeaeb477f02c564b3154c8567cea47530968bd99.json",
+          "objectKey": "cf12b4f449fac9269a34b2cee0f6af950d0597a2ffb15e8a6e82ce184e9adb40.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -11078,95 +11078,6 @@
     ]
    }
   },
-  "LambdaImageDigestReaderE0842577": {
-   "Type": "Custom::EcrImageDigest",
-   "Properties": {
-    "ServiceToken": {
-     "Fn::GetAtt": [
-      "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
-      "Arn"
-     ]
-    },
-    "Create": {
-     "Fn::Join": [
-      "",
-      [
-       "{\"service\":\"ECR\",\"action\":\"describeImages\",\"parameters\":{\"repositoryName\":\"",
-       {
-        "Ref": "LambdaImageBuilderx64Repository57F632F1"
-       },
-       "\",\"imageIds\":[{\"imageTag\":\"latest\"}]},\"physicalResourceId\":{\"id\":\"ImageDigest\"}}"
-      ]
-     ]
-    },
-    "Update": {
-     "Fn::Join": [
-      "",
-      [
-       "{\"service\":\"ECR\",\"action\":\"describeImages\",\"parameters\":{\"repositoryName\":\"",
-       {
-        "Ref": "LambdaImageBuilderx64Repository57F632F1"
-       },
-       "\",\"imageIds\":[{\"imageTag\":\"latest\"}]},\"physicalResourceId\":{\"id\":\"ImageDigest\"}}"
-      ]
-     ]
-    },
-    "Delete": {
-     "Fn::Join": [
-      "",
-      [
-       "{\"service\":\"fake\",\"action\":\"fake\",\"parameters\":{\"version\":1,\"labels\":[\"lambda\",\"x64\"],\"architecture\":\"x86_64\",\"dependable\":\"",
-       {
-        "Ref": "LambdaImageBuilderx64BuildWait195db8dedf29464C8D"
-       },
-       "\"}}"
-      ]
-     ]
-    },
-    "InstallLatestAwsSdk": false
-   },
-   "DependsOn": [
-    "LambdaImageDigestReaderCustomResourcePolicyE8E146E6"
-   ],
-   "UpdateReplacePolicy": "Retain",
-   "DeletionPolicy": "Retain"
-  },
-  "LambdaImageDigestReaderCustomResourcePolicyE8E146E6": {
-   "Type": "AWS::IAM::Policy",
-   "Properties": {
-    "PolicyDocument": {
-     "Statement": [
-      {
-       "Action": "ecr:DescribeImages",
-       "Effect": "Allow",
-       "Resource": {
-        "Fn::GetAtt": [
-         "LambdaImageBuilderx64Repository57F632F1",
-         "Arn"
-        ]
-       }
-      },
-      {
-       "Action": "fake:Fake",
-       "Effect": "Allow",
-       "Resource": {
-        "Fn::GetAtt": [
-         "LambdaImageBuilderx64Repository57F632F1",
-         "Arn"
-        ]
-       }
-      }
-     ],
-     "Version": "2012-10-17"
-    },
-    "PolicyName": "LambdaImageDigestReaderCustomResourcePolicyE8E146E6",
-    "Roles": [
-     {
-      "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2"
-     }
-    ]
-   }
-  },
   "LambdaLog2764B04F": {
    "Type": "AWS::Logs::LogGroup",
    "Properties": {
@@ -11243,7 +11154,10 @@
       "Value": "github-runners-test/Lambda"
      }
     ]
-   }
+   },
+   "DependsOn": [
+    "LambdaImageBuilderx64BuildWait195db8dedf29464C8D"
+   ]
   },
   "LambdaFunction9233991D": {
    "Type": "AWS::Lambda::Function",
@@ -11297,23 +11211,7 @@
         {
          "Ref": "LambdaImageBuilderx64Repository57F632F1"
         },
-        "@sha256:",
-        {
-         "Fn::Select": [
-          1,
-          {
-           "Fn::Split": [
-            ":",
-            {
-             "Fn::GetAtt": [
-              "LambdaImageDigestReaderE0842577",
-              "imageDetails.0.imageDigest"
-             ]
-            }
-           ]
-          }
-         ]
-        }
+        ":latest"
        ]
       ]
      }
@@ -11344,66 +11242,8 @@
     "Timeout": 900
    },
    "DependsOn": [
+    "LambdaImageBuilderx64BuildWait195db8dedf29464C8D",
     "LambdaFunctionServiceRoleB1826A50"
-   ]
-  },
-  "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2": {
-   "Type": "AWS::IAM::Role",
-   "Properties": {
-    "AssumeRolePolicyDocument": {
-     "Statement": [
-      {
-       "Action": "sts:AssumeRole",
-       "Effect": "Allow",
-       "Principal": {
-        "Service": "lambda.amazonaws.com"
-       }
-      }
-     ],
-     "Version": "2012-10-17"
-    },
-    "ManagedPolicyArns": [
-     {
-      "Fn::Join": [
-       "",
-       [
-        "arn:",
-        {
-         "Ref": "AWS::Partition"
-        },
-        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-       ]
-      ]
-     }
-    ]
-   }
-  },
-  "AWS679f53fac002430cb0da5b7982bd22872D164C4C": {
-   "Type": "AWS::Lambda::Function",
-   "Properties": {
-    "Code": {
-     "S3Bucket": {
-      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
-     },
-     "S3Key": "56f7467bbde8a5efebcf57ae9e460027607099bab9f844669dcf5d800172ee5a.zip"
-    },
-    "Handler": "index.handler",
-    "LoggingConfig": {
-     "LogGroup": {
-      "Ref": "RunnerImageBuildHelpersLog13186633"
-     }
-    },
-    "Role": {
-     "Fn::GetAtt": [
-      "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
-      "Arn"
-     ]
-    },
-    "Runtime": "nodejs22.x",
-    "Timeout": 120
-   },
-   "DependsOn": [
-    "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2"
    ]
   },
   "updatelambdadcc036c8876b451ea2c1552f9e06e9e1ServiceRoleE163ADCA": {
@@ -11509,95 +11349,6 @@
     "updatelambdadcc036c8876b451ea2c1552f9e06e9e1ServiceRoleE163ADCA"
    ]
   },
-  "LambdaARMImageDigestReaderF3DD55C4": {
-   "Type": "Custom::EcrImageDigest",
-   "Properties": {
-    "ServiceToken": {
-     "Fn::GetAtt": [
-      "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
-      "Arn"
-     ]
-    },
-    "Create": {
-     "Fn::Join": [
-      "",
-      [
-       "{\"service\":\"ECR\",\"action\":\"describeImages\",\"parameters\":{\"repositoryName\":\"",
-       {
-        "Ref": "LambdaImageBuilderzRepository7C7AD146"
-       },
-       "\",\"imageIds\":[{\"imageTag\":\"latest\"}]},\"physicalResourceId\":{\"id\":\"ImageDigest\"}}"
-      ]
-     ]
-    },
-    "Update": {
-     "Fn::Join": [
-      "",
-      [
-       "{\"service\":\"ECR\",\"action\":\"describeImages\",\"parameters\":{\"repositoryName\":\"",
-       {
-        "Ref": "LambdaImageBuilderzRepository7C7AD146"
-       },
-       "\",\"imageIds\":[{\"imageTag\":\"latest\"}]},\"physicalResourceId\":{\"id\":\"ImageDigest\"}}"
-      ]
-     ]
-    },
-    "Delete": {
-     "Fn::Join": [
-      "",
-      [
-       "{\"service\":\"fake\",\"action\":\"fake\",\"parameters\":{\"version\":1,\"labels\":[\"lambda\",\"arm64\"],\"architecture\":\"arm64\",\"dependable\":\"",
-       {
-        "Ref": "LambdaImageBuilderzBuildWaitf11bb16a9bF6B7C2B1"
-       },
-       "\"}}"
-      ]
-     ]
-    },
-    "InstallLatestAwsSdk": false
-   },
-   "DependsOn": [
-    "LambdaARMImageDigestReaderCustomResourcePolicy2980B36A"
-   ],
-   "UpdateReplacePolicy": "Retain",
-   "DeletionPolicy": "Retain"
-  },
-  "LambdaARMImageDigestReaderCustomResourcePolicy2980B36A": {
-   "Type": "AWS::IAM::Policy",
-   "Properties": {
-    "PolicyDocument": {
-     "Statement": [
-      {
-       "Action": "ecr:DescribeImages",
-       "Effect": "Allow",
-       "Resource": {
-        "Fn::GetAtt": [
-         "LambdaImageBuilderzRepository7C7AD146",
-         "Arn"
-        ]
-       }
-      },
-      {
-       "Action": "fake:Fake",
-       "Effect": "Allow",
-       "Resource": {
-        "Fn::GetAtt": [
-         "LambdaImageBuilderzRepository7C7AD146",
-         "Arn"
-        ]
-       }
-      }
-     ],
-     "Version": "2012-10-17"
-    },
-    "PolicyName": "LambdaARMImageDigestReaderCustomResourcePolicy2980B36A",
-    "Roles": [
-     {
-      "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2"
-     }
-    ]
-   }
-  },
   "LambdaARMLogAA2DA09F": {
    "Type": "AWS::Logs::LogGroup",
    "Properties": {
@@ -11674,7 +11425,10 @@
       "Value": "github-runners-test/LambdaARM"
      }
     ]
-   }
+   },
+   "DependsOn": [
+    "LambdaImageBuilderzBuildWaitf11bb16a9bF6B7C2B1"
+   ]
   },
   "LambdaARMFunctionDD4B5FF7": {
    "Type": "AWS::Lambda::Function",
@@ -11728,23 +11482,7 @@
         {
          "Ref": "LambdaImageBuilderzRepository7C7AD146"
         },
-        "@sha256:",
-        {
-         "Fn::Select": [
-          1,
-          {
-           "Fn::Split": [
-            ":",
-            {
-             "Fn::GetAtt": [
-              "LambdaARMImageDigestReaderF3DD55C4",
-              "imageDetails.0.imageDigest"
-             ]
-            }
-           ]
-          }
-         ]
-        }
+        ":latest"
        ]
       ]
      }
@@ -11775,6 +11513,7 @@
     "Timeout": 900
    },
    "DependsOn": [
+    "LambdaImageBuilderzBuildWaitf11bb16a9bF6B7C2B1",
     "LambdaARMFunctionServiceRole136069A0"
    ]
   },


### PR DESCRIPTION
A failed deployment that also rebuilt a Lambda runner image leaves the stack in `UPDATE_ROLLBACK_FAILED`:

```
Resource handler returned message: "Source image 1234567890.dkr.ecr.us-east-1.amazonaws.com/...@sha256:1ece2333... does not exist. Provide a valid source image. (Service: Lambda, Status Code: 400)"
```

The Lambda function pointed at a specific image digest, resolved at deploy time by a `Custom::EcrImageDigest` custom resource. That digest goes stale as soon as any build replaces `latest` (scheduled or otherwise) and the replaced image is untagged and deleted a day later by the repository lifecycle rule. CloudFormation restores the *cached* previous `ImageUri` on rollback rather than re-resolving it, so it tries to roll back to an image we already deleted.

Reading the digest fresh can't help here. We tried. In the failed deployment the digest reader completed successfully with the new digest two seconds before the function failed with the old cached one. Rollback simply doesn't consult the digest reader.

The digest was originally needed because the out-of-band image updater deliberately stood down during stack operations ("skipping Lambda update as the stack will do it for us"), so CloudFormation had to carry the new image itself. That stand-down was removed in #116, which replaced it with a retry loop. The updater has applied the image itself ever since, and the digest has had no job since then.

To fix the issue, the Lambda function now points at the image tag, like every other provider does. Rollbacks restore `repo:latest`, which always resolves, and the image updater keeps the deployed function current on every push. Confirmed on a live stack: rolling back a deployment that swapped in an entirely new ECR repository sends `latest` in the `UpdateFunctionCode` call (verified in CloudTrail) and succeeds.

This does not change what happens to the runner *image* after a failed deployment. A rolled back stack still runs the image built during the failed deploy. That's a documented known issue.

Note that a stack update taking longer than ~15 minutes on the function itself can still exhaust the updater's retries and leave the image stale until the next scheduled rebuild. The window is narrow (it needs an image rebuild and a function property change in the same deployment) and self-corrects, so it's left alone for now.