### PR TITLE
fix: Failed deployment deletes the AMI that was just built

### DIFF
--- a/src/image-builders/aws-image-builder/builder.ts
+++ b/src/image-builders/aws-image-builder/builder.ts
@@ -520,8 +520,8 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
       resources: ['*'],
     }));
 
-    // delete old version on update and on stack deletion
-    this.imageCleaner('Container', recipe.name.toLowerCase(), recipe.version);
+    // delete old versions on update, and everything on stack deletion
+    this.imageCleaner('Container', recipe.name, recipe.version);
 
     // delete old docker images + IB resources daily
     new imagebuilder.CfnLifecyclePolicy(this, 'Lifecycle Policy Docker', {
@@ -839,12 +839,12 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
       cacheKey: recipe.version, // re-evaluate AMI whenever the recipe changes
     };
 
-    this.amiCleaner(recipe, stackName, builderName);
+    this.amiCleaner(recipe, stackName, builderName, launchTemplate);
 
     return this.boundAmi;
   }
 
-  private amiCleaner(recipe: AmiRecipe, stackName: string, builderName: string) {
+  private amiCleaner(recipe: AmiRecipe, stackName: string, builderName: string, launchTemplate: ec2.LaunchTemplate) {
     // this is here to provide safe upgrade from old cdk-github-runners versions
     // this lambda was used by a custom resource to delete all amis when the builder was removed
     // if we remove the custom resource, role and lambda, all amis will be deleted on update
@@ -870,8 +870,8 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
       l1role.overrideLogicalId('deleteamidcc036c8876b451ea2c1552f9e06e9e1ServiceRole1CC58A6F');
     }
 
-    // delete old version on update and on stack deletion
-    this.imageCleaner('Image', recipe.name.toLowerCase(), recipe.version);
+    // delete old versions on update, and everything on stack deletion
+    this.imageCleaner('Image', recipe.name, recipe.version, launchTemplate);
 
     // delete old AMIs + IB resources daily
     new imagebuilder.CfnLifecyclePolicy(this, 'Lifecycle Policy AMI', {
@@ -941,19 +941,20 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
     return this.boundComponents;
   }
 
-  private imageCleaner(type: 'Container' | 'Image', recipeName: string, version: string) {
+  private imageCleaner(type: 'Container' | 'Image', recipeName: string, version: string, launchTemplate?: ec2.LaunchTemplate) {
     const cleanerFunction = singletonLambda(DeleteResourcesFunction, this, 'aws-image-builder-delete-resources', {
       description: 'Custom resource handler that deletes resources of old versions of EC2 Image Builder images',
       initialPolicy: [
         new iam.PolicyStatement({
           actions: [
+            'imagebuilder:ListImages',
             'imagebuilder:ListImageBuildVersions',
             'imagebuilder:DeleteImage',
           ],
           resources: ['*'],
         }),
         new iam.PolicyStatement({
-          actions: ['ec2:DescribeImages'],
+          actions: ['ec2:DescribeImages', 'ec2:DescribeLaunchTemplateVersions'],
           resources: ['*'],
         }),
         new iam.PolicyStatement({
@@ -969,6 +970,11 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
           actions: ['ecr:BatchDeleteImage'],
           resources: ['*'],
         }),
+        new iam.PolicyStatement({
+          // used to tell whether the whole stack is going away, and with it the launch template we protect images by
+          actions: ['cloudformation:DescribeStacks'],
+          resources: [cdk.Stack.of(this).stackId],
+        }),
       ],
       logGroup: singletonLogGroup(this, SingletonLogType.RUNNER_IMAGE_BUILD),
       loggingFormat: lambda.LoggingFormat.JSON,
@@ -979,12 +985,9 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
       serviceToken: cleanerFunction.functionArn,
       resourceType: 'Custom::ImageBuilder-Delete-Resources',
       properties: <DeleteResourcesProps>{
-        ImageVersionArn: cdk.Stack.of(this).formatArn({
-          service: 'imagebuilder',
-          resource: 'image',
-          resourceName: `${recipeName}/${version}`,
-          arnFormat: cdk.ArnFormat.SLASH_RESOURCE_NAME,
-        }),
+        RecipeName: recipeName,
+        RecipeVersion: version,
+        LaunchTemplateId: launchTemplate?.launchTemplateId,
       },
     });
   }

--- a/src/image-builders/aws-image-builder/delete-resources.lambda.ts
+++ b/src/image-builders/aws-image-builder/delete-resources.lambda.ts
@@ -24,6 +24,7 @@ const DELETABLE_IMAGE_STATUSES = [
   'DEPRECATED',
   'FAILED',
   'CANCELLED',
+  'DISABLED',
 ];
 
 // delete all images when the stack is being torn down, as there is nothing left to protect and this is our last chance to clean up
@@ -144,6 +145,7 @@ async function recipeBuilds(recipeName: string) {
     versions = await ib.send(new ListImagesCommand({
       owner: 'Self',
       filters: [{ name: 'name', values: [recipeName] }],
+      includeDeprecated: true,
       nextToken: versions.nextToken,
     }));
 

--- a/src/image-builders/aws-image-builder/delete-resources.lambda.ts
+++ b/src/image-builders/aws-image-builder/delete-resources.lambda.ts
@@ -92,12 +92,22 @@ async function isStackTearingDown(stackId: string) {
   }
 }
 
+// the launch template is gone for good, so there is no AMI left for us to protect
+const MISSING_LAUNCH_TEMPLATE_ERRORS = [
+  'InvalidLaunchTemplateId.NotFound',
+  'InvalidLaunchTemplateId.Malformed',
+  'InvalidLaunchTemplateId.VersionNotFound',
+];
+
 /**
  * Get AMI from launch template so we know to not delete an AMI that's still being used.
  *
- * If the launch template is missing, or we can't read it, we return undefined and will delete all images. This can happen when the stack is being
- * torn down and the launch template is already gone. Another use case is when the stack is rolling back the initial creation of the image before the
- * launch template had a chance to be created.
+ * We return undefined when the launch template is gone, or when its default version has no AMI yet, as neither leaves an AMI in use. That happens
+ * when the stack is being torn down and the launch template is already deleted, and when the stack is rolling back the initial creation of the image
+ * before the launch template had a chance to get an AMI.
+ *
+ * Any other error means we simply don't know which AMI is in use, which is not the same as knowing none is. We throw so the caller can leave
+ * everything alone instead of deleting an AMI that runners may still be starting from.
  */
 async function launchTemplateAmi(launchTemplateId: string) {
   try {
@@ -108,12 +118,16 @@ async function launchTemplateAmi(launchTemplateId: string) {
 
     return versions.LaunchTemplateVersions?.[0]?.LaunchTemplateData?.ImageId;
   } catch (e) {
-    console.warn({
-      notice: 'Unable to read launch template, no AMI will be protected',
-      launchTemplate: launchTemplateId,
-      error: e,
-    });
-    return undefined;
+    if (MISSING_LAUNCH_TEMPLATE_ERRORS.includes((e as Error).name)) {
+      console.log({
+        notice: 'Launch template is gone, so no AMI needs to be protected',
+        launchTemplate: launchTemplateId,
+        error: (e as Error).name,
+      });
+      return undefined;
+    }
+
+    throw e;
   }
 }
 
@@ -284,7 +298,21 @@ async function deleteResources(props: DeleteResourcesProps, teardown: boolean) {
     return;
   }
 
-  const protectedAmi = props.LaunchTemplateId && !teardown ? await launchTemplateAmi(props.LaunchTemplateId) : undefined;
+  let protectedAmi: string | undefined;
+  if (props.LaunchTemplateId && !teardown) {
+    try {
+      protectedAmi = await launchTemplateAmi(props.LaunchTemplateId);
+    } catch (e) {
+      // we can't tell which AMI is in use, so we leave everything alone. the next deployment will clean up instead.
+      console.warn({
+        notice: 'Unable to read launch template, skipping cleanup so an AMI in use is not deleted',
+        launchTemplate: props.LaunchTemplateId,
+        error: e,
+      });
+      return;
+    }
+  }
+
   const builds = (await recipeBuilds(props.RecipeName)).filter(build => !keepBuild(build, protectedAmi, teardown));
 
   for (const build of builds) {

--- a/src/image-builders/aws-image-builder/delete-resources.lambda.ts
+++ b/src/image-builders/aws-image-builder/delete-resources.lambda.ts
@@ -1,145 +1,310 @@
-import { DeregisterImageCommand, DescribeImagesCommand, EC2Client } from '@aws-sdk/client-ec2';
+import { CloudFormationClient, DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
+import { DeregisterImageCommand, DescribeImagesCommand, DescribeLaunchTemplateVersionsCommand, EC2Client } from '@aws-sdk/client-ec2';
 import { BatchDeleteImageCommand, ECRClient } from '@aws-sdk/client-ecr';
-import { DeleteImageCommand, ImagebuilderClient, ListImageBuildVersionsCommand, ListImageBuildVersionsResponse } from '@aws-sdk/client-imagebuilder';
+import {
+  DeleteImageCommand,
+  ImagebuilderClient,
+  ImageSummary,
+  ListImageBuildVersionsCommand,
+  ListImageBuildVersionsResponse,
+  ListImagesCommand,
+  ListImagesResponse,
+} from '@aws-sdk/client-imagebuilder';
 import * as AWSLambda from 'aws-lambda';
 import { customResourceRespond } from '../../lambda-helpers';
 
+const cfn = new CloudFormationClient();
 const ec2 = new EC2Client();
 const ecr = new ECRClient();
 const ib = new ImagebuilderClient();
+
+// only delete images that are done and not ones in progress
+const DELETABLE_IMAGE_STATUSES = [
+  'AVAILABLE',
+  'DEPRECATED',
+  'FAILED',
+  'CANCELLED',
+];
+
+// delete all images when the stack is being torn down, as there is nothing left to protect and this is our last chance to clean up
+const TEARDOWN_STACK_STATUSES = [
+  'DELETE_IN_PROGRESS',
+  'DELETE_FAILED',
+  'DELETE_COMPLETE',
+  // these are rollback from initial creation and specifically not UPDATE_ROLLBACK_* which is rollback of an update where stack lives on
+  'ROLLBACK_IN_PROGRESS',
+  'ROLLBACK_FAILED',
+  'ROLLBACK_COMPLETE',
+];
 
 /**
  * @internal
  */
 export interface DeleteResourcesProps {
   ServiceToken: string;
-  ImageVersionArn: string;
+
+  /**
+   * Current recipe version. We clean all versions, but this is here to make sure CloudFormation calls us to clean up after an update. Changing the
+   * recipe changes the version, which makes CloudFormation delete the old physical resource once the update succeeded, and that's what gets us called
+   * to clean up.
+   */
+  RecipeVersion: string;
+
+  /**
+   * Recipe whose images we clean up.
+   *
+   * This can be missing when cleaning up for deploys made with version 0.16.0 and below.
+   */
+  RecipeName?: string;
+
+  /**
+   * Launch template that gets updated by EC2 Image Builder with the latest AMI. We will skip deleting the AMI that the launch template points at, so
+   * we don't break any runners that are still using it. When a stack is being deleted, we won't skip.
+   */
+  LaunchTemplateId?: string;
 }
 
-async function deleteResources(props: DeleteResourcesProps) {
-  const buildsToDelete: string[] = [];
-  const amisToDelete: string[] = [];
-  const dockerImagesToDelete: string[] = [];
+/**
+ * Check whether the entire stack is being torn down.
+ *
+ * On any error we assume it isn't. Leaving an image behind costs a little money, but deleting one that's still in use breaks every runner until the
+ * next scheduled build.
+ */
+async function isStackTearingDown(stackId: string) {
+  try {
+    const stacks = await cfn.send(new DescribeStacksCommand({ StackName: stackId }));
+    const status = stacks.Stacks?.[0]?.StackStatus;
+    if (!status) {
+      console.warn({
+        notice: 'Unable to find stack status, assuming the stack is staying around',
+        stack: stackId,
+      });
+      return false;
+    }
+    return TEARDOWN_STACK_STATUSES.includes(status);
+  } catch (e) {
+    console.warn({
+      notice: 'Unable to get stack status, assuming the stack is staying around',
+      stack: stackId,
+      error: e,
+    });
+    return false;
+  }
+}
 
-  let result: ListImageBuildVersionsResponse = {};
-  do {
-    result = await ib.send(new ListImageBuildVersionsCommand({
-      imageVersionArn: props.ImageVersionArn,
-      nextToken: result.nextToken,
+/**
+ * Get AMI from launch template so we know to not delete an AMI that's still being used.
+ *
+ * If the launch template is missing, or we can't read it, we return undefined and will delete all images. This can happen when the stack is being
+ * torn down and the launch template is already gone. Another use case is when the stack is rolling back the initial creation of the image before the
+ * launch template had a chance to be created.
+ */
+async function launchTemplateAmi(launchTemplateId: string) {
+  try {
+    const versions = await ec2.send(new DescribeLaunchTemplateVersionsCommand({
+      LaunchTemplateId: launchTemplateId,
+      Versions: ['$Default'],
     }));
-    if (result.imageSummaryList) {
-      for (const image of result.imageSummaryList) {
-        if (image.arn) {
-          buildsToDelete.push(image.arn);
-        }
-        for (const output of image.outputResources?.amis ?? []) {
-          if (output.image) {
-            amisToDelete.push(output.image);
-          }
-        }
-        for (const output of image.outputResources?.containers ?? []) {
-          if (output.imageUris) {
-            dockerImagesToDelete.push(...output.imageUris);
-          }
-        }
-      }
-    }
-  } while (result.nextToken);
 
-  // delete amis
-  for (const imageId of amisToDelete) {
-    try {
-      console.log({
-        notice: 'Deleting AMI',
-        image: imageId,
-      });
+    return versions.LaunchTemplateVersions?.[0]?.LaunchTemplateData?.ImageId;
+  } catch (e) {
+    console.warn({
+      notice: 'Unable to read launch template, no AMI will be protected',
+      launchTemplate: launchTemplateId,
+      error: e,
+    });
+    return undefined;
+  }
+}
 
-      const imageDesc = await ec2.send(new DescribeImagesCommand({
-        Owners: ['self'],
-        ImageIds: [imageId],
-      }));
+/**
+ * Get image builds of every version of the recipe. We want to clean up all versions, not just the one CloudFormation gave us. Otherwise, leftovers
+ * from previously interrupted deployments would stay around forever, as lifecycle policies retain images per recipe version and a leftover is usually
+ * the only image of its version.
+ */
+async function recipeBuilds(recipeName: string) {
+  const builds: ImageSummary[] = [];
 
-      if (imageDesc.Images?.length !== 1) {
-        console.warn({
-          notice: 'Unable to find AMI',
-          image: imageId,
-        });
+  let versions: ListImagesResponse = {};
+  do {
+    versions = await ib.send(new ListImagesCommand({
+      owner: 'Self',
+      filters: [{ name: 'name', values: [recipeName] }],
+      nextToken: versions.nextToken,
+    }));
+
+    for (const version of versions.imageVersionList ?? []) {
+      if (!version.arn) {
         continue;
       }
 
-      await ec2.send(new DeregisterImageCommand({
-        ImageId: imageId,
-        DeleteAssociatedSnapshots: true,
-      }));
-    } catch (e) {
+      let result: ListImageBuildVersionsResponse = {};
+      do {
+        result = await ib.send(new ListImageBuildVersionsCommand({
+          imageVersionArn: version.arn,
+          nextToken: result.nextToken,
+        }));
+        builds.push(...result.imageSummaryList ?? []);
+      } while (result.nextToken);
+    }
+  } while (versions.nextToken);
+
+  return builds;
+}
+
+/**
+ * Decide whether a build can be deleted. During teardown everything goes, as nothing is left to protect and we won't be called again. Otherwise, we
+ * only touch builds that finished, and never the AMI runners are currently using.
+ */
+function keepBuild(build: ImageSummary, protectedAmi: string | undefined, teardown: boolean) {
+  if (teardown) {
+    // last chance to clean up, so try everything. deleting a build that's still running will simply fail and be logged.
+    return false;
+  }
+
+  if (!build.state?.status || !DELETABLE_IMAGE_STATUSES.includes(build.state.status)) {
+    console.log({
+      notice: 'Keeping build as it has not finished yet',
+      build: build.arn,
+      status: build.state?.status,
+    });
+    return true;
+  }
+
+  if (protectedAmi && (build.outputResources?.amis ?? []).some(ami => ami.image === protectedAmi)) {
+    console.log({
+      notice: 'Keeping build as its AMI is used by the launch template',
+      build: build.arn,
+      image: protectedAmi,
+    });
+    return true;
+  }
+
+  return false;
+}
+
+async function deleteAmi(imageId: string) {
+  try {
+    console.log({
+      notice: 'Deleting AMI',
+      image: imageId,
+    });
+
+    const imageDesc = await ec2.send(new DescribeImagesCommand({
+      Owners: ['self'],
+      ImageIds: [imageId],
+    }));
+
+    if (imageDesc.Images?.length !== 1) {
       console.warn({
-        notice: 'Failed to delete AMI',
+        notice: 'Unable to find AMI',
         image: imageId,
-        error: e,
       });
+      return;
     }
-  }
 
-  // delete docker images
-  for (const image of dockerImagesToDelete) {
-    try {
+    await ec2.send(new DeregisterImageCommand({
+      ImageId: imageId,
+      DeleteAssociatedSnapshots: true,
+    }));
+  } catch (e) {
+    console.warn({
+      notice: 'Failed to delete AMI',
+      image: imageId,
+      error: e,
+    });
+  }
+}
+
+async function deleteDockerImage(image: string) {
+  try {
+    console.log({
+      notice: 'Deleting Docker Image',
+      image,
+    });
+
+    // image looks like 0123456789.dkr.ecr.us-east-1.amazonaws.com/github-runners-test-windowsimagebuilderrepositorya4cbb6d8-hehdl99r7s3d:1.0.10-1
+    const parts = image.split('/')[1].split(':');
+    const repo = parts[0];
+    const tag = parts[1];
+
+    // skip 'latest' as it's a shared tag across recipe versions.
+    // without this skip, simple recipe upgrades will end up with latest being gone and runners not starting.
+    // old image versions will still point to 'latest' even when a new one replaced it.
+    // on complete stack destruction, ecr.Repository(... emptyOnDelete: true ...) will take care of it.
+    if (tag === 'latest') {
       console.log({
-        notice: 'Deleting Docker Image',
+        notice: 'Skipping latest tag as it is shared',
         image,
       });
+      return;
+    }
 
-      // image looks like 0123456789.dkr.ecr.us-east-1.amazonaws.com/github-runners-test-windowsimagebuilderrepositorya4cbb6d8-hehdl99r7s3d:1.0.10-1
-      const parts = image.split('/')[1].split(':');
-      const repo = parts[0];
-      const tag = parts[1];
+    await ecr.send(new BatchDeleteImageCommand({
+      repositoryName: repo,
+      imageIds: [
+        {
+          imageTag: tag,
+        },
+      ],
+    }));
+  } catch (e) {
+    console.warn({
+      notice: 'Failed to delete docker image',
+      image,
+      error: e,
+    });
+  }
+}
 
-      // skip 'latest' as it's a shared tag across recipe versions.
-      // without this skip, simple recipe upgrades will end up with latest being gone and runners not starting.
-      // old image versions will still point to 'latest' even when a new one replaced it.
-      // on complete stack destruction, ecr.Repository(... emptyOnDelete: true ...) will take care of it.
-      if (tag === 'latest') {
-        console.log({
-          notice: 'Skipping latest tag as it is shared',
-          image,
-        });
-        continue;
+async function deleteBuild(build: string) {
+  try {
+    console.log({
+      notice: 'Deleting Image Build',
+      build,
+    });
+
+    await ib.send(new DeleteImageCommand({
+      imageBuildVersionArn: build,
+    }));
+  } catch (e) {
+    console.warn({
+      notice: 'Failed to delete image version build',
+      build,
+      error: e,
+    });
+  }
+}
+
+async function deleteResources(props: DeleteResourcesProps, teardown: boolean) {
+  if (!props.RecipeName) {
+    console.log({
+      notice: 'Skipping resource left by an older version of this construct, the next deployment will clean it up',
+    });
+    return;
+  }
+
+  const protectedAmi = props.LaunchTemplateId && !teardown ? await launchTemplateAmi(props.LaunchTemplateId) : undefined;
+  const builds = (await recipeBuilds(props.RecipeName)).filter(build => !keepBuild(build, protectedAmi, teardown));
+
+  for (const build of builds) {
+    for (const output of build.outputResources?.amis ?? []) {
+      if (output.image) {
+        await deleteAmi(output.image);
       }
+    }
 
-      // delete image
-      await ecr.send(new BatchDeleteImageCommand({
-        repositoryName: repo,
-        imageIds: [
-          {
-            imageTag: tag,
-          },
-        ],
-      }));
-    } catch (e) {
-      console.warn({
-        notice: 'Failed to delete docker image',
-        image,
-        error: e,
-      });
+    for (const output of build.outputResources?.containers ?? []) {
+      for (const image of output.imageUris ?? []) {
+        await deleteDockerImage(image);
+      }
     }
   }
 
-  // delete builds (last so retries would still work)
-  for (const build of buildsToDelete) {
-    try {
-      console.log({
-        notice: 'Deleting Image Build',
-        build,
-      });
-
-      await ib.send(new DeleteImageCommand({
-        imageBuildVersionArn: build,
-      }));
-    } catch (e) {
-      console.warn({
-        notice: 'Failed to delete image version build',
-        build,
-        error: e,
-      });
+  // delete builds last so retries would still work
+  for (const build of builds) {
+    if (build.arn) {
+      await deleteBuild(build.arn);
     }
   }
 }
@@ -157,14 +322,15 @@ export async function handler(event: AWSLambda.CloudFormationCustomResourceEvent
     switch (event.RequestType) {
       case 'Create':
       case 'Update':
-        // we just return the arn as the physical id
-        // this way a change in the version will trigger delete of the old version on cleanup of stack
-        // it will also trigger delete on stack deletion
-        await customResourceRespond(event, 'SUCCESS', 'OK', props.ImageVersionArn, {});
+        // we just return the recipe version as the physical id.
+        // this way a change in the version makes CloudFormation delete the old physical resource, which is how we get called to clean up after a
+        // successful update. it also gets us called on stack deletion. the cleanup itself covers every version of the recipe, so it doesn't matter
+        // which version we're called for.
+        await customResourceRespond(event, 'SUCCESS', 'OK', props.RecipeVersion, {});
         break;
       case 'Delete':
         if (event.PhysicalResourceId != 'FAIL') {
-          await deleteResources(props);
+          await deleteResources(props, await isStackTearingDown(event.StackId));
         }
         await customResourceRespond(event, 'SUCCESS', 'OK', event.PhysicalResourceId, {});
         break;

--- a/src/image-builders/aws-image-builder/delete-resources.lambda.ts
+++ b/src/image-builders/aws-image-builder/delete-resources.lambda.ts
@@ -334,7 +334,7 @@ async function deleteResources(props: DeleteResourcesProps, teardown: boolean) {
   }
 
   // delete builds last so retries would still work
-  for (const build of builds) {
+  for (const build of filteredBuilds) {
     if (build.arn) {
       await deleteBuild(build.arn);
     }

--- a/src/image-builders/aws-image-builder/delete-resources.lambda.ts
+++ b/src/image-builders/aws-image-builder/delete-resources.lambda.ts
@@ -298,6 +298,8 @@ async function deleteResources(props: DeleteResourcesProps, teardown: boolean) {
     return;
   }
 
+  const builds = await recipeBuilds(props.RecipeName);
+
   let protectedAmi: string | undefined;
   if (props.LaunchTemplateId && !teardown) {
     try {
@@ -313,9 +315,9 @@ async function deleteResources(props: DeleteResourcesProps, teardown: boolean) {
     }
   }
 
-  const builds = (await recipeBuilds(props.RecipeName)).filter(build => !keepBuild(build, protectedAmi, teardown));
+  const filteredBuilds = builds.filter(build => !keepBuild(build, protectedAmi, teardown));
 
-  for (const build of builds) {
+  for (const build of filteredBuilds) {
     for (const output of build.outputResources?.amis ?? []) {
       if (output.image) {
         await deleteAmi(output.image);

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -113,16 +113,16 @@
         }
       }
     },
-    "c8204ff40a1a2de9aebe5c4383623c9db9683a11ff3ba0fcfffa6e3aa388a359": {
+    "f442f8ef55541968808d9101b860fd25eebe0705740f3ce2a44e7565185e0983": {
       "displayName": "aws-image-builder-delete-resources-dcc036c8-876b-451e-a2c1-552f9e06e9e1/Code",
       "source": {
-        "path": "asset.c8204ff40a1a2de9aebe5c4383623c9db9683a11ff3ba0fcfffa6e3aa388a359.lambda",
+        "path": "asset.f442f8ef55541968808d9101b860fd25eebe0705740f3ce2a44e7565185e0983.lambda",
         "packaging": "zip"
       },
       "destinations": {
-        "current_account-current_region-bd5d96f5": {
+        "current_account-current_region-f668bff3": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "c8204ff40a1a2de9aebe5c4383623c9db9683a11ff3ba0fcfffa6e3aa388a359.zip",
+          "objectKey": "f442f8ef55541968808d9101b860fd25eebe0705740f3ce2a44e7565185e0983.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -309,16 +309,16 @@
         }
       }
     },
-    "a146090bd5c02b9956e7dff78934c7b6ca95562955e4fc2ad3a0af32370dc147": {
+    "a4271f76c01ae8302384bd1e2f22dfa33136343896b5a9756ed296e7be9f6625": {
       "displayName": "github-runners-test Template",
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
       },
       "destinations": {
-        "current_account-current_region-40fe4d21": {
+        "current_account-current_region-3c909f67": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "a146090bd5c02b9956e7dff78934c7b6ca95562955e4fc2ad3a0af32370dc147.json",
+          "objectKey": "a4271f76c01ae8302384bd1e2f22dfa33136343896b5a9756ed296e7be9f6625.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -113,16 +113,16 @@
         }
       }
     },
-    "f442f8ef55541968808d9101b860fd25eebe0705740f3ce2a44e7565185e0983": {
+    "d2c5c3085feada3d9e4da7223ac774f941e040d97f67209721f4abb3604fda43": {
       "displayName": "aws-image-builder-delete-resources-dcc036c8-876b-451e-a2c1-552f9e06e9e1/Code",
       "source": {
-        "path": "asset.f442f8ef55541968808d9101b860fd25eebe0705740f3ce2a44e7565185e0983.lambda",
+        "path": "asset.d2c5c3085feada3d9e4da7223ac774f941e040d97f67209721f4abb3604fda43.lambda",
         "packaging": "zip"
       },
       "destinations": {
-        "current_account-current_region-f668bff3": {
+        "current_account-current_region-a52da01a": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "f442f8ef55541968808d9101b860fd25eebe0705740f3ce2a44e7565185e0983.zip",
+          "objectKey": "d2c5c3085feada3d9e4da7223ac774f941e040d97f67209721f4abb3604fda43.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -309,16 +309,16 @@
         }
       }
     },
-    "a4271f76c01ae8302384bd1e2f22dfa33136343896b5a9756ed296e7be9f6625": {
+    "42645f647bca7e2440d5266be9c76dad9fc2475ada81c198570042b41f98ce4f": {
       "displayName": "github-runners-test Template",
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
       },
       "destinations": {
-        "current_account-current_region-3c909f67": {
+        "current_account-current_region-43c30c45": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "a4271f76c01ae8302384bd1e2f22dfa33136343896b5a9756ed296e7be9f6625.json",
+          "objectKey": "42645f647bca7e2440d5266be9c76dad9fc2475ada81c198570042b41f98ce4f.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -2025,30 +2025,11 @@
       "Arn"
      ]
     },
-    "ImageVersionArn": {
-     "Fn::Join": [
-      "",
-      [
-       "arn:",
-       {
-        "Ref": "AWS::Partition"
-       },
-       ":imagebuilder:",
-       {
-        "Ref": "AWS::Region"
-       },
-       ":",
-       {
-        "Ref": "AWS::AccountId"
-       },
-       ":image/github-runners-test-windowsimagebuilder-containerrecipe-c577a80b/",
-       {
-        "Fn::GetAtt": [
-         "WindowsImageBuilderContainerRecipeB2A421D7",
-         "Version"
-        ]
-       }
-      ]
+    "RecipeName": "github-runners-test-WindowsImageBuilder-ContainerRecipe-C577A80B",
+    "RecipeVersion": {
+     "Fn::GetAtt": [
+      "WindowsImageBuilderContainerRecipeB2A421D7",
+      "Version"
      ]
     }
    },
@@ -2643,31 +2624,15 @@
       "Arn"
      ]
     },
-    "ImageVersionArn": {
-     "Fn::Join": [
-      "",
-      [
-       "arn:",
-       {
-        "Ref": "AWS::Partition"
-       },
-       ":imagebuilder:",
-       {
-        "Ref": "AWS::Region"
-       },
-       ":",
-       {
-        "Ref": "AWS::AccountId"
-       },
-       ":image/github-runners-test-amilinuxbuilder-amirecipe-2b5c5a8b/",
-       {
-        "Fn::GetAtt": [
-         "AMILinuxBuilderAmiRecipe7C7ED6C7",
-         "Version"
-        ]
-       }
-      ]
+    "RecipeName": "github-runners-test-AMILinuxBuilder-AmiRecipe-2B5C5A8B",
+    "RecipeVersion": {
+     "Fn::GetAtt": [
+      "AMILinuxBuilderAmiRecipe7C7ED6C7",
+      "Version"
      ]
+    },
+    "LaunchTemplateId": {
+     "Ref": "AMILinuxBuilderLaunchtemplateA29452C4"
     }
    },
    "UpdateReplacePolicy": "Delete",
@@ -5115,31 +5080,15 @@
       "Arn"
      ]
     },
-    "ImageVersionArn": {
-     "Fn::Join": [
-      "",
-      [
-       "arn:",
-       {
-        "Ref": "AWS::Partition"
-       },
-       ":imagebuilder:",
-       {
-        "Ref": "AWS::Region"
-       },
-       ":",
-       {
-        "Ref": "AWS::AccountId"
-       },
-       ":image/github-runners-test-amilinuxarm64builder-amirecipe-9167b5ef/",
-       {
-        "Fn::GetAtt": [
-         "AMILinuxarm64BuilderAmiRecipe6A6ED38F",
-         "Version"
-        ]
-       }
-      ]
+    "RecipeName": "github-runners-test-AMILinuxarm64Builder-AmiRecipe-9167B5EF",
+    "RecipeVersion": {
+     "Fn::GetAtt": [
+      "AMILinuxarm64BuilderAmiRecipe6A6ED38F",
+      "Version"
      ]
+    },
+    "LaunchTemplateId": {
+     "Ref": "AMILinuxarm64BuilderLaunchtemplate8F5EFF44"
     }
    },
    "UpdateReplacePolicy": "Delete",
@@ -5664,31 +5613,15 @@
       "Arn"
      ]
     },
-    "ImageVersionArn": {
-     "Fn::Join": [
-      "",
-      [
-       "arn:",
-       {
-        "Ref": "AWS::Partition"
-       },
-       ":imagebuilder:",
-       {
-        "Ref": "AWS::Region"
-       },
-       ":",
-       {
-        "Ref": "AWS::AccountId"
-       },
-       ":image/github-runners-test-windowsec2builder-amirecipe-beda5750/",
-       {
-        "Fn::GetAtt": [
-         "WindowsEC2BuilderAmiRecipe41A137FF",
-         "Version"
-        ]
-       }
-      ]
+    "RecipeName": "github-runners-test-WindowsEC2Builder-AmiRecipe-BEDA5750",
+    "RecipeVersion": {
+     "Fn::GetAtt": [
+      "WindowsEC2BuilderAmiRecipe41A137FF",
+      "Version"
      ]
+    },
+    "LaunchTemplateId": {
+     "Ref": "WindowsEC2BuilderLaunchtemplate0A66E9C2"
     }
    },
    "UpdateReplacePolicy": "Delete",
@@ -7859,6 +7792,7 @@
      "Statement": [
       {
        "Action": [
+        "imagebuilder:ListImages",
         "imagebuilder:ListImageBuildVersions",
         "imagebuilder:DeleteImage"
        ],
@@ -7866,7 +7800,10 @@
        "Resource": "*"
       },
       {
-       "Action": "ec2:DescribeImages",
+       "Action": [
+        "ec2:DescribeImages",
+        "ec2:DescribeLaunchTemplateVersions"
+       ],
        "Effect": "Allow",
        "Resource": "*"
       },
@@ -7887,6 +7824,13 @@
        "Action": "ecr:BatchDeleteImage",
        "Effect": "Allow",
        "Resource": "*"
+      },
+      {
+       "Action": "cloudformation:DescribeStacks",
+       "Effect": "Allow",
+       "Resource": {
+        "Ref": "AWS::StackId"
+       }
       }
      ],
      "Version": "2012-10-17"
@@ -7906,7 +7850,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "c8204ff40a1a2de9aebe5c4383623c9db9683a11ff3ba0fcfffa6e3aa388a359.zip"
+     "S3Key": "f442f8ef55541968808d9101b860fd25eebe0705740f3ce2a44e7565185e0983.zip"
     },
     "Description": "Custom resource handler that deletes resources of old versions of EC2 Image Builder images",
     "Environment": {

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -7850,7 +7850,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "f442f8ef55541968808d9101b860fd25eebe0705740f3ce2a44e7565185e0983.zip"
+     "S3Key": "d2c5c3085feada3d9e4da7223ac774f941e040d97f67209721f4abb3604fda43.zip"
     },
     "Description": "Custom resource handler that deletes resources of old versions of EC2 Image Builder images",
     "Environment": {


### PR DESCRIPTION
A stack update that fails *after* EC2 Image Builder finished building a new runner image leaves the runner provider broken. No runner can start until the next scheduled build, which is up to seven days away with default settings (`rebuildInterval`).

The step function will fail to start an EC2 runner with:

```
{
  "resourceType": "aws-sdk:ec2",
  "resource": "runInstances.waitForTaskToken",
  "error": "Ec2.Ec2Exception",
  "cause": "The image id '[ami-080b30a8007b83806]' does not exist (Service: Ec2, Status Code: 400, Request ID: a60bccde-20ee-4ad0-b003-a574f769f42c) (SDK Attempt Count: 1)"
}
```

Our `DeleteResourcesFunction` custom resource uses the recipe version as its physical resource id, so a successful update replaces it and CloudFormation deletes the old version's resources. On an update rollback the same mechanism works in reverse: CloudFormation deletes the *new* physical resource, so the cleaner deregisters the AMI that was just built.

For Docker images this is harmless, since the `latest` tag is skipped and still resolves. For AMIs it isn't. EC2 Image Builder had already pointed the launch template at the new AMI, and CloudFormation cannot roll that back because it isn't even aware of the change. The launch template is left pointing at a deregistered AMI.

The fix gives AMIs what the `latest` tag already gives Docker images. The cleaner reads the launch template's default version and never deletes the AMI it points at. The launch template is the only reliable source of truth, since EC2 Image Builder sets it outside of CloudFormation. The stack ends up running a newer image than it asked for, which is the documented known issue, rather than no image at all which is arguably a more broken state.

The cleaner now also goes over every version of the recipe, not just the version CloudFormation asked about. Without that, an image kept by the rule above would possibly stay forever. Other images that were missed due to bad deploys or any other reason would also stay around. This change assures we always leave the camp ground clean after we visited. No stranded AMIs collecting dust and costing money.

Only builds that finished are touched. Distribution is one of the build steps, so an image that hasn't finished may still be on its way to the launch template. Failed and cancelled builds are cleaned up like any other, as they leave an Image Builder resource behind that nothing else removes.

Stack status is checked, but only to know whether the whole stack is going away. During stack deletion, and during rollback of a failed *create*, there is no launch template left to protect and this is our last chance to clean up, so everything is deleted. It is never used to decide whether an individual image is in use. The check is needed because the cleaner has to reference the launch template to read its default version, so CloudFormation deletes the cleaner before the launch template, and we can't tell a teardown from an update by whether the launch template still exists.

If the launch template can't be read at all due to throttling, a transient error, or a missing grant; the cleanup is skipped entirely rather than treated as "nothing to protect". Not knowing which AMI is in use is not the same as knowing none is.

### Upgrading

An upgrade that also changes the recipe leaves one image behind per builder. CloudFormation hands us the properties of the previously deployed template when it deletes the old physical resource, and those don't carry the recipe name or the launch template. We can't clean up by recipe without the name, and we can't safely clean up the old version without the launch template either, since `waitOnDeploy: false` builds nothing during deployment and leaves the old image still in use. That one delete is skipped, and the leftover is collected by the next deployment that changes the recipe.

An upgrade on its own doesn't change the recipe, so nothing new gets built, nothing is superseded, and nothing is left behind. Most upgrades do end up touching the recipe though, as components change with the library.

### Related

This prevents the state behind #870, where a launch template pointing at a deleted AMI makes `AmiRootDevice` fail every subsequent deployment with `ami-... doesn't exist`. Stacks already in that state are not recovered by this change. That will be handled separately.

### Testing

`test/default.integ.ts` has a `testDeploymentFailureAfterImageBuilt` flag that fails a deployment after every image is built. Before this fix, enabling that flag resulted in a launch template pointing to an AMI that no longer exists. Runner would fail to start and the step function would be stuck in a loop of ``.
