### PR TITLE
fix: mkdir: cannot create directory '/tmp/home': File exists

### DIFF
--- a/src/providers/lambda-bootstrap.sh
+++ b/src/providers/lambda-bootstrap.sh
@@ -9,13 +9,13 @@ do
   EVENT_DATA=$(curl -sS -LD "$HEADERS" "http://${AWS_LAMBDA_RUNTIME_API}/2018-06-01/runtime/invocation/next")
   REQUEST_ID=$(grep -Fi Lambda-Runtime-Aws-Request-Id "$HEADERS" | tr -d '[:space:]' | cut -d: -f2)
 
+  # cleanup from possible previous runs
+  find /tmp -mindepth 1 -maxdepth 1 -exec rm -rf '{}' \;
+
   # execute runner and respond
   if bash /runner.sh "$EVENT_DATA"; then
     curl "http://${AWS_LAMBDA_RUNTIME_API}/2018-06-01/runtime/invocation/$REQUEST_ID/response" -d ""
   else
     curl "http://${AWS_LAMBDA_RUNTIME_API}/2018-06-01/runtime/invocation/$REQUEST_ID/error" -d "{\"errorMessage\": \"Runner failed with exit code $?\", \"errorType\": \"Error\", \"stackTrace\": []}"
   fi
-
-  # cleanup
-  find /tmp -mindepth 1 -maxdepth 1 -exec rm -rf '{}' \;
 done

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -141,16 +141,16 @@
         }
       }
     },
-    "2fc3b84da69dcc5adb6dc4721b50c1166474fa7e5fd5f242e833d12ac28e09d9": {
+    "bcf81c8f7be4af52ed43aa443eec25742f41f428e2ccfe810d3b010998a3262e": {
       "displayName": "Lambda Image Builder x64/Component 6 Lambda-Entrypoint Asset 0",
       "source": {
-        "path": "asset.2fc3b84da69dcc5adb6dc4721b50c1166474fa7e5fd5f242e833d12ac28e09d9.sh",
+        "path": "asset.bcf81c8f7be4af52ed43aa443eec25742f41f428e2ccfe810d3b010998a3262e.sh",
         "packaging": "file"
       },
       "destinations": {
-        "current_account-current_region-07fa966c": {
+        "current_account-current_region-e4b6f8a5": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "2fc3b84da69dcc5adb6dc4721b50c1166474fa7e5fd5f242e833d12ac28e09d9.sh",
+          "objectKey": "bcf81c8f7be4af52ed43aa443eec25742f41f428e2ccfe810d3b010998a3262e.sh",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -309,16 +309,16 @@
         }
       }
     },
-    "a9246d5d280c499f3479998289ea93fcc8cbc94a953dcb4076579ba5e20fe17f": {
+    "a146090bd5c02b9956e7dff78934c7b6ca95562955e4fc2ad3a0af32370dc147": {
       "displayName": "github-runners-test Template",
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
       },
       "destinations": {
-        "current_account-current_region-6def6bb0": {
+        "current_account-current_region-40fe4d21": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "a9246d5d280c499f3479998289ea93fcc8cbc94a953dcb4076579ba5e20fe17f.json",
+          "objectKey": "a146090bd5c02b9956e7dff78934c7b6ca95562955e4fc2ad3a0af32370dc147.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -1583,7 +1583,7 @@
         },
         " asset5-GithubRunner-2\",\n        \"cat > component5-GithubRunner.sh <<'EOFGITHUBRUNNERSDOCKERFILE'\\n#!/bin/bash\\nset -exuo pipefail\\nRUNNER_VERSION=`curl --retry 5 --retry-delay 30 --retry-all-errors -w \\\"%{redirect_url}\\\" -fsS https://github.com/actions/runner/releases/latest | grep -oE \\\"[^/v]+$\\\"`\\ncurl --retry 5 --retry-delay 30 --retry-all-errors -fsSLO \\\"https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz\\\"\\ntar -C /home/runner -xzf \\\"actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz\\\"\\nrm actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz\\necho -n latest > /home/runner/RUNNER_VERSION\\nchmod +x /home/runner/job-reporter.sh\\nchmod +x /home/runner/job-started-hook.sh\\nchmod +x /home/runner/job-completed-hook.sh\\necho ACTIONS_RUNNER_HOOK_JOB_STARTED=/home/runner/job-started-hook.sh >> /home/runner/.env\\necho ACTIONS_RUNNER_HOOK_JOB_COMPLETED=/home/runner/job-completed-hook.sh >> /home/runner/.env\\nchown runner /home/runner/.env\\ntouch /home/runner/.workflowid && chown runner /home/runner/.workflowid\\ndnf install -y openssl-libs krb5-libs zlib libicu-67.1\\nmkdir -p /opt/hostedtoolcache\\nchown runner /opt/hostedtoolcache\\nEOFGITHUBRUNNERSDOCKERFILE\",\n        \"chmod +x component5-GithubRunner.sh\",\n        \"aws s3 cp ",
         {
-         "Fn::Sub": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/2fc3b84da69dcc5adb6dc4721b50c1166474fa7e5fd5f242e833d12ac28e09d9.sh"
+         "Fn::Sub": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/bcf81c8f7be4af52ed43aa443eec25742f41f428e2ccfe810d3b010998a3262e.sh"
         },
         " asset6-Lambda-Entrypoint-0\",\n        \"aws s3 cp ",
         {
@@ -1626,15 +1626,15 @@
     ]
    }
   },
-  "LambdaImageBuilderx64BuildWaitHandle195db8dedf059C592A": {
+  "LambdaImageBuilderx64BuildWaitHandle21eac63410F0A23419": {
    "Type": "AWS::CloudFormation::WaitConditionHandle"
   },
-  "LambdaImageBuilderx64BuildWait195db8dedf29464C8D": {
+  "LambdaImageBuilderx64BuildWait21eac634101DAAFA12": {
    "Type": "AWS::CloudFormation::WaitCondition",
    "Properties": {
     "Count": 1,
     "Handle": {
-     "Ref": "LambdaImageBuilderx64BuildWaitHandle195db8dedf059C592A"
+     "Ref": "LambdaImageBuilderx64BuildWaitHandle21eac63410F0A23419"
     },
     "Timeout": "3600"
    }
@@ -1655,7 +1655,7 @@
      "Ref": "LambdaImageBuilderx64CodeBuild67DE14C8"
     },
     "WaitHandle": {
-     "Ref": "LambdaImageBuilderx64BuildWaitHandle195db8dedf059C592A"
+     "Ref": "LambdaImageBuilderx64BuildWaitHandle21eac63410F0A23419"
     }
    },
    "DependsOn": [
@@ -4576,7 +4576,7 @@
         },
         " asset5-GithubRunner-2\",\n        \"cat > component5-GithubRunner.sh <<'EOFGITHUBRUNNERSDOCKERFILE'\\n#!/bin/bash\\nset -exuo pipefail\\nRUNNER_VERSION=`curl --retry 5 --retry-delay 30 --retry-all-errors -w \\\"%{redirect_url}\\\" -fsS https://github.com/actions/runner/releases/latest | grep -oE \\\"[^/v]+$\\\"`\\ncurl --retry 5 --retry-delay 30 --retry-all-errors -fsSLO \\\"https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-arm64-${RUNNER_VERSION}.tar.gz\\\"\\ntar -C /home/runner -xzf \\\"actions-runner-linux-arm64-${RUNNER_VERSION}.tar.gz\\\"\\nrm actions-runner-linux-arm64-${RUNNER_VERSION}.tar.gz\\necho -n latest > /home/runner/RUNNER_VERSION\\nchmod +x /home/runner/job-reporter.sh\\nchmod +x /home/runner/job-started-hook.sh\\nchmod +x /home/runner/job-completed-hook.sh\\necho ACTIONS_RUNNER_HOOK_JOB_STARTED=/home/runner/job-started-hook.sh >> /home/runner/.env\\necho ACTIONS_RUNNER_HOOK_JOB_COMPLETED=/home/runner/job-completed-hook.sh >> /home/runner/.env\\nchown runner /home/runner/.env\\ntouch /home/runner/.workflowid && chown runner /home/runner/.workflowid\\ndnf install -y openssl-libs krb5-libs zlib libicu-67.1\\nmkdir -p /opt/hostedtoolcache\\nchown runner /opt/hostedtoolcache\\nEOFGITHUBRUNNERSDOCKERFILE\",\n        \"chmod +x component5-GithubRunner.sh\",\n        \"aws s3 cp ",
         {
-         "Fn::Sub": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/2fc3b84da69dcc5adb6dc4721b50c1166474fa7e5fd5f242e833d12ac28e09d9.sh"
+         "Fn::Sub": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/bcf81c8f7be4af52ed43aa443eec25742f41f428e2ccfe810d3b010998a3262e.sh"
         },
         " asset6-Lambda-Entrypoint-0\",\n        \"aws s3 cp ",
         {
@@ -4619,15 +4619,15 @@
     ]
    }
   },
-  "LambdaImageBuilderzBuildWaitHandlef11bb16a9bD1DAB4ED": {
+  "LambdaImageBuilderzBuildWaitHandlebe8ebaa598C29DF766": {
    "Type": "AWS::CloudFormation::WaitConditionHandle"
   },
-  "LambdaImageBuilderzBuildWaitf11bb16a9bF6B7C2B1": {
+  "LambdaImageBuilderzBuildWaitbe8ebaa59848691A2C": {
    "Type": "AWS::CloudFormation::WaitCondition",
    "Properties": {
     "Count": 1,
     "Handle": {
-     "Ref": "LambdaImageBuilderzBuildWaitHandlef11bb16a9bD1DAB4ED"
+     "Ref": "LambdaImageBuilderzBuildWaitHandlebe8ebaa598C29DF766"
     },
     "Timeout": "3600"
    }
@@ -4648,7 +4648,7 @@
      "Ref": "LambdaImageBuilderzCodeBuild73AB6718"
     },
     "WaitHandle": {
-     "Ref": "LambdaImageBuilderzBuildWaitHandlef11bb16a9bD1DAB4ED"
+     "Ref": "LambdaImageBuilderzBuildWaitHandlebe8ebaa598C29DF766"
     }
    },
    "DependsOn": [
@@ -11156,7 +11156,7 @@
     ]
    },
    "DependsOn": [
-    "LambdaImageBuilderx64BuildWait195db8dedf29464C8D"
+    "LambdaImageBuilderx64BuildWait21eac634101DAAFA12"
    ]
   },
   "LambdaFunction9233991D": {
@@ -11242,7 +11242,7 @@
     "Timeout": 900
    },
    "DependsOn": [
-    "LambdaImageBuilderx64BuildWait195db8dedf29464C8D",
+    "LambdaImageBuilderx64BuildWait21eac634101DAAFA12",
     "LambdaFunctionServiceRoleB1826A50"
    ]
   },
@@ -11427,7 +11427,7 @@
     ]
    },
    "DependsOn": [
-    "LambdaImageBuilderzBuildWaitf11bb16a9bF6B7C2B1"
+    "LambdaImageBuilderzBuildWaitbe8ebaa59848691A2C"
    ]
   },
   "LambdaARMFunctionDD4B5FF7": {
@@ -11513,7 +11513,7 @@
     "Timeout": 900
    },
    "DependsOn": [
-    "LambdaImageBuilderzBuildWaitf11bb16a9bF6B7C2B1",
+    "LambdaImageBuilderzBuildWaitbe8ebaa59848691A2C",
     "LambdaARMFunctionServiceRole136069A0"
    ]
   },


### PR DESCRIPTION
When a Lambda provider exits uncleanly, it can leave behind files in `/tmp`. This can cause the next run to fail as it won't be able to create `/tmp/home` or conflict with any of the files there. Instead of cleaning up *after* the runner, we should clean-up every time before the runner starts. This way a previous failed run can't leave anything behind.

I saw this issue when I set the timeout for the Lambda provider lower than the idle reaper timeout. The function timed out and the clean-up code never ran.