### PR TITLE
fix: Too much noise from Delete Failed Runner step

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -50,6 +50,10 @@ Integration tests check the happy paths. We should also test the unhappy paths m
 * Retries
   * Confirm runner errors are retried
   * Confirm failed runner doesn't stay registered in GitHub
+* Failed runner clean-up
+  * Confirm `Delete Failed Runner` succeeds and `Rethrow Error` is the state that fails
+  * Confirm the execution fails with the error that stopped the runner, and not a generic one
+  * Confirm runner doesn't stay registered in GitHub
 * Stolen runner detection
   * Confirm a new runner is created when an unknown job is assigned to one of our runners
 * Other tests to be automated in the future
@@ -63,6 +67,31 @@ The two retries scenarios can be tested with the following test cases:
 * Let Lambda runner timeout by starting a job that lasts longer than 15 minutes
    * The runner should be retried and eventually the step function should be aborted as an idle runner
    * No runner should be registered on GitHub at the end
+
+### Failed runner clean-up
+
+Failed runner clean-up only happens when a runner provider actually fails. The quickest real failure is a Lambda runner
+that times out before the idle reaper gets to it. The reaper's queue has a 10 minute delivery delay, so its first check
+is at about 10 minutes no matter what `idleTimeout` says. Any runner timeout below that works:
+
+```typescript
+new GitHubRunners(this, 'runners', {
+  providers: [
+    new LambdaRunnerProvider(this, 'Lambda', {
+      timeout: cdk.Duration.minutes(2), // dies well before the reaper's first check
+    }),
+  ],
+  retryOptions: { retry: false }, // one clean pass instead of a day of retries
+});
+```
+
+Start a step function without a job actually pending (e.g. by duplicating input from a previous job). After about two minutes:
+
+* `Delete Failed Runner` should be green, with `runnerFound` and `runnerDeleted` both true in `$.delete`
+* `Rethrow Error` should be the red state, and the execution should fail with the runner timeout and not with a clean-up error
+* No runner should be registered on GitHub at the end
+
+### Stolen runners
 
 Stolen runners can be tested with the following steps:
 

--- a/src/delete-failed-runner.lambda.ts
+++ b/src/delete-failed-runner.lambda.ts
@@ -10,28 +10,37 @@ class RunnerBusy extends Error {
   }
 }
 
-class ReraisedError extends Error {
-  constructor(event: StepFunctionLambdaInput) {
-    super(event.error!.Cause);
-    this.name = event.error!.Error;
-    this.message = event.error!.Cause;
-    Object.setPrototypeOf(this, ReraisedError.prototype);
-  }
+/**
+ * Outcome of the clean-up, stored in `$.delete` by the step function so the execution history says what happened.
+ *
+ * We don't fail the execution ourselves. The original error that got us here is re-raised by a separate `Rethrow Error`
+ * state, so a red `Delete Failed Runner` state always means the clean-up itself had a problem.
+ */
+interface DeleteFailedRunnerResult {
+  /**
+   * Was a runner still registered on GitHub Actions when we looked for it?
+   */
+  readonly runnerFound: boolean;
+
+  /**
+   * Did we delete the runner? Always false when no runner was found, as there is nothing to delete.
+   */
+  readonly runnerDeleted: boolean;
 }
 
-export async function handler(event: StepFunctionLambdaInput) {
+export async function handler(event: StepFunctionLambdaInput): Promise<DeleteFailedRunnerResult> {
   const { octokit, githubSecrets } = await getOctokit(event.installationId);
 
   // find runner id
   const runner = await getRunner(octokit, githubSecrets.runnerLevel, event.owner, event.repo, event.runnerName);
   if (!runner) {
-    console.error({
-      notice: 'Unable to find runner id',
+    console.warn({
+      notice: 'Unable to find runner id (usually fine, as the runner may have never registered or already removed itself)',
       owner: event.owner,
       repo: event.repo,
       runnerName: event.runnerName,
     });
-    throw new ReraisedError(event);
+    return { runnerFound: false, runnerDeleted: false };
   }
 
   console.log({
@@ -62,8 +71,9 @@ export async function handler(event: StepFunctionLambdaInput) {
         runnerName: event.runnerName,
         error: e,
       });
+      return { runnerFound: true, runnerDeleted: false };
     }
   }
 
-  throw new ReraisedError(event);
+  return { runnerFound: true, runnerDeleted: true };
 }

--- a/src/lambda-helpers.ts
+++ b/src/lambda-helpers.ts
@@ -5,7 +5,6 @@ export interface StepFunctionLambdaInput {
   readonly repo: string;
   readonly runnerName: string;
   readonly installationId?: number;
-  readonly labels: string[];
 }
 
 const sm = new SecretsManagerClient();

--- a/src/lambda-helpers.ts
+++ b/src/lambda-helpers.ts
@@ -6,10 +6,6 @@ export interface StepFunctionLambdaInput {
   readonly runnerName: string;
   readonly installationId?: number;
   readonly labels: string[];
-  readonly error?: {
-    readonly Error: string;
-    readonly Cause: string;
-  };
 }
 
 const sm = new SecretsManagerClient();

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -316,6 +316,7 @@ export class GitHubRunners extends Construct implements ec2.IConnectable {
   private warmConfigHashes: string[] = [];
   private deleteFailedRunnerIndex = 0;
   private deleteFailedRunnerFunction?: lambda.IFunction;
+  private rethrowErrorState?: stepfunctions.Fail;
 
   constructor(scope: Construct, id: string, readonly props?: GitHubRunnersProps) {
     super(scope, id);
@@ -573,7 +574,6 @@ export class GitHubRunners extends Construct implements ec2.IConnectable {
         owner: stepfunctions.JsonPath.stringAt('$.owner'),
         repo: stepfunctions.JsonPath.stringAt('$.repo'),
         installationId: stepfunctions.JsonPath.numberAt('$.installationId'),
-        error: stepfunctions.JsonPath.objectAt('$.error'),
       }),
     });
     task.addRetry({
@@ -589,6 +589,13 @@ export class GitHubRunners extends Construct implements ec2.IConnectable {
         errors: [stepfunctions.Errors.ALL],
         resultPath: stepfunctions.JsonPath.DISCARD,
       });
+    } else {
+      this.rethrowErrorState ??= new stepfunctions.Fail(this, 'Rethrow Error', {
+        comment: 'Fail the execution with the original error that stopped the runner',
+        errorPath: stepfunctions.JsonPath.stringAt('$.error.Error'),
+        causePath: stepfunctions.JsonPath.stringAt('$.error.Cause'),
+      });
+      task.next(this.rethrowErrorState);
     }
     state.addCatch(task, {
       errors: [stepfunctions.Errors.ALL],

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -211,16 +211,16 @@
         }
       }
     },
-    "bdc642e1a0563fa2b1eea04c70f26d3c1be56f4c14a59974ba88f81d95995d2e": {
+    "8203163cce02a39b2fb7bd9957b4b339b3aa3c831000932c9f252c90416a7a92": {
       "displayName": "runners/delete-runner/Code",
       "source": {
-        "path": "asset.bdc642e1a0563fa2b1eea04c70f26d3c1be56f4c14a59974ba88f81d95995d2e.lambda",
+        "path": "asset.8203163cce02a39b2fb7bd9957b4b339b3aa3c831000932c9f252c90416a7a92.lambda",
         "packaging": "zip"
       },
       "destinations": {
-        "current_account-current_region-7b48716b": {
+        "current_account-current_region-e0ef606a": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "bdc642e1a0563fa2b1eea04c70f26d3c1be56f4c14a59974ba88f81d95995d2e.zip",
+          "objectKey": "8203163cce02a39b2fb7bd9957b4b339b3aa3c831000932c9f252c90416a7a92.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -309,16 +309,16 @@
         }
       }
     },
-    "cf12b4f449fac9269a34b2cee0f6af950d0597a2ffb15e8a6e82ce184e9adb40": {
+    "a9246d5d280c499f3479998289ea93fcc8cbc94a953dcb4076579ba5e20fe17f": {
       "displayName": "github-runners-test Template",
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
       },
       "destinations": {
-        "current_account-current_region-522e1c9c": {
+        "current_account-current_region-6def6bb0": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "cf12b4f449fac9269a34b2cee0f6af950d0597a2ffb15e8a6e82ce184e9adb40.json",
+          "objectKey": "a9246d5d280c499f3479998289ea93fcc8cbc94a953dcb4076579ba5e20fe17f.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -14812,7 +14812,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "bdc642e1a0563fa2b1eea04c70f26d3c1be56f4c14a59974ba88f81d95995d2e.zip"
+     "S3Key": "8203163cce02a39b2fb7bd9957b4b339b3aa3c831000932c9f252c90416a7a92.zip"
     },
     "Description": "Delete failed GitHub Actions runner on error",
     "Environment": {
@@ -16815,7 +16815,7 @@
          "Arn"
         ]
        },
-       "\",\"Parameters\":{\"runnerName.$\":\"$$.Execution.Name\",\"owner.$\":\"$.owner\",\"repo.$\":\"$.repo\",\"installationId.$\":\"$.installationId\",\"error.$\":\"$.error\"}},\"ECS Non-Spot\":{\"End\":true,\"Type\":\"Task\",\"Resource\":\"arn:",
+       "\",\"Parameters\":{\"runnerName.$\":\"$$.Execution.Name\",\"owner.$\":\"$.owner\",\"repo.$\":\"$.repo\",\"installationId.$\":\"$.installationId\"}},\"ECS Non-Spot\":{\"End\":true,\"Type\":\"Task\",\"Resource\":\"arn:",
        {
         "Ref": "AWS::Partition"
        },
@@ -17107,7 +17107,7 @@
          "Arn"
         ]
        },
-       "\",\"Parameters\":{\"runnerName.$\":\"$$.Execution.Name\",\"owner.$\":\"$.owner\",\"repo.$\":\"$.repo\",\"installationId.$\":\"$.installationId\",\"error.$\":\"$.error\"}},\"EC2 Linux ",
+       "\",\"Parameters\":{\"runnerName.$\":\"$$.Execution.Name\",\"owner.$\":\"$.owner\",\"repo.$\":\"$.repo\",\"installationId.$\":\"$.installationId\"}},\"EC2 Linux ",
        {
         "Ref": "VpcPublicSubnet2Subnet691E08A3"
        },
@@ -17169,7 +17169,7 @@
          "Arn"
         ]
        },
-       "\",\"Parameters\":{\"runnerName.$\":\"$$.Execution.Name\",\"owner.$\":\"$.owner\",\"repo.$\":\"$.repo\",\"installationId.$\":\"$.installationId\",\"error.$\":\"$.error\"}},\"EC2 Linux 2 ",
+       "\",\"Parameters\":{\"runnerName.$\":\"$$.Execution.Name\",\"owner.$\":\"$.owner\",\"repo.$\":\"$.repo\",\"installationId.$\":\"$.installationId\"}},\"EC2 Linux 2 ",
        {
         "Ref": "VpcPublicSubnet1Subnet5C2D37C4"
        },
@@ -17231,7 +17231,7 @@
          "Arn"
         ]
        },
-       "\",\"Parameters\":{\"runnerName.$\":\"$$.Execution.Name\",\"owner.$\":\"$.owner\",\"repo.$\":\"$.repo\",\"installationId.$\":\"$.installationId\",\"error.$\":\"$.error\"}},\"EC2 Linux 2 ",
+       "\",\"Parameters\":{\"runnerName.$\":\"$$.Execution.Name\",\"owner.$\":\"$.owner\",\"repo.$\":\"$.repo\",\"installationId.$\":\"$.installationId\"}},\"EC2 Linux 2 ",
        {
         "Ref": "VpcPublicSubnet2Subnet691E08A3"
        },
@@ -17340,7 +17340,7 @@
          "Arn"
         ]
        },
-       "\",\"Parameters\":{\"runnerName.$\":\"$$.Execution.Name\",\"owner.$\":\"$.owner\",\"repo.$\":\"$.repo\",\"installationId.$\":\"$.installationId\",\"error.$\":\"$.error\"}},\"EC2 Spot Linux ",
+       "\",\"Parameters\":{\"runnerName.$\":\"$$.Execution.Name\",\"owner.$\":\"$.owner\",\"repo.$\":\"$.repo\",\"installationId.$\":\"$.installationId\"}},\"EC2 Spot Linux ",
        {
         "Ref": "VpcPublicSubnet2Subnet691E08A3"
        },
@@ -17449,7 +17449,7 @@
          "Arn"
         ]
        },
-       "\",\"Parameters\":{\"runnerName.$\":\"$$.Execution.Name\",\"owner.$\":\"$.owner\",\"repo.$\":\"$.repo\",\"installationId.$\":\"$.installationId\",\"error.$\":\"$.error\"}},\"EC2 Linux arm64 ",
+       "\",\"Parameters\":{\"runnerName.$\":\"$$.Execution.Name\",\"owner.$\":\"$.owner\",\"repo.$\":\"$.repo\",\"installationId.$\":\"$.installationId\"}},\"EC2 Linux arm64 ",
        {
         "Ref": "VpcPublicSubnet2Subnet691E08A3"
        },
@@ -17558,7 +17558,7 @@
          "Arn"
         ]
        },
-       "\",\"Parameters\":{\"runnerName.$\":\"$$.Execution.Name\",\"owner.$\":\"$.owner\",\"repo.$\":\"$.repo\",\"installationId.$\":\"$.installationId\",\"error.$\":\"$.error\"}},\"EC2 Windows ",
+       "\",\"Parameters\":{\"runnerName.$\":\"$$.Execution.Name\",\"owner.$\":\"$.owner\",\"repo.$\":\"$.repo\",\"installationId.$\":\"$.installationId\"}},\"EC2 Windows ",
        {
         "Ref": "VpcPublicSubnet2Subnet691E08A3"
        },
@@ -17605,14 +17605,14 @@
        {
         "Ref": "EC2WindowsAMIRootDevice9FFC971A"
        },
-       "\",\"Ebs\":{\"DeleteOnTermination\":true,\"VolumeSize\":30}}],\"TagSpecifications\":[{\"ResourceType\":\"instance\",\"Tags\":[{\"Key\":\"Name\",\"Value.$\":\"$$.Execution.Name\"},{\"Key\":\"GitHubRunners:Provider\",\"Value\":\"github-runners-test/EC2 Windows\"},{\"Key\":\"GitHubRunners:Repo\",\"Value.$\":\"States.Format('{}/{}', $.owner, $.repo)\"},{\"Key\":\"GitHubRunners:Labels\",\"Value.$\":\"$.labels\"}]},{\"ResourceType\":\"volume\",\"Tags\":[{\"Key\":\"Name\",\"Value.$\":\"$$.Execution.Name\"},{\"Key\":\"GitHubRunners:Provider\",\"Value\":\"github-runners-test/EC2 Windows\"},{\"Key\":\"GitHubRunners:Repo\",\"Value.$\":\"States.Format('{}/{}', $.owner, $.repo)\"},{\"Key\":\"GitHubRunners:Labels\",\"Value.$\":\"$.labels\"}]}]}}}}]},\"Delete Failed Runner 8\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Lambda.ClientExecutionTimeoutException\",\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2},{\"ErrorEquals\":[\"RunnerBusy\"],\"IntervalSeconds\":60,\"MaxAttempts\":60,\"BackoffRate\":1}],\"Type\":\"Task\",\"Comment\":\"Clean-up failed runner from GitHub Actions (if present)\",\"ResultPath\":\"$.delete\",\"Resource\":\"",
+       "\",\"Ebs\":{\"DeleteOnTermination\":true,\"VolumeSize\":30}}],\"TagSpecifications\":[{\"ResourceType\":\"instance\",\"Tags\":[{\"Key\":\"Name\",\"Value.$\":\"$$.Execution.Name\"},{\"Key\":\"GitHubRunners:Provider\",\"Value\":\"github-runners-test/EC2 Windows\"},{\"Key\":\"GitHubRunners:Repo\",\"Value.$\":\"States.Format('{}/{}', $.owner, $.repo)\"},{\"Key\":\"GitHubRunners:Labels\",\"Value.$\":\"$.labels\"}]},{\"ResourceType\":\"volume\",\"Tags\":[{\"Key\":\"Name\",\"Value.$\":\"$$.Execution.Name\"},{\"Key\":\"GitHubRunners:Provider\",\"Value\":\"github-runners-test/EC2 Windows\"},{\"Key\":\"GitHubRunners:Repo\",\"Value.$\":\"States.Format('{}/{}', $.owner, $.repo)\"},{\"Key\":\"GitHubRunners:Labels\",\"Value.$\":\"$.labels\"}]}]}}}}]},\"Delete Failed Runner 8\":{\"Next\":\"Rethrow Error\",\"Retry\":[{\"ErrorEquals\":[\"Lambda.ClientExecutionTimeoutException\",\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2},{\"ErrorEquals\":[\"RunnerBusy\"],\"IntervalSeconds\":60,\"MaxAttempts\":60,\"BackoffRate\":1}],\"Type\":\"Task\",\"Comment\":\"Clean-up failed runner from GitHub Actions (if present)\",\"ResultPath\":\"$.delete\",\"Resource\":\"",
        {
         "Fn::GetAtt": [
          "runnersdeleterunner7F8D5293",
          "Arn"
         ]
        },
-       "\",\"Parameters\":{\"runnerName.$\":\"$$.Execution.Name\",\"owner.$\":\"$.owner\",\"repo.$\":\"$.repo\",\"installationId.$\":\"$.installationId\",\"error.$\":\"$.error\"}}}}]}}}"
+       "\",\"Parameters\":{\"runnerName.$\":\"$$.Execution.Name\",\"owner.$\":\"$.owner\",\"repo.$\":\"$.repo\",\"installationId.$\":\"$.installationId\"}},\"Rethrow Error\":{\"Type\":\"Fail\",\"Comment\":\"Fail the execution with the original error that stopped the runner\",\"ErrorPath\":\"$.error.Error\",\"CausePath\":\"$.error.Cause\"}}}]}}}"
       ]
      ]
     },

--- a/test/delete-failed-runner.test.ts
+++ b/test/delete-failed-runner.test.ts
@@ -16,7 +16,6 @@ const EVENT = {
   repo: 'my-repo',
   runnerName: 'runner-1',
   installationId: 123,
-  labels: ['linux'],
 };
 
 const RUNNER = { id: 42, name: 'runner-1' };

--- a/test/delete-failed-runner.test.ts
+++ b/test/delete-failed-runner.test.ts
@@ -1,0 +1,78 @@
+const mockGetOctokit = jest.fn();
+const mockGetRunner = jest.fn();
+const mockDeleteRunner = jest.fn();
+
+jest.mock('../src/lambda-github', () => ({
+  getOctokit: (...args: unknown[]) => mockGetOctokit(...args),
+  getRunner: (...args: unknown[]) => mockGetRunner(...args),
+  deleteRunner: (...args: unknown[]) => mockDeleteRunner(...args),
+}));
+
+// Import handler after mocks are set up
+import { handler } from '../src/delete-failed-runner.lambda';
+
+const EVENT = {
+  owner: 'my-org',
+  repo: 'my-repo',
+  runnerName: 'runner-1',
+  installationId: 123,
+  labels: ['linux'],
+};
+
+const RUNNER = { id: 42, name: 'runner-1' };
+
+describe('delete-failed-runner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    mockGetOctokit.mockResolvedValue({
+      octokit: {},
+      githubSecrets: { runnerLevel: 'repo' },
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('Deletes the runner when it is still registered', async () => {
+    mockGetRunner.mockResolvedValue(RUNNER);
+    mockDeleteRunner.mockResolvedValue(undefined);
+
+    await expect(handler(EVENT)).resolves.toEqual({ runnerFound: true, runnerDeleted: true });
+
+    expect(mockDeleteRunner).toHaveBeenCalledWith({}, 'repo', 'my-org', 'my-repo', 42);
+  });
+
+  // the step function fails the execution with a separate `Rethrow Error` state, so a missing runner -- which is the
+  // common case -- must not fail this Lambda
+  test('Succeeds when the runner is already gone', async () => {
+    mockGetRunner.mockResolvedValue(undefined);
+
+    await expect(handler(EVENT)).resolves.toEqual({ runnerFound: false, runnerDeleted: false });
+
+    expect(mockDeleteRunner).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  test('Succeeds but reports the runner was not deleted when GitHub rejects the delete', async () => {
+    mockGetRunner.mockResolvedValue(RUNNER);
+    mockDeleteRunner.mockRejectedValue(new Error('Internal server error'));
+
+    await expect(handler(EVENT)).resolves.toEqual({ runnerFound: true, runnerDeleted: false });
+
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  // this one the step function does need to see, so it can retry until the job lets go of the runner
+  test('Fails with RunnerBusy when the runner is still running a job', async () => {
+    mockGetRunner.mockResolvedValue(RUNNER);
+    mockDeleteRunner.mockRejectedValue(new Error('Bad request - runner "runner-1" is still running a job'));
+
+    await expect(handler(EVENT)).rejects.toMatchObject({ name: 'RunnerBusy' });
+  });
+});


### PR DESCRIPTION
Every time we tried to delete a *possibly* failed runner, we printed an error to the log and made it seem like the deletion step failed in the step function.

The log showed up in our saved Logs Insights queries used for debugging. The step function error made it look like deleting a runner failed even if there wasn't a runner to begin with.

This PR reduces the noise level by:

1. Changing `console.error()` to `console.warn()` so it's not caught in Log Insights
2. Splitting out the error step to a new step called Rethrow Error to make it clear that it's not the runner deletion that failed