### PR TITLE
fix: Failed deployment deletes the AMI that was just built

### DIFF
--- a/API.md
+++ b/API.md
@@ -6390,6 +6390,9 @@ Additional tags to apply to the AMI built by this builder.
 These additional tags are set on top of `Name`, `GitHubRunners:Stack`, and `GitHubRunners:Builder`.
 You may override the built-in tags.
 
+Overriding `GitHubRunners:Stack` will stop old AMIs from being deleted, as the image cleaner is only allowed to touch AMIs tagged with the name
+of the stack it lives in. You will have to delete those AMIs yourself.
+
 ---
 
 ##### `fastLaunchOptions`<sup>Optional</sup> <a name="fastLaunchOptions" id="@cloudsnorkel/cdk-github-runners.AwsImageBuilderRunnerImageBuilderProps.property.fastLaunchOptions"></a>

--- a/README.md
+++ b/README.md
@@ -599,6 +599,7 @@ Other useful metrics to track:
 ## Known Issues
 
 1. Runner images built during a failed deployment are not rolled back. If your stack fails to deploy after an image was already built, the new image will stay in use. The image will be automatically replaced on the next build interval, but that might take up to 7 days with default settings (`rebuildInterval`). It's recommended to not leave stacks in `UPDATE_ROLLBACK_COMPLETE` state. Deploying again with the configuration you want will rebuild the images and get everything back in sync.
+2. Library downgrades are not well tested. We work hard to keep backwards compatibility, but downgrading to an older version of the library may lead to unexpected issues. For example, downgrading from 0.16.1 may result in runner images being deleted. They will be rebuilt on the next build interval, but that might take up to 7 days with default settings (`rebuildInterval`). It's recommended to not downgrade the library unless you know what you're doing.
 
 ## Getting Help
 

--- a/src/image-builders/aws-image-builder/builder.ts
+++ b/src/image-builders/aws-image-builder/builder.ts
@@ -4,6 +4,7 @@ import {
   aws_ec2 as ec2,
   aws_ecr as ecr,
   aws_events as events,
+  aws_events_targets as events_targets,
   aws_iam as iam,
   aws_imagebuilder as imagebuilder,
   aws_lambda as lambda,
@@ -16,14 +17,14 @@ import {
   RemovalPolicy,
   Stack,
 } from 'aws-cdk-lib';
-import { TagMutability } from 'aws-cdk-lib/aws-ecr';
+import { TagMutability, TagStatus } from 'aws-cdk-lib/aws-ecr';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Construct, IConstruct } from 'constructs';
 import { AmiRecipe, defaultBaseAmi } from './ami';
 import { BaseContainerImage, BaseImage } from './base-image';
 import { ContainerRecipe, defaultBaseDockerImage } from './container';
 import { DeleteResourcesFunction } from './delete-resources-function';
-import { DeleteResourcesProps } from './delete-resources.lambda';
+import { CleanerTarget, DeleteResourcesProps, ScheduledCleanupEvent } from './delete-resources.lambda';
 import { FilterFailedBuildsFunction } from './filter-failed-builds-function';
 import { generateBuildWorkflowWithDockerSetupCommands, Workflow } from './workflow';
 import { Architecture, Os, RunnerAmi, RunnerImage, RunnerVersion } from '../../providers';
@@ -62,6 +63,9 @@ export interface AwsImageBuilderRunnerImageBuilderProps {
    *
    * These additional tags are set on top of `Name`, `GitHubRunners:Stack`, and `GitHubRunners:Builder`.
    * You may override the built-in tags.
+   *
+   * Overriding `GitHubRunners:Stack` will stop old AMIs from being deleted, as the image cleaner is only allowed to touch AMIs tagged with the name
+   * of the stack it lives in. You will have to delete those AMIs yourself.
    *
    * @default no additional tags
    */
@@ -356,6 +360,11 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
     this.fastLaunchOptions = props?.awsImageBuilderOptions?.fastLaunchOptions;
     this.storageSize = props?.awsImageBuilderOptions?.storageSize;
     this.amiTags = props?.awsImageBuilderOptions?.amiTags ?? {};
+
+    if ('GitHubRunners:Stack' in this.amiTags) {
+      Annotations.of(this).addWarning('Overriding the GitHubRunners:Stack AMI tag can prevent old AMIs from being deleted. You will have to delete them yourself.');
+    }
+
     this.waitOnDeploy = props?.waitOnDeploy ?? true;
     this.dockerSetupCommands = props?.dockerSetupCommands ?? [];
 
@@ -431,12 +440,20 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
       return this.boundDockerImage;
     }
 
-    // create repository that only keeps one tag
+    // old images are deleted by imageCleaner() as it's the only thing that knows which one is still in use.
+    // the lifecycle rule only picks up images that lost their tags, which the cleaner can no longer find through EC2 Image Builder.
     const repository = new ecr.Repository(this, 'Repository', {
       imageScanOnPush: true,
       imageTagMutability: TagMutability.MUTABLE,
       removalPolicy: RemovalPolicy.DESTROY,
       emptyOnDelete: true,
+      lifecycleRules: [
+        {
+          description: 'Remove untagged images left behind by interrupted pushes',
+          tagStatus: TagStatus.UNTAGGED,
+          maxImageAge: Duration.days(1),
+        },
+      ],
     });
 
     const dist = new imagebuilder.CfnDistributionConfiguration(this, 'Docker Distribution', {
@@ -486,7 +503,7 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
     if (this.waitOnDeploy) {
       this.createImage(infra, dist, log, undefined, recipe.arn);
     }
-    this.dockerImageCleaner(recipe, repository);
+    this.dockerImageCleaner(recipe);
 
     this.createPipeline(infra, dist, log, undefined, recipe.arn);
 
@@ -503,7 +520,7 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
     return this.boundDockerImage;
   }
 
-  private dockerImageCleaner(recipe: ContainerRecipe, repository: ecr.IRepository) {
+  private dockerImageCleaner(recipe: ContainerRecipe) {
     // this is here to provide safe upgrade from old cdk-github-runners versions
     // this lambda was used by a custom resource to delete all images builds on cleanup
     // if we remove the custom resource and the lambda, the old images will be deleted on update
@@ -520,56 +537,8 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
       resources: ['*'],
     }));
 
-    // delete old version on update and on stack deletion
-    this.imageCleaner('Container', recipe.name.toLowerCase(), recipe.version);
-
-    // delete old docker images + IB resources daily
-    new imagebuilder.CfnLifecyclePolicy(this, 'Lifecycle Policy Docker', {
-      name: uniqueImageBuilderName(this),
-      description: `Delete old GitHub Runner Docker images for ${this.node.path}`,
-      executionRole: new iam.Role(this, 'Lifecycle Policy Docker Role', {
-        assumedBy: new iam.ServicePrincipal('imagebuilder.amazonaws.com'),
-        inlinePolicies: {
-          ib: new iam.PolicyDocument({
-            statements: [
-              new iam.PolicyStatement({
-                actions: ['tag:GetResources', 'imagebuilder:DeleteImage'],
-                resources: ['*'], // Image Builder doesn't support scoping this :(
-              }),
-            ],
-          }),
-          ecr: new iam.PolicyDocument({
-            statements: [
-              new iam.PolicyStatement({
-                actions: ['ecr:BatchGetImage', 'ecr:BatchDeleteImage'],
-                resources: [repository.repositoryArn],
-              }),
-            ],
-          }),
-        },
-      }).roleArn,
-      policyDetails: [{
-        action: {
-          type: 'DELETE',
-          includeResources: {
-            containers: true,
-          },
-        },
-        filter: {
-          type: 'COUNT',
-          value: 2,
-        },
-      }],
-      resourceType: 'CONTAINER_IMAGE',
-      resourceSelection: {
-        recipes: [
-          {
-            name: recipe.name,
-            semanticVersion: '1.x.x',
-          },
-        ],
-      },
-    });
+    // delete old Docker images daily, and everything when this builder is removed
+    this.imageCleaner('Container', recipe.name, recipe.version);
   }
 
   protected createLog(id: string, recipeName: string): logs.LogGroup {
@@ -839,12 +808,12 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
       cacheKey: recipe.version, // re-evaluate AMI whenever the recipe changes
     };
 
-    this.amiCleaner(recipe, stackName, builderName);
+    this.amiCleaner(recipe, launchTemplate);
 
     return this.boundAmi;
   }
 
-  private amiCleaner(recipe: AmiRecipe, stackName: string, builderName: string) {
+  private amiCleaner(recipe: AmiRecipe, launchTemplate: ec2.LaunchTemplate) {
     // this is here to provide safe upgrade from old cdk-github-runners versions
     // this lambda was used by a custom resource to delete all amis when the builder was removed
     // if we remove the custom resource, role and lambda, all amis will be deleted on update
@@ -870,67 +839,8 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
       l1role.overrideLogicalId('deleteamidcc036c8876b451ea2c1552f9e06e9e1ServiceRole1CC58A6F');
     }
 
-    // delete old version on update and on stack deletion
-    this.imageCleaner('Image', recipe.name.toLowerCase(), recipe.version);
-
-    // delete old AMIs + IB resources daily
-    new imagebuilder.CfnLifecyclePolicy(this, 'Lifecycle Policy AMI', {
-      name: uniqueImageBuilderName(this),
-      description: `Delete old GitHub Runner AMIs for ${this.node.path}`,
-      executionRole: new iam.Role(this, 'Lifecycle Policy AMI Role', {
-        assumedBy: new iam.ServicePrincipal('imagebuilder.amazonaws.com'),
-        inlinePolicies: {
-          ib: new iam.PolicyDocument({
-            statements: [
-              new iam.PolicyStatement({
-                actions: ['tag:GetResources', 'imagebuilder:DeleteImage'],
-                resources: ['*'], // Image Builder doesn't support scoping this :(
-              }),
-            ],
-          }),
-          ami: new iam.PolicyDocument({
-            statements: [
-              new iam.PolicyStatement({
-                actions: ['ec2:DescribeImages', 'ec2:DescribeImageAttribute'],
-                resources: ['*'],
-              }),
-              new iam.PolicyStatement({
-                actions: ['ec2:DeregisterImage', 'ec2:DeleteSnapshot'],
-                resources: ['*'],
-                conditions: {
-                  StringEquals: {
-                    'aws:ResourceTag/GitHubRunners:Stack': stackName,
-                    'aws:ResourceTag/GitHubRunners:Builder': builderName,
-                  },
-                },
-              }),
-            ],
-          }),
-        },
-      }).roleArn,
-      policyDetails: [{
-        action: {
-          type: 'DELETE',
-          includeResources: {
-            amis: true,
-            snapshots: true,
-          },
-        },
-        filter: {
-          type: 'COUNT',
-          value: 2,
-        },
-      }],
-      resourceType: 'AMI_IMAGE',
-      resourceSelection: {
-        recipes: [
-          {
-            name: recipe.name,
-            semanticVersion: '1.x.x',
-          },
-        ],
-      },
-    });
+    // delete old AMIs daily, and everything when this builder is removed
+    this.imageCleaner('Image', recipe.name, recipe.version, launchTemplate);
   }
 
   private bindComponents(): ImageBuilderComponent[] {
@@ -941,19 +851,29 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
     return this.boundComponents;
   }
 
-  private imageCleaner(type: 'Container' | 'Image', recipeName: string, version: string) {
+  /**
+   * Set up cleanup of images built by this builder
+   *
+   * A single Lambda handles both paths. On a schedule it deletes old images, but keeping the latest 2 and the one the launch template points at.
+   * On removal of the builder, or deletion of the stack, a custom resource has it delete every image of this builder.
+   *
+   * The custom resource always reports the same physical resource id, so CloudFormation never replaces it. That's what makes deleting everything
+   * safe: `Delete` can then only mean the builder is going away, and never an update or a rollback of one.
+   */
+  private imageCleaner(type: 'Container' | 'Image', recipeName: string, version: string, launchTemplate?: ec2.LaunchTemplate) {
     const cleanerFunction = singletonLambda(DeleteResourcesFunction, this, 'aws-image-builder-delete-resources', {
-      description: 'Custom resource handler that deletes resources of old versions of EC2 Image Builder images',
+      description: 'Deletes old EC2 Image Builder runner images, and all of them when their builder is removed',
       initialPolicy: [
         new iam.PolicyStatement({
           actions: [
+            'imagebuilder:ListImages',
             'imagebuilder:ListImageBuildVersions',
             'imagebuilder:DeleteImage',
           ],
           resources: ['*'],
         }),
         new iam.PolicyStatement({
-          actions: ['ec2:DescribeImages'],
+          actions: ['ec2:DescribeImages', 'ec2:DescribeLaunchTemplateVersions'],
           resources: ['*'],
         }),
         new iam.PolicyStatement({
@@ -975,17 +895,44 @@ export class AwsImageBuilderRunnerImageBuilder extends RunnerImageBuilderBase {
       timeout: cdk.Duration.minutes(10),
     });
 
+    const target: CleanerTarget = {
+      RecipeName: recipeName,
+      LaunchTemplateId: launchTemplate?.launchTemplateId,
+    };
+
+    // delete everything when this builder is removed or the stack is deleted
     new CustomResource(this, `${type} Cleaner`, {
       serviceToken: cleanerFunction.functionArn,
       resourceType: 'Custom::ImageBuilder-Delete-Resources',
       properties: <DeleteResourcesProps>{
+        ...target,
+        // this one property is for backwards compatibility. versions 0.16.0 and older used it. if we remove it and an upgrade from 0.16.0 fails, then
+        // old code can end up running on these properties as it cleans up the update. without this property, the old code will delete every image in
+        // the account. it assumed ImageVersionArn was sent and passed it as-is to ListImageBuildVersionsCommand which will happily return all images
+        // in the account when imageVersionArn is undefined.
+        // it is also used for successful upgrades from 0.16.0 with the corner case of the deployment also removing a builder at the same time as the
+        // upgrade. in that case, the new code will run against the old properties. so technically not the one we send here, but it's relevant.
         ImageVersionArn: cdk.Stack.of(this).formatArn({
           service: 'imagebuilder',
           resource: 'image',
-          resourceName: `${recipeName}/${version}`,
+          resourceName: `${recipeName.toLowerCase()}/${version}`,
           arnFormat: cdk.ArnFormat.SLASH_RESOURCE_NAME,
         }),
       },
+    });
+
+    // delete old images daily
+    new events.Rule(this, `${type} Cleaner Schedule`, {
+      description: `Delete old GitHub Runner images for ${this.node.path}`,
+      schedule: events.Schedule.rate(Duration.days(1)),
+      targets: [
+        new events_targets.LambdaFunction(cleanerFunction, {
+          event: events.RuleTargetInput.fromObject(<ScheduledCleanupEvent>{
+            RequestType: 'Scheduled',
+            ...target,
+          }),
+        }),
+      ],
     });
   }
 }

--- a/src/image-builders/aws-image-builder/delete-resources.lambda.ts
+++ b/src/image-builders/aws-image-builder/delete-resources.lambda.ts
@@ -1,6 +1,14 @@
-import { DeregisterImageCommand, DescribeImagesCommand, EC2Client } from '@aws-sdk/client-ec2';
+import { DeregisterImageCommand, DescribeImagesCommand, DescribeLaunchTemplateVersionsCommand, EC2Client } from '@aws-sdk/client-ec2';
 import { BatchDeleteImageCommand, ECRClient } from '@aws-sdk/client-ecr';
-import { DeleteImageCommand, ImagebuilderClient, ListImageBuildVersionsCommand, ListImageBuildVersionsResponse } from '@aws-sdk/client-imagebuilder';
+import {
+  DeleteImageCommand,
+  ImagebuilderClient,
+  ImageSummary,
+  ListImageBuildVersionsCommand,
+  ListImageBuildVersionsResponse,
+  ListImagesCommand,
+  ListImagesResponse,
+} from '@aws-sdk/client-imagebuilder';
 import * as AWSLambda from 'aws-lambda';
 import { customResourceRespond } from '../../lambda-helpers';
 
@@ -9,142 +17,441 @@ const ecr = new ECRClient();
 const ib = new ImagebuilderClient();
 
 /**
+ * Physical resource id we hand out when the custom resource is first created.
+ *
+ * The id itself matters less than the fact that it never changes. We never want to see a replacement as that would cause us to delete all images, and
+ * they might still be in use. That's also why on `Update` we just echo back whatever id came in (and it will be different for upgrades). Updates, and
+ * rollbacks of updates, leave the resource alone. That's what makes it safe to delete everything we find on `Delete`.
+ *
+ * Stacks that predate this version keep the image version ARN they were given as their id, forever, and that's fine. What tells a real removal from a
+ * leftover of the old behavior is the properties, not the id. See `deleteAllResources`.
+ *
  * @internal
  */
-export interface DeleteResourcesProps {
-  ServiceToken: string;
-  ImageVersionArn: string;
+export const CLEANER_PHYSICAL_RESOURCE_ID = 'runner-images-deleted-when-builder-is-removed';
+
+/**
+ * Number of finished images we keep around on the scheduled cleanup, on top of the image that's currently in use. It gives us something to fall back
+ * on, and keeps an image built by a deployment that later rolled back from being collected the moment it's built.
+ */
+const KEEP_IMAGES = 2;
+
+/**
+ * Images that are done building. Anything else is still on its way to the launch template, as distribution is one of the build steps, so we never
+ * touch it. The full list of states also has PENDING, CREATING, BUILDING, TESTING, DISTRIBUTING, and INTEGRATING.
+ */
+const DELETABLE_IMAGE_STATUSES = [
+  'AVAILABLE',
+  'DEPRECATED',
+  'FAILED',
+  'CANCELLED',
+];
+
+/**
+ * The launch template is gone for good, so there is no AMI left for us to protect. Any other error means we simply don't know which AMI is in use,
+ * which is not the same as knowing no AMI is in use.
+ */
+const MISSING_LAUNCH_TEMPLATE_ERRORS = [
+  'InvalidLaunchTemplateId.NotFound',
+  'InvalidLaunchTemplateId.Malformed',
+];
+
+/**
+ * Everything we need to find the images of one builder, and the one image of those that's still in use.
+ *
+ * @internal
+ */
+export interface CleanerTarget {
+  /**
+   * Recipe whose images we clean up. EC2 Image Builder names images after the recipe that built them.
+   *
+   * Missing on a builder removed by the very deployment that upgrades from version 0.16.0 or below, as CloudFormation hands a `Delete` the
+   * properties of the last template that deployed successfully. `ImageVersionArn` is used to find the recipe in that case.
+   */
+  readonly RecipeName?: string;
+
+  /**
+   * Launch template that EC2 Image Builder points at the latest AMI. We never delete the AMI of its default version, or runners still starting from
+   * it would fail. Not set for Docker image builders.
+   */
+  readonly LaunchTemplateId?: string;
+
+  /**
+   * Current version of the recipe, as an image version ARN.
+   *
+   * This is the only property version 0.16.0 and below wrote, and the only one they read. We keep writing it for two reasons. It tells us the recipe
+   * when we get a `Delete` carrying their properties. And should their code ever run against our properties -- a downgrade replaces the custom
+   * resource, and the old code then handles the delete of the resource it superseded -- it has something scoped to work with. Without it, they call
+   * ListImageBuildVersions with no image version, which lists every image build version in the account and deletes all of them.
+   */
+  readonly ImageVersionArn?: string;
 }
 
-async function deleteResources(props: DeleteResourcesProps) {
-  const buildsToDelete: string[] = [];
-  const amisToDelete: string[] = [];
-  const dockerImagesToDelete: string[] = [];
+/**
+ * @internal
+ */
+export interface DeleteResourcesProps extends CleanerTarget {
+  readonly ServiceToken: string;
+}
 
-  let result: ListImageBuildVersionsResponse = {};
-  do {
-    result = await ib.send(new ListImageBuildVersionsCommand({
-      imageVersionArn: props.ImageVersionArn,
-      nextToken: result.nextToken,
+/**
+ * Scheduled event sent by the EventBridge rule of a single builder.
+ *
+ * @internal
+ */
+export interface ScheduledCleanupEvent extends CleanerTarget {
+  readonly RequestType: 'Scheduled';
+}
+
+/**
+ * Get the AMI the launch template points at, so we know not to delete an image that's still in use.
+ *
+ * EC2 Image Builder sets the default version of the launch template outside of CloudFormation, and RunInstances uses that same default version, so
+ * it's the only reliable answer to "which AMI is in use". Note this is `$Default` and not `$Latest`.
+ *
+ * Returns undefined when the launch template is gone, or when its default version has no AMI yet, as neither leaves an AMI in use. Throws on any
+ * other error so the caller can leave everything alone.
+ */
+async function launchTemplateAmi(launchTemplateId: string) {
+  try {
+    const versions = await ec2.send(new DescribeLaunchTemplateVersionsCommand({
+      LaunchTemplateId: launchTemplateId,
+      Versions: ['$Default'],
     }));
-    if (result.imageSummaryList) {
-      for (const image of result.imageSummaryList) {
-        if (image.arn) {
-          buildsToDelete.push(image.arn);
-        }
-        for (const output of image.outputResources?.amis ?? []) {
-          if (output.image) {
-            amisToDelete.push(output.image);
-          }
-        }
-        for (const output of image.outputResources?.containers ?? []) {
-          if (output.imageUris) {
-            dockerImagesToDelete.push(...output.imageUris);
-          }
-        }
-      }
-    }
-  } while (result.nextToken);
 
-  // delete amis
-  for (const imageId of amisToDelete) {
-    try {
+    return versions.LaunchTemplateVersions?.[0]?.LaunchTemplateData?.ImageId;
+  } catch (e) {
+    if (MISSING_LAUNCH_TEMPLATE_ERRORS.includes((e as Error).name)) {
       console.log({
-        notice: 'Deleting AMI',
-        image: imageId,
+        notice: 'Launch template is gone or empty, so no AMI needs to be protected',
+        launchTemplate: launchTemplateId,
+        error: (e as Error).name,
       });
+      return undefined;
+    }
 
-      const imageDesc = await ec2.send(new DescribeImagesCommand({
-        Owners: ['self'],
-        ImageIds: [imageId],
-      }));
+    throw e;
+  }
+}
 
-      if (imageDesc.Images?.length !== 1) {
-        console.warn({
-          notice: 'Unable to find AMI',
-          image: imageId,
-        });
+/**
+ * Get the image builds of every version of the recipe.
+ *
+ * Every version is listed and not just the current one. Recipe versions change with every component change, so leftovers from interrupted deployments
+ * would otherwise stay around forever. `includeDeprecated` is required or deprecated versions are never returned and can never be cleaned up.
+ *
+ * The `name` filter is case-sensitive, so it has to be the recipe name as written and not the lowercased form that image ARNs use.
+ */
+async function recipeBuilds(recipeName: string) {
+  const builds: ImageSummary[] = [];
+  let listed = 0;
+
+  let versions: ListImagesResponse = {};
+  do {
+    versions = await ib.send(new ListImagesCommand({
+      owner: 'Self',
+      filters: [{ name: 'name', values: [recipeName] }],
+      includeDeprecated: true,
+      nextToken: versions.nextToken,
+    }));
+
+    for (const version of versions.imageVersionList ?? []) {
+      if (!version.arn) {
         continue;
       }
 
-      await ec2.send(new DeregisterImageCommand({
-        ImageId: imageId,
-        DeleteAssociatedSnapshots: true,
-      }));
-    } catch (e) {
+      listed++;
+
+      let result: ListImageBuildVersionsResponse = {};
+      do {
+        result = await ib.send(new ListImageBuildVersionsCommand({
+          imageVersionArn: version.arn,
+          nextToken: result.nextToken,
+        }));
+        builds.push(...result.imageSummaryList ?? []);
+      } while (result.nextToken);
+    }
+  } while (versions.nextToken);
+
+  console.log({
+    notice: 'Listed image versions',
+    recipe: recipeName,
+    versions: listed,
+    builds: builds.length,
+  });
+
+  return builds;
+}
+
+function buildDate(build: ImageSummary) {
+  return (build.dateCreated ? Date.parse(build.dateCreated) : 0) || 0;
+}
+
+async function deleteAmi(imageId: string) {
+  try {
+    console.log({
+      notice: 'Deleting AMI',
+      image: imageId,
+    });
+
+    const imageDesc = await ec2.send(new DescribeImagesCommand({
+      Owners: ['self'],
+      ImageIds: [imageId],
+    }));
+
+    if (imageDesc.Images?.length !== 1) {
       console.warn({
-        notice: 'Failed to delete AMI',
+        notice: 'Unable to find AMI',
         image: imageId,
-        error: e,
       });
+      return;
     }
-  }
 
-  // delete docker images
-  for (const image of dockerImagesToDelete) {
-    try {
+    await ec2.send(new DeregisterImageCommand({
+      ImageId: imageId,
+      DeleteAssociatedSnapshots: true,
+    }));
+  } catch (e) {
+    console.warn({
+      notice: 'Failed to delete AMI',
+      image: imageId,
+      error: e,
+    });
+  }
+}
+
+async function deleteDockerImage(image: string) {
+  try {
+    console.log({
+      notice: 'Deleting Docker Image',
+      image,
+    });
+
+    // image looks like 0123456789.dkr.ecr.us-east-1.amazonaws.com/github-runners-test-windowsimagebuilderrepositorya4cbb6d8-hehdl99r7s3d:1.0.10-1
+    const parts = image.split('/')[1].split(':');
+    const repo = parts[0];
+    const tag = parts[1];
+
+    // skip 'latest' as it's a shared tag across recipe versions.
+    // without this skip, simple recipe upgrades will end up with latest being gone and runners not starting.
+    // old image versions will still point to 'latest' even when a new one replaced it.
+    // on complete stack destruction, ecr.Repository(... emptyOnDelete: true ...) will take care of it.
+    if (tag === 'latest') {
       console.log({
-        notice: 'Deleting Docker Image',
+        notice: 'Skipping latest tag as it is shared and still in use',
         image,
       });
+      return;
+    }
 
-      // image looks like 0123456789.dkr.ecr.us-east-1.amazonaws.com/github-runners-test-windowsimagebuilderrepositorya4cbb6d8-hehdl99r7s3d:1.0.10-1
-      const parts = image.split('/')[1].split(':');
-      const repo = parts[0];
-      const tag = parts[1];
+    await ecr.send(new BatchDeleteImageCommand({
+      repositoryName: repo,
+      imageIds: [
+        {
+          imageTag: tag,
+        },
+      ],
+    }));
+  } catch (e) {
+    console.warn({
+      notice: 'Failed to delete docker image',
+      image,
+      error: e,
+    });
+  }
+}
 
-      // skip 'latest' as it's a shared tag across recipe versions.
-      // without this skip, simple recipe upgrades will end up with latest being gone and runners not starting.
-      // old image versions will still point to 'latest' even when a new one replaced it.
-      // on complete stack destruction, ecr.Repository(... emptyOnDelete: true ...) will take care of it.
-      if (tag === 'latest') {
-        console.log({
-          notice: 'Skipping latest tag as it is shared',
-          image,
-        });
-        continue;
+async function deleteBuild(build: string) {
+  try {
+    console.log({
+      notice: 'Deleting Image Build',
+      build,
+    });
+
+    await ib.send(new DeleteImageCommand({
+      imageBuildVersionArn: build,
+    }));
+  } catch (e) {
+    console.warn({
+      notice: 'Failed to delete image version build',
+      build,
+      error: e,
+    });
+  }
+}
+
+/**
+ * Delete the given builds along with everything they produced. EC2 Image Builder resources go last, so a failure in the middle still leaves us able
+ * to find the AMIs and Docker images on the next run.
+ */
+async function deleteBuilds(builds: ImageSummary[]) {
+  for (const build of builds) {
+    for (const output of build.outputResources?.amis ?? []) {
+      if (output.image) {
+        await deleteAmi(output.image);
       }
+    }
 
-      // delete image
-      await ecr.send(new BatchDeleteImageCommand({
-        repositoryName: repo,
-        imageIds: [
-          {
-            imageTag: tag,
-          },
-        ],
-      }));
-    } catch (e) {
-      console.warn({
-        notice: 'Failed to delete docker image',
-        image,
-        error: e,
-      });
+    for (const output of build.outputResources?.containers ?? []) {
+      for (const image of output.imageUris ?? []) {
+        await deleteDockerImage(image);
+      }
     }
   }
 
-  // delete builds (last so retries would still work)
-  for (const build of buildsToDelete) {
-    try {
-      console.log({
-        notice: 'Deleting Image Build',
-        build,
-      });
-
-      await ib.send(new DeleteImageCommand({
-        imageBuildVersionArn: build,
-      }));
-    } catch (e) {
-      console.warn({
-        notice: 'Failed to delete image version build',
-        build,
-        error: e,
-      });
+  for (const build of builds) {
+    if (build.arn) {
+      await deleteBuild(build.arn);
     }
   }
 }
 
-export async function handler(event: AWSLambda.CloudFormationCustomResourceEvent, _context: AWSLambda.Context) {
+/**
+ * Scheduled cleanup of one builder. Keeps the image that's in use, the newest few images, and anything that hasn't finished building.
+ */
+async function deleteOldResources(target: CleanerTarget) {
+  if (!target.RecipeName) {
+    console.warn({
+      notice: 'No recipe name, nothing to clean up',
+    });
+    return;
+  }
+
+  let protectedAmi: string | undefined;
+  if (target.LaunchTemplateId) {
+    try {
+      protectedAmi = await launchTemplateAmi(target.LaunchTemplateId);
+    } catch (e) {
+      // we can't tell which AMI is in use, so we leave everything alone and try again tomorrow
+      console.warn({
+        notice: 'Unable to read launch template, skipping cleanup so an AMI in use is not deleted',
+        launchTemplate: target.LaunchTemplateId,
+        error: e,
+      });
+      return;
+    }
+  }
+
+  // unfinished builds may still be on their way to the launch template, so they are never deleted and never counted
+  const finished = (await recipeBuilds(target.RecipeName)).filter(build => {
+    if (build.state?.status && DELETABLE_IMAGE_STATUSES.includes(build.state.status)) {
+      return true;
+    }
+
+    console.log({
+      notice: 'Keeping build as it has not finished yet',
+      build: build.arn,
+      status: build.state?.status,
+    });
+    return false;
+  });
+
+  // newest first, so the newest few can be kept
+  finished.sort((a, b) => buildDate(b) - buildDate(a));
+
+  // remove any non-successful build + all successful builds after the first KEEP_IMAGES, but skip protectedAmi
+  const successful = finished.filter(build => build.state?.status === 'AVAILABLE');
+  const unsuccessful = finished.filter(build => build.state?.status !== 'AVAILABLE');
+  const oldBuilds = unsuccessful.concat(successful.slice(KEEP_IMAGES)).filter(build => {
+    if (protectedAmi && (build.outputResources?.amis ?? []).some(ami => ami.image === protectedAmi)) {
+      console.log({
+        notice: 'Keeping build as its AMI is used by the launch template',
+        build: build.arn,
+        image: protectedAmi,
+      });
+      return false;
+    }
+
+    return true;
+  });
+
+  console.log({
+    notice: 'Deleting old images',
+    recipe: target.RecipeName,
+    found: finished.length,
+    deleting: oldBuilds.length,
+  });
+
+  await deleteBuilds(oldBuilds);
+}
+
+/**
+ * Name of the recipe that built a given image version, read off one of its builds.
+ *
+ * EC2 Image Builder names an image after the recipe that built it, and unlike the name inside the ARN this one keeps the original casing that the
+ * ListImages filter needs. One page is enough, as every build of a version carries the same name.
+ */
+async function recipeOfImageVersion(imageVersionArn: string) {
+  try {
+    const builds = await ib.send(new ListImageBuildVersionsCommand({ imageVersionArn }));
+    return builds.imageSummaryList?.find(build => build.name)?.name;
+  } catch (e) {
+    console.warn({
+      notice: 'Failed to look up the recipe of an image version',
+      image: imageVersionArn,
+      error: e,
+    });
+    return undefined;
+  }
+}
+
+/**
+ * The builder is being removed, so nothing it built is in use anymore. Delete all of it, including the AMI of the launch template.
+ *
+ * Nothing else can get us here. The physical resource id never changes, so CloudFormation never replaces this resource, and a `Delete` can only mean
+ * the builder is gone from the template or the stack is being deleted.
+ */
+async function deleteAllResources(target: CleanerTarget) {
+  let recipeName = target.RecipeName;
+
+  if (!recipeName) {
+    // properties written by version 0.16.0 or below, which named the image version instead of the recipe. we get those for a builder removed by the
+    // very deployment that upgrades, as its last successful template is still the old one.
+    if (!target.ImageVersionArn) {
+      console.warn({
+        notice: 'Neither a recipe name nor an image version to clean up',
+      });
+      return;
+    }
+
+    recipeName = await recipeOfImageVersion(target.ImageVersionArn);
+    if (!recipeName) {
+      console.warn({
+        notice: 'No builds left to tell us which recipe to clean up',
+        image: target.ImageVersionArn,
+      });
+      return;
+    }
+
+    console.log({
+      notice: 'Found the recipe of a builder last deployed by an older version of this construct',
+      image: target.ImageVersionArn,
+      recipe: recipeName,
+    });
+  }
+
+  const builds = await recipeBuilds(recipeName);
+
+  console.log({
+    notice: 'Deleting all images',
+    recipe: recipeName,
+    deleting: builds.length,
+  });
+
+  await deleteBuilds(builds);
+}
+
+export async function handler(event: ScheduledCleanupEvent | AWSLambda.CloudFormationCustomResourceEvent, _context: AWSLambda.Context) {
+  if (event.RequestType === 'Scheduled') {
+    console.log({
+      notice: 'Scheduled image cleanup request',
+      ...event,
+    });
+
+    await deleteOldResources(event);
+    return;
+  }
+
   try {
     console.log({
       notice: 'CloudFormation custom resource request',
@@ -152,20 +459,19 @@ export async function handler(event: AWSLambda.CloudFormationCustomResourceEvent
       ResponseURL: '...',
     });
 
-    const props = event.ResourceProperties as DeleteResourcesProps;
-
     switch (event.RequestType) {
       case 'Create':
+        await customResourceRespond(event, 'SUCCESS', 'OK', CLEANER_PHYSICAL_RESOURCE_ID, {});
+        break;
       case 'Update':
-        // we just return the arn as the physical id
-        // this way a change in the version will trigger delete of the old version on cleanup of stack
-        // it will also trigger delete on stack deletion
-        await customResourceRespond(event, 'SUCCESS', 'OK', props.ImageVersionArn, {});
+        // echo the id back rather than returning our own, so it never changes -- not even on the deployment that upgrades from a version that used
+        // the image version ARN as the id. a changed id is a replacement, and CloudFormation backs a replacement out by deleting the new physical
+        // resource, which would have us delete every image of a builder that is still very much in use.
+        await customResourceRespond(event, 'SUCCESS', 'OK', event.PhysicalResourceId, {});
         break;
       case 'Delete':
-        if (event.PhysicalResourceId != 'FAIL') {
-          await deleteResources(props);
-        }
+        // the id never changes, so a Delete can only mean this builder is going away
+        await deleteAllResources(event.ResourceProperties as DeleteResourcesProps);
         await customResourceRespond(event, 'SUCCESS', 'OK', event.PhysicalResourceId, {});
         break;
     }
@@ -174,6 +480,10 @@ export async function handler(event: AWSLambda.CloudFormationCustomResourceEvent
       notice: 'Failed to delete Image Builder resources',
       error: e,
     });
-    await customResourceRespond(event, 'FAILED', (e as Error).message || 'Internal Error', 'FAIL', {});
+    // never hand back an id other than the one we were given. a changed id is a replacement, and CloudFormation backs a replacement out by deleting
+    // the new physical resource, which would have us delete every image of a builder that is still in use. a failed Create has no id yet, and the
+    // constant below is the one a successful Create would have returned anyway, so its rollback still deletes whatever the failed create did build.
+    const physicalResourceId = ('PhysicalResourceId' in event && event.PhysicalResourceId) || CLEANER_PHYSICAL_RESOURCE_ID;
+    await customResourceRespond(event, 'FAILED', (e as Error).message || 'Internal Error', physicalResourceId, {});
   }
 }

--- a/src/image-builders/aws-image-builder/delete-resources.lambda.ts
+++ b/src/image-builders/aws-image-builder/delete-resources.lambda.ts
@@ -57,6 +57,33 @@ const MISSING_LAUNCH_TEMPLATE_ERRORS = [
 ];
 
 /**
+ * Someone already deregistered the AMI, or Image Builder recorded an id we can never act on. Either way there is nothing left of it to lose track of,
+ * so the build that points at it can go. DescribeImages raises these rather than returning an empty list when it is given an explicit image id.
+ *
+ * Treating them as anything else would leave the build behind forever, failing every scheduled run and every delete for an AMI that is already gone.
+ */
+const MISSING_AMI_ERRORS = [
+  'InvalidAMIID.NotFound',
+  'InvalidAMIID.Unavailable',
+  'InvalidAMIID.Malformed',
+];
+
+/**
+ * The repository, or the image in it, is already gone. Same reasoning as `MISSING_AMI_ERRORS`.
+ */
+const MISSING_DOCKER_IMAGE_ERRORS = [
+  'RepositoryNotFoundException',
+  'ImageNotFoundException',
+];
+
+/**
+ * The image build is already gone, so there is nothing left to delete. Same reasoning as `MISSING_AMI_ERRORS`.
+ */
+const MISSING_BUILD_ERRORS = [
+  'ResourceNotFoundException',
+];
+
+/**
  * Everything we need to find the images of one builder, and the one image of those that's still in use.
  *
  * @internal
@@ -218,6 +245,15 @@ async function deleteAmi(imageId: string) {
 
     return true;
   } catch (e) {
+    if (MISSING_AMI_ERRORS.includes((e as Error).name)) {
+      console.log({
+        notice: 'AMI is already gone',
+        image: imageId,
+        error: (e as Error).name,
+      });
+      return true;
+    }
+
     console.warn({
       notice: 'Failed to delete AMI',
       image: imageId,
@@ -267,6 +303,15 @@ async function deleteDockerImage(image: string) {
 
     return true;
   } catch (e) {
+    if (MISSING_DOCKER_IMAGE_ERRORS.includes((e as Error).name)) {
+      console.log({
+        notice: 'Docker image is already gone',
+        image,
+        error: (e as Error).name,
+      });
+      return true;
+    }
+
     console.warn({
       notice: 'Failed to delete docker image',
       image,
@@ -292,6 +337,15 @@ async function deleteBuild(build: string) {
 
     return true;
   } catch (e) {
+    if (MISSING_BUILD_ERRORS.includes((e as Error).name)) {
+      console.log({
+        notice: 'Image build is already gone',
+        build,
+        error: (e as Error).name,
+      });
+      return true;
+    }
+
     console.warn({
       notice: 'Failed to delete image version build',
       build,

--- a/src/image-builders/aws-image-builder/delete-resources.lambda.ts
+++ b/src/image-builders/aws-image-builder/delete-resources.lambda.ts
@@ -187,6 +187,10 @@ function buildDate(build: ImageSummary) {
   return (build.dateCreated ? Date.parse(build.dateCreated) : 0) || 0;
 }
 
+/**
+ * Returns false if the AMI is still out there, so the caller knows to keep the build that points at it. An AMI we can no longer find is not a
+ * failure, as there is nothing left to lose track of.
+ */
 async function deleteAmi(imageId: string) {
   try {
     console.log({
@@ -204,22 +208,29 @@ async function deleteAmi(imageId: string) {
         notice: 'Unable to find AMI',
         image: imageId,
       });
-      return;
+      return true;
     }
 
     await ec2.send(new DeregisterImageCommand({
       ImageId: imageId,
       DeleteAssociatedSnapshots: true,
     }));
+
+    return true;
   } catch (e) {
     console.warn({
       notice: 'Failed to delete AMI',
       image: imageId,
       error: e,
     });
+    return false;
   }
 }
 
+/**
+ * Returns false if the tag is still out there, so the caller knows to keep the build that points at it. Skipping 'latest' is not a failure, as it is
+ * never ours to delete and every Docker build carries it.
+ */
 async function deleteDockerImage(image: string) {
   try {
     console.log({
@@ -235,13 +246,14 @@ async function deleteDockerImage(image: string) {
     // skip 'latest' as it's a shared tag across recipe versions.
     // without this skip, simple recipe upgrades will end up with latest being gone and runners not starting.
     // old image versions will still point to 'latest' even when a new one replaced it.
-    // on complete stack destruction, ecr.Repository(... emptyOnDelete: true ...) will take care of it.
+    // the repository is a child of the builder, so removing the builder or destroying the stack takes it with them and
+    // ecr.Repository(... emptyOnDelete: true ...) takes care of the tag.
     if (tag === 'latest') {
       console.log({
         notice: 'Skipping latest tag as it is shared and still in use',
         image,
       });
-      return;
+      return true;
     }
 
     await ecr.send(new BatchDeleteImageCommand({
@@ -252,15 +264,21 @@ async function deleteDockerImage(image: string) {
         },
       ],
     }));
+
+    return true;
   } catch (e) {
     console.warn({
       notice: 'Failed to delete docker image',
       image,
       error: e,
     });
+    return false;
   }
 }
 
+/**
+ * Returns false if the build is still there, so the caller knows something was left behind.
+ */
 async function deleteBuild(build: string) {
   try {
     console.log({
@@ -271,38 +289,69 @@ async function deleteBuild(build: string) {
     await ib.send(new DeleteImageCommand({
       imageBuildVersionArn: build,
     }));
+
+    return true;
   } catch (e) {
     console.warn({
       notice: 'Failed to delete image version build',
       build,
       error: e,
     });
+    return false;
   }
 }
 
 /**
- * Delete the given builds along with everything they produced. EC2 Image Builder resources go last, so a failure in the middle still leaves us able
- * to find the AMIs and Docker images on the next run.
+ * Delete the given builds along with everything they produced. The EC2 Image Builder resource is the only way back to an AMI or a Docker image, so a
+ * build is deleted last and only once everything it points at is gone. Leave one behind and whatever it produced leaks with no way to find it again.
+ *
+ * Deletes everything it can first, and only then reports what was left behind. A scheduled run is retried by Lambda and then again the next day. A
+ * custom resource responds FAILED, which CloudFormation retries every few minutes before it gives up and skips the resource, and which the user sees
+ * either way instead of quietly paying for AMIs nothing will ever come back for.
+ *
+ * Every one of those retries relists the recipe, so it picks up exactly what the last attempt could not delete. That only works because the builds
+ * pointing at those leftovers were kept: delete a build and its AMI is unreachable, so the retry would find nothing left to do.
  */
 async function deleteBuilds(builds: ImageSummary[]) {
+  const leftBehind = new Set<ImageSummary>();
+
   for (const build of builds) {
     for (const output of build.outputResources?.amis ?? []) {
-      if (output.image) {
-        await deleteAmi(output.image);
+      if (output.image && !await deleteAmi(output.image)) {
+        leftBehind.add(build);
       }
     }
 
     for (const output of build.outputResources?.containers ?? []) {
       for (const image of output.imageUris ?? []) {
-        await deleteDockerImage(image);
+        if (!await deleteDockerImage(image)) {
+          leftBehind.add(build);
+        }
       }
     }
   }
 
   for (const build of builds) {
-    if (build.arn) {
-      await deleteBuild(build.arn);
+    if (!build.arn) {
+      continue;
     }
+
+    if (leftBehind.has(build)) {
+      // keep it, so the next run can still find what we could not delete
+      console.warn({
+        notice: 'Keeping image build as not everything it produced could be deleted',
+        build: build.arn,
+      });
+      continue;
+    }
+
+    if (!await deleteBuild(build.arn)) {
+      leftBehind.add(build);
+    }
+  }
+
+  if (leftBehind.size > 0) {
+    throw new Error(`Failed to delete ${leftBehind.size} of ${builds.length} runner image builds. See the log for the error of each one.`);
   }
 }
 

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -113,16 +113,16 @@
         }
       }
     },
-    "0e132b725e8285b93452c1c291622b7619228d7ff44387df9637d07dcf4cf8e7": {
+    "4fa02673a430673898b8874377dabcfa7a2364b7fa832e8b947761e6941d26c2": {
       "displayName": "aws-image-builder-delete-resources-dcc036c8-876b-451e-a2c1-552f9e06e9e1/Code",
       "source": {
-        "path": "asset.0e132b725e8285b93452c1c291622b7619228d7ff44387df9637d07dcf4cf8e7.lambda",
+        "path": "asset.4fa02673a430673898b8874377dabcfa7a2364b7fa832e8b947761e6941d26c2.lambda",
         "packaging": "zip"
       },
       "destinations": {
-        "current_account-current_region-d8bf35f7": {
+        "current_account-current_region-bdc0c14f": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "0e132b725e8285b93452c1c291622b7619228d7ff44387df9637d07dcf4cf8e7.zip",
+          "objectKey": "4fa02673a430673898b8874377dabcfa7a2364b7fa832e8b947761e6941d26c2.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -309,16 +309,16 @@
         }
       }
     },
-    "30c9b4eee2268e25f9e6099637fecf2ccd906c111d67adc33fdbc71894b68254": {
+    "07b39f60e48101983353e2677485709889b22010cb8057b6115ada11d0f8ba91": {
       "displayName": "github-runners-test Template",
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
       },
       "destinations": {
-        "current_account-current_region-46f3a204": {
+        "current_account-current_region-7041fea9": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "30c9b4eee2268e25f9e6099637fecf2ccd906c111d67adc33fdbc71894b68254.json",
+          "objectKey": "07b39f60e48101983353e2677485709889b22010cb8057b6115ada11d0f8ba91.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -113,16 +113,16 @@
         }
       }
     },
-    "4fa02673a430673898b8874377dabcfa7a2364b7fa832e8b947761e6941d26c2": {
+    "09be9786702c789b1b41fe3ac96e758cf25ce6d8412fab0de06cfc9c0146f4c3": {
       "displayName": "aws-image-builder-delete-resources-dcc036c8-876b-451e-a2c1-552f9e06e9e1/Code",
       "source": {
-        "path": "asset.4fa02673a430673898b8874377dabcfa7a2364b7fa832e8b947761e6941d26c2.lambda",
+        "path": "asset.09be9786702c789b1b41fe3ac96e758cf25ce6d8412fab0de06cfc9c0146f4c3.lambda",
         "packaging": "zip"
       },
       "destinations": {
-        "current_account-current_region-bdc0c14f": {
+        "current_account-current_region-4533b754": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "4fa02673a430673898b8874377dabcfa7a2364b7fa832e8b947761e6941d26c2.zip",
+          "objectKey": "09be9786702c789b1b41fe3ac96e758cf25ce6d8412fab0de06cfc9c0146f4c3.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -309,16 +309,16 @@
         }
       }
     },
-    "07b39f60e48101983353e2677485709889b22010cb8057b6115ada11d0f8ba91": {
+    "c163b57c1d253089e2c16d4c68441d94f2d29c2dc64352e63343cbf3c78e3908": {
       "displayName": "github-runners-test Template",
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
       },
       "destinations": {
-        "current_account-current_region-7041fea9": {
+        "current_account-current_region-0a497ea6": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "07b39f60e48101983353e2677485709889b22010cb8057b6115ada11d0f8ba91.json",
+          "objectKey": "c163b57c1d253089e2c16d4c68441d94f2d29c2dc64352e63343cbf3c78e3908.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.assets.json
+++ b/test/default.integ.snapshot/github-runners-test.assets.json
@@ -113,16 +113,16 @@
         }
       }
     },
-    "c8204ff40a1a2de9aebe5c4383623c9db9683a11ff3ba0fcfffa6e3aa388a359": {
+    "0e132b725e8285b93452c1c291622b7619228d7ff44387df9637d07dcf4cf8e7": {
       "displayName": "aws-image-builder-delete-resources-dcc036c8-876b-451e-a2c1-552f9e06e9e1/Code",
       "source": {
-        "path": "asset.c8204ff40a1a2de9aebe5c4383623c9db9683a11ff3ba0fcfffa6e3aa388a359.lambda",
+        "path": "asset.0e132b725e8285b93452c1c291622b7619228d7ff44387df9637d07dcf4cf8e7.lambda",
         "packaging": "zip"
       },
       "destinations": {
-        "current_account-current_region-bd5d96f5": {
+        "current_account-current_region-d8bf35f7": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "c8204ff40a1a2de9aebe5c4383623c9db9683a11ff3ba0fcfffa6e3aa388a359.zip",
+          "objectKey": "0e132b725e8285b93452c1c291622b7619228d7ff44387df9637d07dcf4cf8e7.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -309,16 +309,16 @@
         }
       }
     },
-    "a146090bd5c02b9956e7dff78934c7b6ca95562955e4fc2ad3a0af32370dc147": {
+    "30c9b4eee2268e25f9e6099637fecf2ccd906c111d67adc33fdbc71894b68254": {
       "displayName": "github-runners-test Template",
       "source": {
         "path": "github-runners-test.template.json",
         "packaging": "file"
       },
       "destinations": {
-        "current_account-current_region-40fe4d21": {
+        "current_account-current_region-46f3a204": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "a146090bd5c02b9956e7dff78934c7b6ca95562955e4fc2ad3a0af32370dc147.json",
+          "objectKey": "30c9b4eee2268e25f9e6099637fecf2ccd906c111d67adc33fdbc71894b68254.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -7717,7 +7717,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "0e132b725e8285b93452c1c291622b7619228d7ff44387df9637d07dcf4cf8e7.zip"
+     "S3Key": "4fa02673a430673898b8874377dabcfa7a2364b7fa832e8b947761e6941d26c2.zip"
     },
     "Description": "Deletes old EC2 Image Builder runner images, and all of them when their builder is removed",
     "Environment": {

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -1812,7 +1812,10 @@
     "ImageScanningConfiguration": {
      "ScanOnPush": true
     },
-    "ImageTagMutability": "MUTABLE"
+    "ImageTagMutability": "MUTABLE",
+    "LifecyclePolicy": {
+     "LifecyclePolicyText": "{\"rules\":[{\"rulePriority\":1,\"description\":\"Remove untagged images left behind by interrupted pushes\",\"selection\":{\"tagStatus\":\"untagged\",\"countType\":\"sinceImagePushed\",\"countNumber\":1,\"countUnit\":\"days\"},\"action\":{\"type\":\"expire\"}}]}"
+    }
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -2025,6 +2028,7 @@
       "Arn"
      ]
     },
+    "RecipeName": "github-runners-test-WindowsImageBuilder-ContainerRecipe-C577A80B",
     "ImageVersionArn": {
      "Fn::Join": [
       "",
@@ -2055,96 +2059,43 @@
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
   },
-  "WindowsImageBuilderLifecyclePolicyDockerRole13C6E553": {
-   "Type": "AWS::IAM::Role",
+  "WindowsImageBuilderContainerCleanerSchedule3E51CC1C": {
+   "Type": "AWS::Events::Rule",
    "Properties": {
-    "AssumeRolePolicyDocument": {
-     "Statement": [
-      {
-       "Action": "sts:AssumeRole",
-       "Effect": "Allow",
-       "Principal": {
-        "Service": "imagebuilder.amazonaws.com"
-       }
-      }
-     ],
-     "Version": "2012-10-17"
-    },
-    "Policies": [
+    "Description": "Delete old GitHub Runner images for github-runners-test/Windows Image Builder",
+    "ScheduleExpression": "rate(1 day)",
+    "State": "ENABLED",
+    "Targets": [
      {
-      "PolicyDocument": {
-       "Statement": [
-        {
-         "Action": [
-          "tag:GetResources",
-          "imagebuilder:DeleteImage"
-         ],
-         "Effect": "Allow",
-         "Resource": "*"
-        }
-       ],
-       "Version": "2012-10-17"
+      "Arn": {
+       "Fn::GetAtt": [
+        "awsimagebuilderdeleteresourcesdcc036c8876b451ea2c1552f9e06e9e18E1C8382",
+        "Arn"
+       ]
       },
-      "PolicyName": "ib"
-     },
-     {
-      "PolicyDocument": {
-       "Statement": [
-        {
-         "Action": [
-          "ecr:BatchGetImage",
-          "ecr:BatchDeleteImage"
-         ],
-         "Effect": "Allow",
-         "Resource": {
-          "Fn::GetAtt": [
-           "WindowsImageBuilderRepositoryA4CBB6D8",
-           "Arn"
-          ]
-         }
-        }
-       ],
-       "Version": "2012-10-17"
-      },
-      "PolicyName": "ecr"
+      "Id": "Target0",
+      "Input": "{\"RequestType\":\"Scheduled\",\"RecipeName\":\"github-runners-test-WindowsImageBuilder-ContainerRecipe-C577A80B\"}"
      }
     ]
    }
   },
-  "WindowsImageBuilderLifecyclePolicyDockerB9CE4B0A": {
-   "Type": "AWS::ImageBuilder::LifecyclePolicy",
+  "WindowsImageBuilderContainerCleanerScheduleAllowEventRulegithubrunnerstestawsimagebuilderdeleteresourcesdcc036c8876b451ea2c1552f9e06e9e110E163149AC24482": {
+   "Type": "AWS::Lambda::Permission",
    "Properties": {
-    "Description": "Delete old GitHub Runner Docker images for github-runners-test/Windows Image Builder",
-    "ExecutionRole": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
      "Fn::GetAtt": [
-      "WindowsImageBuilderLifecyclePolicyDockerRole13C6E553",
+      "awsimagebuilderdeleteresourcesdcc036c8876b451ea2c1552f9e06e9e18E1C8382",
       "Arn"
      ]
     },
-    "Name": "github-runners-test-WindowsImageBuilder-18C0E1B2",
-    "PolicyDetails": [
-     {
-      "Action": {
-       "IncludeResources": {
-        "Containers": true
-       },
-       "Type": "DELETE"
-      },
-      "Filter": {
-       "Type": "COUNT",
-       "Value": 2
-      }
-     }
-    ],
-    "ResourceSelection": {
-     "Recipes": [
-      {
-       "Name": "github-runners-test-WindowsImageBuilder-ContainerRecipe-C577A80B",
-       "SemanticVersion": "1.x.x"
-      }
+    "Principal": "events.amazonaws.com",
+    "SourceArn": {
+     "Fn::GetAtt": [
+      "WindowsImageBuilderContainerCleanerSchedule3E51CC1C",
+      "Arn"
      ]
-    },
-    "ResourceType": "CONTAINER_IMAGE"
+    }
    }
   },
   "WindowsImageBuilderDockerPipeline3613721A": {
@@ -2643,6 +2594,10 @@
       "Arn"
      ]
     },
+    "RecipeName": "github-runners-test-AMILinuxBuilder-AmiRecipe-2B5C5A8B",
+    "LaunchTemplateId": {
+     "Ref": "AMILinuxBuilderLaunchtemplateA29452C4"
+    },
     "ImageVersionArn": {
      "Fn::Join": [
       "",
@@ -2673,106 +2628,54 @@
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
   },
-  "AMILinuxBuilderLifecyclePolicyAMIRole7BBFF711": {
-   "Type": "AWS::IAM::Role",
+  "AMILinuxBuilderImageCleanerSchedule99C1B08D": {
+   "Type": "AWS::Events::Rule",
    "Properties": {
-    "AssumeRolePolicyDocument": {
-     "Statement": [
-      {
-       "Action": "sts:AssumeRole",
-       "Effect": "Allow",
-       "Principal": {
-        "Service": "imagebuilder.amazonaws.com"
-       }
-      }
-     ],
-     "Version": "2012-10-17"
-    },
-    "Policies": [
+    "Description": "Delete old GitHub Runner images for github-runners-test/AMI Linux Builder",
+    "ScheduleExpression": "rate(1 day)",
+    "State": "ENABLED",
+    "Targets": [
      {
-      "PolicyDocument": {
-       "Statement": [
-        {
-         "Action": [
-          "tag:GetResources",
-          "imagebuilder:DeleteImage"
-         ],
-         "Effect": "Allow",
-         "Resource": "*"
-        }
-       ],
-       "Version": "2012-10-17"
+      "Arn": {
+       "Fn::GetAtt": [
+        "awsimagebuilderdeleteresourcesdcc036c8876b451ea2c1552f9e06e9e18E1C8382",
+        "Arn"
+       ]
       },
-      "PolicyName": "ib"
-     },
-     {
-      "PolicyDocument": {
-       "Statement": [
-        {
-         "Action": [
-          "ec2:DescribeImages",
-          "ec2:DescribeImageAttribute"
-         ],
-         "Effect": "Allow",
-         "Resource": "*"
-        },
-        {
-         "Action": [
-          "ec2:DeregisterImage",
-          "ec2:DeleteSnapshot"
-         ],
-         "Condition": {
-          "StringEquals": {
-           "aws:ResourceTag/GitHubRunners:Stack": "github-runners-test",
-           "aws:ResourceTag/GitHubRunners:Builder": "github-runners-test/AMI Linux Builder"
-          }
+      "Id": "Target0",
+      "Input": {
+       "Fn::Join": [
+        "",
+        [
+         "{\"RequestType\":\"Scheduled\",\"RecipeName\":\"github-runners-test-AMILinuxBuilder-AmiRecipe-2B5C5A8B\",\"LaunchTemplateId\":\"",
+         {
+          "Ref": "AMILinuxBuilderLaunchtemplateA29452C4"
          },
-         "Effect": "Allow",
-         "Resource": "*"
-        }
-       ],
-       "Version": "2012-10-17"
-      },
-      "PolicyName": "ami"
+         "\"}"
+        ]
+       ]
+      }
      }
     ]
    }
   },
-  "AMILinuxBuilderLifecyclePolicyAMIFB556CB2": {
-   "Type": "AWS::ImageBuilder::LifecyclePolicy",
+  "AMILinuxBuilderImageCleanerScheduleAllowEventRulegithubrunnerstestawsimagebuilderdeleteresourcesdcc036c8876b451ea2c1552f9e06e9e110E163141CA0514B": {
+   "Type": "AWS::Lambda::Permission",
    "Properties": {
-    "Description": "Delete old GitHub Runner AMIs for github-runners-test/AMI Linux Builder",
-    "ExecutionRole": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
      "Fn::GetAtt": [
-      "AMILinuxBuilderLifecyclePolicyAMIRole7BBFF711",
+      "awsimagebuilderdeleteresourcesdcc036c8876b451ea2c1552f9e06e9e18E1C8382",
       "Arn"
      ]
     },
-    "Name": "github-runners-test-AMILinuxBuilder-67243E6D",
-    "PolicyDetails": [
-     {
-      "Action": {
-       "IncludeResources": {
-        "Amis": true,
-        "Snapshots": true
-       },
-       "Type": "DELETE"
-      },
-      "Filter": {
-       "Type": "COUNT",
-       "Value": 2
-      }
-     }
-    ],
-    "ResourceSelection": {
-     "Recipes": [
-      {
-       "Name": "github-runners-test-AMILinuxBuilder-AmiRecipe-2B5C5A8B",
-       "SemanticVersion": "1.x.x"
-      }
+    "Principal": "events.amazonaws.com",
+    "SourceArn": {
+     "Fn::GetAtt": [
+      "AMILinuxBuilderImageCleanerSchedule99C1B08D",
+      "Arn"
      ]
-    },
-    "ResourceType": "AMI_IMAGE"
+    }
    }
   },
   "CodeBuildImageBuilderRoleF1F34984": {
@@ -5115,6 +5018,10 @@
       "Arn"
      ]
     },
+    "RecipeName": "github-runners-test-AMILinuxarm64Builder-AmiRecipe-9167B5EF",
+    "LaunchTemplateId": {
+     "Ref": "AMILinuxarm64BuilderLaunchtemplate8F5EFF44"
+    },
     "ImageVersionArn": {
      "Fn::Join": [
       "",
@@ -5145,106 +5052,54 @@
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
   },
-  "AMILinuxarm64BuilderLifecyclePolicyAMIRole1D81BF43": {
-   "Type": "AWS::IAM::Role",
+  "AMILinuxarm64BuilderImageCleanerScheduleA0B2C476": {
+   "Type": "AWS::Events::Rule",
    "Properties": {
-    "AssumeRolePolicyDocument": {
-     "Statement": [
-      {
-       "Action": "sts:AssumeRole",
-       "Effect": "Allow",
-       "Principal": {
-        "Service": "imagebuilder.amazonaws.com"
-       }
-      }
-     ],
-     "Version": "2012-10-17"
-    },
-    "Policies": [
+    "Description": "Delete old GitHub Runner images for github-runners-test/AMI Linux arm64 Builder",
+    "ScheduleExpression": "rate(1 day)",
+    "State": "ENABLED",
+    "Targets": [
      {
-      "PolicyDocument": {
-       "Statement": [
-        {
-         "Action": [
-          "tag:GetResources",
-          "imagebuilder:DeleteImage"
-         ],
-         "Effect": "Allow",
-         "Resource": "*"
-        }
-       ],
-       "Version": "2012-10-17"
+      "Arn": {
+       "Fn::GetAtt": [
+        "awsimagebuilderdeleteresourcesdcc036c8876b451ea2c1552f9e06e9e18E1C8382",
+        "Arn"
+       ]
       },
-      "PolicyName": "ib"
-     },
-     {
-      "PolicyDocument": {
-       "Statement": [
-        {
-         "Action": [
-          "ec2:DescribeImages",
-          "ec2:DescribeImageAttribute"
-         ],
-         "Effect": "Allow",
-         "Resource": "*"
-        },
-        {
-         "Action": [
-          "ec2:DeregisterImage",
-          "ec2:DeleteSnapshot"
-         ],
-         "Condition": {
-          "StringEquals": {
-           "aws:ResourceTag/GitHubRunners:Stack": "github-runners-test",
-           "aws:ResourceTag/GitHubRunners:Builder": "github-runners-test/AMI Linux arm64 Builder"
-          }
+      "Id": "Target0",
+      "Input": {
+       "Fn::Join": [
+        "",
+        [
+         "{\"RequestType\":\"Scheduled\",\"RecipeName\":\"github-runners-test-AMILinuxarm64Builder-AmiRecipe-9167B5EF\",\"LaunchTemplateId\":\"",
+         {
+          "Ref": "AMILinuxarm64BuilderLaunchtemplate8F5EFF44"
          },
-         "Effect": "Allow",
-         "Resource": "*"
-        }
-       ],
-       "Version": "2012-10-17"
-      },
-      "PolicyName": "ami"
+         "\"}"
+        ]
+       ]
+      }
      }
     ]
    }
   },
-  "AMILinuxarm64BuilderLifecyclePolicyAMI44B6EABD": {
-   "Type": "AWS::ImageBuilder::LifecyclePolicy",
+  "AMILinuxarm64BuilderImageCleanerScheduleAllowEventRulegithubrunnerstestawsimagebuilderdeleteresourcesdcc036c8876b451ea2c1552f9e06e9e110E16314D9F8DE87": {
+   "Type": "AWS::Lambda::Permission",
    "Properties": {
-    "Description": "Delete old GitHub Runner AMIs for github-runners-test/AMI Linux arm64 Builder",
-    "ExecutionRole": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
      "Fn::GetAtt": [
-      "AMILinuxarm64BuilderLifecyclePolicyAMIRole1D81BF43",
+      "awsimagebuilderdeleteresourcesdcc036c8876b451ea2c1552f9e06e9e18E1C8382",
       "Arn"
      ]
     },
-    "Name": "github-runners-test-AMILinuxarm64Builder-3F449283",
-    "PolicyDetails": [
-     {
-      "Action": {
-       "IncludeResources": {
-        "Amis": true,
-        "Snapshots": true
-       },
-       "Type": "DELETE"
-      },
-      "Filter": {
-       "Type": "COUNT",
-       "Value": 2
-      }
-     }
-    ],
-    "ResourceSelection": {
-     "Recipes": [
-      {
-       "Name": "github-runners-test-AMILinuxarm64Builder-AmiRecipe-9167B5EF",
-       "SemanticVersion": "1.x.x"
-      }
+    "Principal": "events.amazonaws.com",
+    "SourceArn": {
+     "Fn::GetAtt": [
+      "AMILinuxarm64BuilderImageCleanerScheduleA0B2C476",
+      "Arn"
      ]
-    },
-    "ResourceType": "AMI_IMAGE"
+    }
    }
   },
   "WindowsEC2BuilderRole1BA7D3E7": {
@@ -5664,6 +5519,10 @@
       "Arn"
      ]
     },
+    "RecipeName": "github-runners-test-WindowsEC2Builder-AmiRecipe-BEDA5750",
+    "LaunchTemplateId": {
+     "Ref": "WindowsEC2BuilderLaunchtemplate0A66E9C2"
+    },
     "ImageVersionArn": {
      "Fn::Join": [
       "",
@@ -5694,106 +5553,54 @@
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
   },
-  "WindowsEC2BuilderLifecyclePolicyAMIRoleE85A7F2C": {
-   "Type": "AWS::IAM::Role",
+  "WindowsEC2BuilderImageCleanerScheduleE8DEB84B": {
+   "Type": "AWS::Events::Rule",
    "Properties": {
-    "AssumeRolePolicyDocument": {
-     "Statement": [
-      {
-       "Action": "sts:AssumeRole",
-       "Effect": "Allow",
-       "Principal": {
-        "Service": "imagebuilder.amazonaws.com"
-       }
-      }
-     ],
-     "Version": "2012-10-17"
-    },
-    "Policies": [
+    "Description": "Delete old GitHub Runner images for github-runners-test/Windows EC2 Builder",
+    "ScheduleExpression": "rate(1 day)",
+    "State": "ENABLED",
+    "Targets": [
      {
-      "PolicyDocument": {
-       "Statement": [
-        {
-         "Action": [
-          "tag:GetResources",
-          "imagebuilder:DeleteImage"
-         ],
-         "Effect": "Allow",
-         "Resource": "*"
-        }
-       ],
-       "Version": "2012-10-17"
+      "Arn": {
+       "Fn::GetAtt": [
+        "awsimagebuilderdeleteresourcesdcc036c8876b451ea2c1552f9e06e9e18E1C8382",
+        "Arn"
+       ]
       },
-      "PolicyName": "ib"
-     },
-     {
-      "PolicyDocument": {
-       "Statement": [
-        {
-         "Action": [
-          "ec2:DescribeImages",
-          "ec2:DescribeImageAttribute"
-         ],
-         "Effect": "Allow",
-         "Resource": "*"
-        },
-        {
-         "Action": [
-          "ec2:DeregisterImage",
-          "ec2:DeleteSnapshot"
-         ],
-         "Condition": {
-          "StringEquals": {
-           "aws:ResourceTag/GitHubRunners:Stack": "github-runners-test",
-           "aws:ResourceTag/GitHubRunners:Builder": "github-runners-test/Windows EC2 Builder"
-          }
+      "Id": "Target0",
+      "Input": {
+       "Fn::Join": [
+        "",
+        [
+         "{\"RequestType\":\"Scheduled\",\"RecipeName\":\"github-runners-test-WindowsEC2Builder-AmiRecipe-BEDA5750\",\"LaunchTemplateId\":\"",
+         {
+          "Ref": "WindowsEC2BuilderLaunchtemplate0A66E9C2"
          },
-         "Effect": "Allow",
-         "Resource": "*"
-        }
-       ],
-       "Version": "2012-10-17"
-      },
-      "PolicyName": "ami"
+         "\"}"
+        ]
+       ]
+      }
      }
     ]
    }
   },
-  "WindowsEC2BuilderLifecyclePolicyAMIF732B3A7": {
-   "Type": "AWS::ImageBuilder::LifecyclePolicy",
+  "WindowsEC2BuilderImageCleanerScheduleAllowEventRulegithubrunnerstestawsimagebuilderdeleteresourcesdcc036c8876b451ea2c1552f9e06e9e110E16314ED4BC60B": {
+   "Type": "AWS::Lambda::Permission",
    "Properties": {
-    "Description": "Delete old GitHub Runner AMIs for github-runners-test/Windows EC2 Builder",
-    "ExecutionRole": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
      "Fn::GetAtt": [
-      "WindowsEC2BuilderLifecyclePolicyAMIRoleE85A7F2C",
+      "awsimagebuilderdeleteresourcesdcc036c8876b451ea2c1552f9e06e9e18E1C8382",
       "Arn"
      ]
     },
-    "Name": "github-runners-test-WindowsEC2Builder-5FAF8285",
-    "PolicyDetails": [
-     {
-      "Action": {
-       "IncludeResources": {
-        "Amis": true,
-        "Snapshots": true
-       },
-       "Type": "DELETE"
-      },
-      "Filter": {
-       "Type": "COUNT",
-       "Value": 2
-      }
-     }
-    ],
-    "ResourceSelection": {
-     "Recipes": [
-      {
-       "Name": "github-runners-test-WindowsEC2Builder-AmiRecipe-BEDA5750",
-       "SemanticVersion": "1.x.x"
-      }
+    "Principal": "events.amazonaws.com",
+    "SourceArn": {
+     "Fn::GetAtt": [
+      "WindowsEC2BuilderImageCleanerScheduleE8DEB84B",
+      "Arn"
      ]
-    },
-    "ResourceType": "AMI_IMAGE"
+    }
    }
   },
   "AL2builderRole6A57C48A": {
@@ -7859,6 +7666,7 @@
      "Statement": [
       {
        "Action": [
+        "imagebuilder:ListImages",
         "imagebuilder:ListImageBuildVersions",
         "imagebuilder:DeleteImage"
        ],
@@ -7866,7 +7674,10 @@
        "Resource": "*"
       },
       {
-       "Action": "ec2:DescribeImages",
+       "Action": [
+        "ec2:DescribeImages",
+        "ec2:DescribeLaunchTemplateVersions"
+       ],
        "Effect": "Allow",
        "Resource": "*"
       },
@@ -7906,9 +7717,9 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "c8204ff40a1a2de9aebe5c4383623c9db9683a11ff3ba0fcfffa6e3aa388a359.zip"
+     "S3Key": "0e132b725e8285b93452c1c291622b7619228d7ff44387df9637d07dcf4cf8e7.zip"
     },
-    "Description": "Custom resource handler that deletes resources of old versions of EC2 Image Builder images",
+    "Description": "Deletes old EC2 Image Builder runner images, and all of them when their builder is removed",
     "Environment": {
      "Variables": {
       "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1"
@@ -13289,12 +13100,12 @@
     "AMILinuxBuilderAMIPipelineEC5051DF",
     "AMILinuxBuilderAmiRecipeAMIRootDevice7FF39374",
     "AMILinuxBuilderAmiRecipe7C7ED6C7",
+    "AMILinuxBuilderImageCleanerScheduleAllowEventRulegithubrunnerstestawsimagebuilderdeleteresourcesdcc036c8876b451ea2c1552f9e06e9e110E163141CA0514B",
+    "AMILinuxBuilderImageCleanerSchedule99C1B08D",
     "AMILinuxBuilderImageCleanerF1745EF6",
     "AMILinuxBuilderInfrastructure6FCD154A",
     "AMILinuxBuilderInstanceProfile3CA638BE",
     "AMILinuxBuilderLaunchtemplateA29452C4",
-    "AMILinuxBuilderLifecyclePolicyAMIFB556CB2",
-    "AMILinuxBuilderLifecyclePolicyAMIRole7BBFF711",
     "AMILinuxBuilderRoleDefaultPolicy69ED051F",
     "AMILinuxBuilderRole0C42378A"
    ],
@@ -13617,12 +13428,12 @@
     "AMILinuxBuilderAMIPipelineEC5051DF",
     "AMILinuxBuilderAmiRecipeAMIRootDevice7FF39374",
     "AMILinuxBuilderAmiRecipe7C7ED6C7",
+    "AMILinuxBuilderImageCleanerScheduleAllowEventRulegithubrunnerstestawsimagebuilderdeleteresourcesdcc036c8876b451ea2c1552f9e06e9e110E163141CA0514B",
+    "AMILinuxBuilderImageCleanerSchedule99C1B08D",
     "AMILinuxBuilderImageCleanerF1745EF6",
     "AMILinuxBuilderInfrastructure6FCD154A",
     "AMILinuxBuilderInstanceProfile3CA638BE",
     "AMILinuxBuilderLaunchtemplateA29452C4",
-    "AMILinuxBuilderLifecyclePolicyAMIFB556CB2",
-    "AMILinuxBuilderLifecyclePolicyAMIRole7BBFF711",
     "AMILinuxBuilderRoleDefaultPolicy69ED051F",
     "AMILinuxBuilderRole0C42378A"
    ],
@@ -13779,12 +13590,12 @@
     "AMILinuxBuilderAMIPipelineEC5051DF",
     "AMILinuxBuilderAmiRecipeAMIRootDevice7FF39374",
     "AMILinuxBuilderAmiRecipe7C7ED6C7",
+    "AMILinuxBuilderImageCleanerScheduleAllowEventRulegithubrunnerstestawsimagebuilderdeleteresourcesdcc036c8876b451ea2c1552f9e06e9e110E163141CA0514B",
+    "AMILinuxBuilderImageCleanerSchedule99C1B08D",
     "AMILinuxBuilderImageCleanerF1745EF6",
     "AMILinuxBuilderInfrastructure6FCD154A",
     "AMILinuxBuilderInstanceProfile3CA638BE",
     "AMILinuxBuilderLaunchtemplateA29452C4",
-    "AMILinuxBuilderLifecyclePolicyAMIFB556CB2",
-    "AMILinuxBuilderLifecyclePolicyAMIRole7BBFF711",
     "AMILinuxBuilderRoleDefaultPolicy69ED051F",
     "AMILinuxBuilderRole0C42378A"
    ],
@@ -13940,12 +13751,12 @@
     "AMILinuxarm64BuilderAmiLog84A9D94A",
     "AMILinuxarm64BuilderAMIPipeline9CC1354C",
     "AMILinuxarm64BuilderAmiRecipe6A6ED38F",
+    "AMILinuxarm64BuilderImageCleanerScheduleAllowEventRulegithubrunnerstestawsimagebuilderdeleteresourcesdcc036c8876b451ea2c1552f9e06e9e110E16314D9F8DE87",
+    "AMILinuxarm64BuilderImageCleanerScheduleA0B2C476",
     "AMILinuxarm64BuilderImageCleanerA5DDFE7A",
     "AMILinuxarm64BuilderInfrastructure80FA16D6",
     "AMILinuxarm64BuilderInstanceProfileCE3B6B09",
     "AMILinuxarm64BuilderLaunchtemplate8F5EFF44",
-    "AMILinuxarm64BuilderLifecyclePolicyAMI44B6EABD",
-    "AMILinuxarm64BuilderLifecyclePolicyAMIRole1D81BF43",
     "AMILinuxarm64BuilderRoleDefaultPolicy113305EE",
     "AMILinuxarm64BuilderRole40D54E29"
    ],
@@ -14231,12 +14042,12 @@
     "WindowsEC2BuilderAmiLog126E54B2",
     "WindowsEC2BuilderAMIPipelineE3836949",
     "WindowsEC2BuilderAmiRecipe41A137FF",
+    "WindowsEC2BuilderImageCleanerScheduleAllowEventRulegithubrunnerstestawsimagebuilderdeleteresourcesdcc036c8876b451ea2c1552f9e06e9e110E16314ED4BC60B",
+    "WindowsEC2BuilderImageCleanerScheduleE8DEB84B",
     "WindowsEC2BuilderImageCleanerEF537850",
     "WindowsEC2BuilderInfrastructure757D4FD7",
     "WindowsEC2BuilderInstanceProfileA8DBA763",
     "WindowsEC2BuilderLaunchtemplate0A66E9C2",
-    "WindowsEC2BuilderLifecyclePolicyAMIF732B3A7",
-    "WindowsEC2BuilderLifecyclePolicyAMIRoleE85A7F2C",
     "WindowsEC2BuilderRoleDefaultPolicy8A5B4E85",
     "WindowsEC2BuilderRole1BA7D3E7"
    ],

--- a/test/default.integ.snapshot/github-runners-test.template.json
+++ b/test/default.integ.snapshot/github-runners-test.template.json
@@ -7717,7 +7717,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "4fa02673a430673898b8874377dabcfa7a2364b7fa832e8b947761e6941d26c2.zip"
+     "S3Key": "09be9786702c789b1b41fe3ac96e758cf25ce6d8412fab0de06cfc9c0146f4c3.zip"
     },
     "Description": "Deletes old EC2 Image Builder runner images, and all of them when their builder is removed",
     "Environment": {

--- a/test/image-cleaner.test.ts
+++ b/test/image-cleaner.test.ts
@@ -93,6 +93,19 @@ function setupBuilds(builds: ImageSummary[], defaultAmi?: string) {
   mockEcrSend.mockImplementation(async () => ({}));
 }
 
+/**
+ * Have every DeregisterImage fail the way a throttled one would, leaving the AMI behind.
+ */
+function failDeregisterImage() {
+  const ec2Mock = mockEc2Send.getMockImplementation()!;
+  mockEc2Send.mockImplementation(async (command: any) => {
+    if (command instanceof DeregisterImageCommand) {
+      throw Object.assign(new Error('Rate exceeded'), { name: 'RequestLimitExceeded' });
+    }
+    return ec2Mock(command);
+  });
+}
+
 function deletedAmis() {
   return mockEc2Send.mock.calls
     .map(c => c[0])
@@ -210,6 +223,7 @@ describe('Image cleaner custom resource', () => {
     await handler(customResourceEvent('Delete', CLEANER_PHYSICAL_RESOURCE_ID), context);
 
     expect(deletedAmis()).toEqual(['ami-in-use', 'ami-old']);
+    // 'latest' is never ours to delete. the repository goes away with the builder, and emptyOnDelete takes the tag with it
     expect(deletedTags()).toEqual(['1.0.2-1']);
     expect(deletedBuilds()).toHaveLength(2);
     expect(mockRespond).toHaveBeenCalledWith(expect.anything(), 'SUCCESS', 'OK', CLEANER_PHYSICAL_RESOURCE_ID, {});
@@ -231,6 +245,38 @@ describe('Image cleaner custom resource', () => {
     expect(deletedAmis()).toEqual(['ami-in-use', 'ami-old']);
     expect(deletedTags()).toEqual([]);
     expect(mockRespond).toHaveBeenCalledWith(expect.anything(), 'SUCCESS', 'OK', LEGACY_PHYSICAL_ID, {});
+  });
+
+  test('delete fails the custom resource when an AMI could not be deleted', async () => {
+    setupBuilds([build('newest', 0, { ami: 'ami-in-use' })], 'ami-in-use');
+    failDeregisterImage();
+
+    await handler(customResourceEvent('Delete', CLEANER_PHYSICAL_RESOURCE_ID), context);
+
+    // reporting success here would leave an AMI nothing will ever come back for, as the schedule goes away with the builder
+    expect(mockRespond).toHaveBeenCalledWith(expect.anything(), 'FAILED', expect.stringMatching(/Failed to delete 1 of 1/), CLEANER_PHYSICAL_RESOURCE_ID, {});
+    expect(deletedBuilds()).toEqual([]);
+  });
+
+  test('the retry CloudFormation sends after a failed delete finishes the job', async () => {
+    setupBuilds([build('newest', 0, { ami: 'ami-in-use' })], 'ami-in-use');
+    failDeregisterImage();
+
+    await handler(customResourceEvent('Delete', CLEANER_PHYSICAL_RESOURCE_ID), context);
+
+    expect(mockRespond).toHaveBeenCalledWith(expect.anything(), 'FAILED', expect.anything(), CLEANER_PHYSICAL_RESOURCE_ID, {});
+    expect(deletedBuilds()).toEqual([]);
+
+    // a few minutes later CloudFormation sends the same Delete again, and this time EC2 plays along. the build we kept is what makes the AMI
+    // findable on this second pass, so the retry has something to finish rather than a leftover nothing can reach.
+    jest.clearAllMocks();
+    setupBuilds([build('newest', 0, { ami: 'ami-in-use' })], 'ami-in-use');
+
+    await handler(customResourceEvent('Delete', CLEANER_PHYSICAL_RESOURCE_ID), context);
+
+    expect(deletedAmis()).toEqual(['ami-in-use']);
+    expect(deletedBuilds()).toHaveLength(1);
+    expect(mockRespond).toHaveBeenCalledWith(expect.anything(), 'SUCCESS', 'OK', CLEANER_PHYSICAL_RESOURCE_ID, {});
   });
 
   test('delete of a builder whose image version has no builds left deletes nothing', async () => {
@@ -407,6 +453,22 @@ describe('Image cleaner schedule', () => {
     await handler(scheduledEvent('lt-1234'), context);
 
     expect(deletedAmis()).toEqual(['ami-oldest']);
+  });
+
+  test('keeps the image build when its AMI could not be deleted, and fails so it is retried', async () => {
+    setupBuilds([
+      build('newest', 1, { ami: 'ami-newest' }),
+      build('second', 2, { ami: 'ami-second' }),
+      build('oldest', 3, { ami: 'ami-oldest' }),
+    ]);
+
+    failDeregisterImage();
+
+    // only the one build past retention was up for deletion
+    await expect(handler(scheduledEvent(), context)).rejects.toThrow(/Failed to delete 1 of 1/);
+
+    // deleting the build is what makes the AMI unreachable, and it is the only thing that can still lead us back to it
+    expect(deletedBuilds()).toEqual([]);
   });
 
   test('deletes Image Builder resources after the images they point at', async () => {

--- a/test/image-cleaner.test.ts
+++ b/test/image-cleaner.test.ts
@@ -201,7 +201,7 @@ describe('Image cleaner custom resource', () => {
     expect(mockRespond).toHaveBeenCalledWith(expect.anything(), 'SUCCESS', 'OK', LEGACY_PHYSICAL_ID, {});
   });
 
-  test('delete removes everything, including the AMI in use and the latest tag', async () => {
+  test('delete removes everything, including the AMI in use', async () => {
     setupBuilds([
       build('newest', 0, { ami: 'ami-in-use', tags: ['latest', '1.0.2-1'] }),
       build('older', 10, { ami: 'ami-old' }),
@@ -210,7 +210,7 @@ describe('Image cleaner custom resource', () => {
     await handler(customResourceEvent('Delete', CLEANER_PHYSICAL_RESOURCE_ID), context);
 
     expect(deletedAmis()).toEqual(['ami-in-use', 'ami-old']);
-    expect(deletedTags()).toEqual(['latest', '1.0.2-1']);
+    expect(deletedTags()).toEqual(['1.0.2-1']);
     expect(deletedBuilds()).toHaveLength(2);
     expect(mockRespond).toHaveBeenCalledWith(expect.anything(), 'SUCCESS', 'OK', CLEANER_PHYSICAL_RESOURCE_ID, {});
   });
@@ -229,7 +229,7 @@ describe('Image cleaner custom resource', () => {
     expect(listImages.input.filters).toEqual([{ name: 'name', values: [RECIPE] }]);
 
     expect(deletedAmis()).toEqual(['ami-in-use', 'ami-old']);
-    expect(deletedTags()).toEqual(['latest']);
+    expect(deletedTags()).toEqual([]);
     expect(mockRespond).toHaveBeenCalledWith(expect.anything(), 'SUCCESS', 'OK', LEGACY_PHYSICAL_ID, {});
   });
 

--- a/test/image-cleaner.test.ts
+++ b/test/image-cleaner.test.ts
@@ -471,6 +471,44 @@ describe('Image cleaner schedule', () => {
     expect(deletedBuilds()).toEqual([]);
   });
 
+  test('cleans up a build whose AMI someone else already deleted', async () => {
+    setupBuilds([
+      build('newest', 1, { ami: 'ami-newest' }),
+      build('second', 2, { ami: 'ami-second' }),
+      build('oldest', 3, { ami: 'ami-gone-already' }),
+    ]);
+
+    // DescribeImages raises this rather than returning nothing when it is given an image id that no longer exists
+    const ec2Mock = mockEc2Send.getMockImplementation()!;
+    mockEc2Send.mockImplementation(async (command: any) => {
+      if (command instanceof DescribeImagesCommand) {
+        throw Object.assign(new Error('does not exist'), { name: 'InvalidAMIID.NotFound' });
+      }
+      return ec2Mock(command);
+    });
+
+    // nothing is left to lose track of, so the build goes too rather than being kept and retried forever
+    await handler(scheduledEvent(), context);
+
+    expect(deletedBuilds()).toEqual([expect.stringContaining('/oldest')]);
+  });
+
+  test('cleans up a build whose Docker repository someone else already deleted', async () => {
+    setupBuilds([
+      build('newest', 1, { tags: ['1.0.4-1'] }),
+      build('second', 2, { tags: ['1.0.3-1'] }),
+      build('oldest', 3, { tags: ['1.0.2-1'] }),
+    ]);
+
+    mockEcrSend.mockImplementation(async () => {
+      throw Object.assign(new Error('repository does not exist'), { name: 'RepositoryNotFoundException' });
+    });
+
+    await handler(scheduledEvent(), context);
+
+    expect(deletedBuilds()).toEqual([expect.stringContaining('/oldest')]);
+  });
+
   test('deletes Image Builder resources after the images they point at', async () => {
     setupBuilds([
       build('newest', 1, { ami: 'ami-newest' }),

--- a/test/image-cleaner.test.ts
+++ b/test/image-cleaner.test.ts
@@ -1,0 +1,437 @@
+// Mock AWS SDK clients before importing the handler
+const mockEc2Send = jest.fn();
+const mockEcrSend = jest.fn();
+const mockIbSend = jest.fn();
+
+jest.mock('@aws-sdk/client-ec2', () => {
+  const actual = jest.requireActual('@aws-sdk/client-ec2');
+  return {
+    ...actual,
+    EC2Client: jest.fn().mockImplementation(() => ({ send: mockEc2Send })),
+  };
+});
+
+jest.mock('@aws-sdk/client-ecr', () => {
+  const actual = jest.requireActual('@aws-sdk/client-ecr');
+  return {
+    ...actual,
+    ECRClient: jest.fn().mockImplementation(() => ({ send: mockEcrSend })),
+  };
+});
+
+jest.mock('@aws-sdk/client-imagebuilder', () => {
+  const actual = jest.requireActual('@aws-sdk/client-imagebuilder');
+  return {
+    ...actual,
+    ImagebuilderClient: jest.fn().mockImplementation(() => ({ send: mockIbSend })),
+  };
+});
+
+const mockRespond = jest.fn();
+
+jest.mock('../src/lambda-helpers', () => ({
+  customResourceRespond: (...args: unknown[]) => mockRespond(...args),
+}));
+
+// Import after mocks are set up
+import {
+  DeregisterImageCommand,
+  DescribeImagesCommand,
+  DescribeLaunchTemplateVersionsCommand,
+} from '@aws-sdk/client-ec2';
+import { BatchDeleteImageCommand } from '@aws-sdk/client-ecr';
+import { DeleteImageCommand, ImageSummary, ListImageBuildVersionsCommand, ListImagesCommand } from '@aws-sdk/client-imagebuilder';
+import * as AWSLambda from 'aws-lambda';
+import { CLEANER_PHYSICAL_RESOURCE_ID, handler } from '../src/image-builders/aws-image-builder/delete-resources.lambda';
+
+const RECIPE = 'github-runners-test-Builder-AmiRecipe-1234ABCD';
+const REPO = '123456789012.dkr.ecr.us-east-1.amazonaws.com/github-runners-test-repo';
+
+function build(name: string, daysAgo: number, opts: { ami?: string; tags?: string[]; status?: string } = {}): ImageSummary {
+  return {
+    arn: `arn:aws:imagebuilder:us-east-1:123456789012:image/${RECIPE.toLowerCase()}/1.0.0/${name}`,
+    name: RECIPE,
+    dateCreated: new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000).toISOString(),
+    state: { status: opts.status ?? 'AVAILABLE' },
+    outputResources: {
+      amis: opts.ami ? [{ image: opts.ami }] : undefined,
+      containers: opts.tags ? [{ imageUris: opts.tags.map(t => `${REPO}:${t}`) }] : undefined,
+    },
+  };
+}
+
+/**
+ * Have Image Builder return all given builds under a single image version, and EC2 return every AMI as existing.
+ */
+function setupBuilds(builds: ImageSummary[], defaultAmi?: string) {
+  mockIbSend.mockImplementation(async (command: any) => {
+    if (command instanceof ListImagesCommand) {
+      return { imageVersionList: [{ arn: `arn:aws:imagebuilder:us-east-1:123456789012:image/${RECIPE.toLowerCase()}/1.0.0` }] };
+    }
+    if (command instanceof ListImageBuildVersionsCommand) {
+      return { imageSummaryList: builds };
+    }
+    if (command instanceof DeleteImageCommand) {
+      return {};
+    }
+    throw new Error(`Unexpected Image Builder command ${command.constructor.name}`);
+  });
+
+  mockEc2Send.mockImplementation(async (command: any) => {
+    if (command instanceof DescribeLaunchTemplateVersionsCommand) {
+      return { LaunchTemplateVersions: [{ LaunchTemplateData: { ImageId: defaultAmi } }] };
+    }
+    if (command instanceof DescribeImagesCommand) {
+      return { Images: [{ ImageId: command.input.ImageIds[0] }] };
+    }
+    if (command instanceof DeregisterImageCommand) {
+      return {};
+    }
+    throw new Error(`Unexpected EC2 command ${command.constructor.name}`);
+  });
+
+  mockEcrSend.mockImplementation(async () => ({}));
+}
+
+function deletedAmis() {
+  return mockEc2Send.mock.calls
+    .map(c => c[0])
+    .filter(c => c instanceof DeregisterImageCommand)
+    .map(c => c.input.ImageId);
+}
+
+function deletedTags() {
+  return mockEcrSend.mock.calls
+    .map(c => c[0])
+    .filter(c => c instanceof BatchDeleteImageCommand)
+    .map(c => c.input.imageIds[0].imageTag);
+}
+
+function deletedBuilds() {
+  return mockIbSend.mock.calls
+    .map(c => c[0])
+    .filter(c => c instanceof DeleteImageCommand)
+    .map(c => c.input.imageBuildVersionArn);
+}
+
+const context = {} as AWSLambda.Context;
+
+const LEGACY_PHYSICAL_ID = `arn:aws:imagebuilder:us-east-1:123456789012:image/${RECIPE.toLowerCase()}/1.0.3`;
+
+function customResourceEvent(requestType: 'Create' | 'Update' | 'Delete', physicalResourceId?: string) {
+  return {
+    RequestType: requestType,
+    PhysicalResourceId: physicalResourceId,
+    ResponseURL: 'https://example.com/',
+    StackId: 'arn:aws:cloudformation:us-east-1:123456789012:stack/test/1234',
+    RequestId: 'req',
+    LogicalResourceId: 'Cleaner',
+    ResourceType: 'Custom::ImageBuilder-Delete-Resources',
+    ServiceToken: 'arn:aws:lambda:us-east-1:123456789012:function:cleaner',
+    ResourceProperties: {
+      ServiceToken: 'arn:aws:lambda:us-east-1:123456789012:function:cleaner',
+      RecipeName: RECIPE,
+      LaunchTemplateId: 'lt-1234',
+    },
+  } as unknown as AWSLambda.CloudFormationCustomResourceEvent;
+}
+
+/**
+ * A cleaner deployed by an older version of this construct: the image version ARN as its physical id, and no recipe name in its properties.
+ */
+function legacyCustomResourceEvent(requestType: 'Update' | 'Delete') {
+  const event = customResourceEvent(requestType, LEGACY_PHYSICAL_ID) as any;
+  event.ResourceProperties = {
+    ServiceToken: 'arn:aws:lambda:us-east-1:123456789012:function:cleaner',
+    ImageVersionArn: LEGACY_PHYSICAL_ID,
+  };
+  return event as AWSLambda.CloudFormationCustomResourceEvent;
+}
+
+function scheduledEvent(launchTemplateId?: string) {
+  return {
+    RequestType: 'Scheduled' as const,
+    RecipeName: RECIPE,
+    LaunchTemplateId: launchTemplateId,
+  };
+}
+
+describe('Image cleaner custom resource', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('create returns a constant physical resource id so CloudFormation never replaces it', async () => {
+    await handler(customResourceEvent('Create'), context);
+
+    expect(mockRespond).toHaveBeenCalledWith(expect.anything(), 'SUCCESS', 'OK', CLEANER_PHYSICAL_RESOURCE_ID, {});
+  });
+
+  test('update keeps the physical resource id it was given and deletes nothing', async () => {
+    setupBuilds([build('old', 30, { ami: 'ami-old' })]);
+
+    await handler(customResourceEvent('Update', CLEANER_PHYSICAL_RESOURCE_ID), context);
+
+    expect(mockRespond).toHaveBeenCalledWith(expect.anything(), 'SUCCESS', 'OK', CLEANER_PHYSICAL_RESOURCE_ID, {});
+    expect(deletedAmis()).toEqual([]);
+    expect(deletedBuilds()).toEqual([]);
+  });
+
+  test('upgrading an older deployment does not change the physical resource id', async () => {
+    setupBuilds([build('old', 30, { ami: 'ami-old' })]);
+
+    // the properties are the new ones, the physical id is the image version ARN the old version handed out
+    await handler(customResourceEvent('Update', LEGACY_PHYSICAL_ID), context);
+
+    // returning anything else here would be a replacement, and a rollback would then delete every image of a builder still in use
+    expect(mockRespond).toHaveBeenCalledWith(expect.anything(), 'SUCCESS', 'OK', LEGACY_PHYSICAL_ID, {});
+    expect(deletedAmis()).toEqual([]);
+    expect(deletedBuilds()).toEqual([]);
+  });
+
+  test('delete of an upgraded resource removes everything even though its id is still the old one', async () => {
+    setupBuilds([
+      build('newest', 0, { ami: 'ami-in-use' }),
+      build('older', 10, { ami: 'ami-old' }),
+    ], 'ami-in-use');
+
+    await handler(customResourceEvent('Delete', LEGACY_PHYSICAL_ID), context);
+
+    expect(deletedAmis()).toEqual(['ami-in-use', 'ami-old']);
+    expect(mockRespond).toHaveBeenCalledWith(expect.anything(), 'SUCCESS', 'OK', LEGACY_PHYSICAL_ID, {});
+  });
+
+  test('delete removes everything, including the AMI in use and the latest tag', async () => {
+    setupBuilds([
+      build('newest', 0, { ami: 'ami-in-use', tags: ['latest', '1.0.2-1'] }),
+      build('older', 10, { ami: 'ami-old' }),
+    ], 'ami-in-use');
+
+    await handler(customResourceEvent('Delete', CLEANER_PHYSICAL_RESOURCE_ID), context);
+
+    expect(deletedAmis()).toEqual(['ami-in-use', 'ami-old']);
+    expect(deletedTags()).toEqual(['latest', '1.0.2-1']);
+    expect(deletedBuilds()).toHaveLength(2);
+    expect(mockRespond).toHaveBeenCalledWith(expect.anything(), 'SUCCESS', 'OK', CLEANER_PHYSICAL_RESOURCE_ID, {});
+  });
+
+  test('delete of a builder removed by the upgrade itself finds the recipe from the image version', async () => {
+    setupBuilds([
+      build('newest', 0, { ami: 'ami-in-use', tags: ['latest'] }),
+      build('older', 10, { ami: 'ami-old' }),
+    ], 'ami-in-use');
+
+    // new code, but CloudFormation hands us the properties of the last template that deployed successfully, which is the old one
+    await handler(legacyCustomResourceEvent('Delete'), context);
+
+    // the recipe name comes off the builds of the image version, with the casing the ListImages filter needs
+    const listImages = mockIbSend.mock.calls.map(c => c[0]).find(c => c instanceof ListImagesCommand);
+    expect(listImages.input.filters).toEqual([{ name: 'name', values: [RECIPE] }]);
+
+    expect(deletedAmis()).toEqual(['ami-in-use', 'ami-old']);
+    expect(deletedTags()).toEqual(['latest']);
+    expect(mockRespond).toHaveBeenCalledWith(expect.anything(), 'SUCCESS', 'OK', LEGACY_PHYSICAL_ID, {});
+  });
+
+  test('delete of a builder whose image version has no builds left deletes nothing', async () => {
+    setupBuilds([build('newest', 0, { ami: 'ami-in-use' })], 'ami-in-use');
+    mockIbSend.mockImplementation(async (command: any) => {
+      if (command instanceof ListImageBuildVersionsCommand) {
+        return { imageSummaryList: [] };
+      }
+      throw new Error(`Unexpected Image Builder command ${command.constructor.name}`);
+    });
+
+    await handler(legacyCustomResourceEvent('Delete'), context);
+
+    expect(deletedAmis()).toEqual([]);
+    expect(deletedBuilds()).toEqual([]);
+    expect(mockRespond).toHaveBeenCalledWith(expect.anything(), 'SUCCESS', 'OK', LEGACY_PHYSICAL_ID, {});
+  });
+
+  test('a failed update keeps the physical resource id it was given', async () => {
+    setupBuilds([build('old', 30, { ami: 'ami-old' })]);
+    mockRespond.mockRejectedValueOnce(new Error('could not reach the response URL'));
+
+    await handler(customResourceEvent('Update', CLEANER_PHYSICAL_RESOURCE_ID), context);
+
+    // a different id would be a replacement, and rolling one back deletes the new physical resource -- every image of a builder still in use
+    expect(mockRespond).toHaveBeenLastCalledWith(expect.anything(), 'FAILED', expect.anything(), CLEANER_PHYSICAL_RESOURCE_ID, {});
+  });
+
+  test('a failed create falls back to the id a successful one would have returned', async () => {
+    setupBuilds([]);
+    mockRespond.mockRejectedValueOnce(new Error('could not reach the response URL'));
+
+    // there is no physical resource id yet, and the rollback still has to delete whatever the failed create managed to build
+    await handler(customResourceEvent('Create'), context);
+
+    expect(mockRespond).toHaveBeenLastCalledWith(expect.anything(), 'FAILED', expect.anything(), CLEANER_PHYSICAL_RESOURCE_ID, {});
+  });
+
+  test('delete with neither a recipe name nor an image version deletes nothing', async () => {
+    setupBuilds([build('newest', 0, { ami: 'ami-in-use' })], 'ami-in-use');
+
+    const event = customResourceEvent('Delete', CLEANER_PHYSICAL_RESOURCE_ID) as any;
+    event.ResourceProperties = { ServiceToken: 'arn:aws:lambda:us-east-1:123456789012:function:cleaner' };
+
+    await handler(event, context);
+
+    expect(deletedAmis()).toEqual([]);
+    expect(deletedBuilds()).toEqual([]);
+  });
+});
+
+describe('Image cleaner schedule', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('keeps the AMI used by the launch template, the newest images, and unfinished builds', async () => {
+    setupBuilds([
+      build('building', 0, { status: 'BUILDING' }),
+      build('newest', 1, { ami: 'ami-newest' }),
+      build('second', 2, { ami: 'ami-second' }),
+      build('in-use', 3, { ami: 'ami-in-use' }),
+      build('oldest', 4, { ami: 'ami-oldest' }),
+    ], 'ami-in-use');
+
+    await handler(scheduledEvent('lt-1234'), context);
+
+    expect(deletedAmis()).toEqual(['ami-oldest']);
+    expect(deletedBuilds()).toEqual([expect.stringContaining('/oldest')]);
+  });
+
+  test('builds that produced no image do not take up the slots of the ones we keep to fall back on', async () => {
+    setupBuilds([
+      build('failed-today', 0, { status: 'FAILED' }),
+      build('failed-yesterday', 1, { status: 'FAILED' }),
+      build('newest', 2, { ami: 'ami-newest' }),
+      build('second', 3, { ami: 'ami-second' }),
+      build('oldest', 4, { ami: 'ami-oldest' }),
+    ]);
+
+    await handler(scheduledEvent(), context);
+
+    // both fallbacks survive two days of failures, and only the third image goes
+    expect(deletedAmis()).toEqual(['ami-oldest']);
+    expect(deletedBuilds()).toEqual([
+      expect.stringContaining('/failed-today'),
+      expect.stringContaining('/failed-yesterday'),
+      expect.stringContaining('/oldest'),
+    ]);
+  });
+
+  test('builds that produced no image are deleted however new they are', async () => {
+    setupBuilds([
+      build('newest', 0, { ami: 'ami-newest' }),
+      build('second', 1, { ami: 'ami-second' }),
+      build('failed', 2, { status: 'FAILED' }),
+      build('cancelled', 3, { status: 'CANCELLED' }),
+      build('deprecated', 4, { ami: 'ami-deprecated', status: 'DEPRECATED' }),
+    ]);
+
+    await handler(scheduledEvent(), context);
+
+    // there is nothing to fall back on in any of them, and the logs and the failure notification are not ours to keep
+    expect(deletedAmis()).toEqual(['ami-deprecated']);
+    expect(deletedBuilds()).toEqual([
+      expect.stringContaining('/failed'),
+      expect.stringContaining('/cancelled'),
+      expect.stringContaining('/deprecated'),
+    ]);
+  });
+
+  test('keeps a deprecated build whose AMI is the one in use', async () => {
+    setupBuilds([
+      build('newest', 0, { ami: 'ami-newest' }),
+      build('second', 1, { ami: 'ami-second' }),
+      build('deprecated-in-use', 2, { ami: 'ami-in-use', status: 'DEPRECATED' }),
+    ], 'ami-in-use');
+
+    await handler(scheduledEvent('lt-1234'), context);
+
+    // deprecating an image does not take it out of the launch template, and runners are still starting from it
+    expect(deletedAmis()).toEqual([]);
+    expect(deletedBuilds()).toEqual([]);
+  });
+
+  test('keeps the latest Docker tag but deletes the versioned tags of old images', async () => {
+    setupBuilds([
+      build('newest', 1, { tags: ['latest', '1.0.4-1'] }),
+      build('second', 2, { tags: ['1.0.3-1'] }),
+      build('third', 3, { tags: ['latest', '1.0.2-1'] }),
+    ]);
+
+    await handler(scheduledEvent(), context);
+
+    expect(deletedTags()).toEqual(['1.0.2-1']);
+    expect(deletedBuilds()).toEqual([expect.stringContaining('/third')]);
+  });
+
+  test('deletes nothing when the launch template cannot be read', async () => {
+    setupBuilds([
+      build('newest', 1, { ami: 'ami-newest' }),
+      build('second', 2, { ami: 'ami-second' }),
+      build('oldest', 3, { ami: 'ami-oldest' }),
+    ], 'ami-newest');
+
+    mockEc2Send.mockImplementation(async (command: any) => {
+      if (command instanceof DescribeLaunchTemplateVersionsCommand) {
+        throw Object.assign(new Error('Rate exceeded'), { name: 'RequestLimitExceeded' });
+      }
+      throw new Error(`Unexpected EC2 command ${command.constructor.name}`);
+    });
+
+    await handler(scheduledEvent('lt-1234'), context);
+
+    expect(deletedAmis()).toEqual([]);
+    expect(deletedBuilds()).toEqual([]);
+  });
+
+  test('cleans up when the launch template is gone for good', async () => {
+    setupBuilds([
+      build('newest', 1, { ami: 'ami-newest' }),
+      build('second', 2, { ami: 'ami-second' }),
+      build('oldest', 3, { ami: 'ami-oldest' }),
+    ]);
+
+    const describeImages = mockEc2Send.getMockImplementation()!;
+    mockEc2Send.mockImplementation(async (command: any) => {
+      if (command instanceof DescribeLaunchTemplateVersionsCommand) {
+        throw Object.assign(new Error('gone'), { name: 'InvalidLaunchTemplateId.NotFound' });
+      }
+      return describeImages(command);
+    });
+
+    await handler(scheduledEvent('lt-1234'), context);
+
+    expect(deletedAmis()).toEqual(['ami-oldest']);
+  });
+
+  test('deletes Image Builder resources after the images they point at', async () => {
+    setupBuilds([
+      build('newest', 1, { ami: 'ami-newest' }),
+      build('second', 2, { ami: 'ami-second' }),
+      build('oldest', 3, { ami: 'ami-oldest' }),
+    ]);
+
+    await handler(scheduledEvent(), context);
+
+    expect(deletedBuilds()).toEqual([expect.stringContaining('/oldest')]);
+    expect(deletedAmis()).toEqual(['ami-oldest']);
+  });
+
+  test('lists deprecated image versions too', async () => {
+    setupBuilds([build('newest', 1, { ami: 'ami-newest' })]);
+
+    await handler(scheduledEvent(), context);
+
+    const listImages = mockIbSend.mock.calls.map(c => c[0]).find(c => c instanceof ListImagesCommand);
+    expect(listImages.input).toMatchObject({
+      owner: 'Self',
+      includeDeprecated: true,
+      filters: [{ name: 'name', values: [RECIPE] }],
+    });
+  });
+});

--- a/test/imagebuilder.test.ts
+++ b/test/imagebuilder.test.ts
@@ -3,7 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as cdk from 'aws-cdk-lib';
 import { aws_ec2 as ec2, aws_ecr as ecr, aws_ssm as ssm } from 'aws-cdk-lib';
-import { Match, Template } from 'aws-cdk-lib/assertions';
+import { Annotations, Match, Template } from 'aws-cdk-lib/assertions';
 import { CloudAssembly } from 'aws-cdk-lib/cx-api';
 import {
   AmiBuilder,
@@ -892,5 +892,146 @@ describe('CodeBuildRunnerImageBuilder ECR permissions', () => {
     // The actual verification happens in the permission tests above
     // This test ensures the code path is exercised
     expect(baseImageRepo).toBeDefined();
+  });
+});
+
+describe('Image cleanup', () => {
+  let app: cdk.App;
+  let stack: cdk.Stack;
+
+  beforeEach(() => {
+    app = new cdk.App();
+    stack = new cdk.Stack(app, 'test');
+  });
+
+  afterAll(CloudAssembly.cleanupTemporaryDirectories);
+
+  test('AMI builder schedules cleanup and protects the launch template AMI', () => {
+    const vpc = new ec2.Vpc(stack, 'vpc');
+
+    Ec2RunnerProvider.imageBuilder(stack, 'builder', { vpc }).bindAmi();
+
+    const template = Template.fromStack(stack);
+
+    // lifecycle policies can't tell which image is in use, so they are gone
+    template.resourceCountIs('AWS::ImageBuilder::LifecyclePolicy', 0);
+
+    // the custom resource only ever deletes on removal of the builder, so it must know the recipe.
+    // ImageVersionArn is what 0.16.0 and below wrote and read, and it is kept so their code stays harmless if it ever runs against these properties
+    template.hasResourceProperties('Custom::ImageBuilder-Delete-Resources', Match.objectLike({
+      RecipeName: Match.anyValue(),
+      LaunchTemplateId: Match.anyValue(),
+      ImageVersionArn: Match.anyValue(),
+    }));
+
+    // and the same lambda cleans up old images daily, telling it which launch template AMI to keep
+    template.hasResourceProperties('AWS::Events::Rule', Match.objectLike({
+      ScheduleExpression: 'rate(1 day)',
+      Targets: Match.arrayWith([
+        Match.objectLike({
+          Input: {
+            'Fn::Join': [
+              '',
+              Match.arrayWith([
+                Match.stringLikeRegexp('"RequestType":"Scheduled".*"LaunchTemplateId":"'),
+                { Ref: Match.stringLikeRegexp('builderLaunchtemplate') },
+              ]),
+            ],
+          },
+        }),
+      ]),
+    }));
+  });
+
+  test('ECR repository expires untagged images the cleaner can no longer see', () => {
+    const vpc = new ec2.Vpc(stack, 'vpc');
+
+    RunnerImageBuilder.new(stack, 'builder', {
+      vpc,
+      builderType: RunnerImageBuilderType.AWS_IMAGE_BUILDER,
+    }).bindDockerImage();
+
+    const template = Template.fromStack(stack);
+
+    // only untagged images, so latest and the version tags are never at risk
+    template.hasResourceProperties('AWS::ECR::Repository', Match.objectLike({
+      LifecyclePolicy: {
+        LifecyclePolicyText: Match.serializedJson(Match.objectLike({
+          rules: [
+            Match.objectLike({
+              selection: Match.objectLike({
+                tagStatus: 'untagged',
+                countType: 'sinceImagePushed',
+                countUnit: 'days',
+                countNumber: 1,
+              }),
+              action: { type: 'expire' },
+            }),
+          ],
+        })),
+      },
+    }));
+  });
+
+  test('Docker image builder schedules cleanup without a launch template', () => {
+    const vpc = new ec2.Vpc(stack, 'vpc');
+
+    RunnerImageBuilder.new(stack, 'builder', {
+      vpc,
+      builderType: RunnerImageBuilderType.AWS_IMAGE_BUILDER,
+    }).bindDockerImage();
+
+    const template = Template.fromStack(stack);
+
+    template.resourceCountIs('AWS::ImageBuilder::LifecyclePolicy', 0);
+
+    template.hasResourceProperties('AWS::Events::Rule', Match.objectLike({
+      ScheduleExpression: 'rate(1 day)',
+      Targets: Match.arrayWith([
+        Match.objectLike({
+          Input: Match.serializedJson(Match.objectLike({
+            RequestType: 'Scheduled',
+            RecipeName: Match.anyValue(),
+          })),
+        }),
+      ]),
+    }));
+  });
+
+  test('cleaner can read launch templates and list all image versions', () => {
+    const vpc = new ec2.Vpc(stack, 'vpc');
+
+    Ec2RunnerProvider.imageBuilder(stack, 'builder', { vpc }).bindAmi();
+
+    const template = Template.fromStack(stack);
+
+    template.hasResourceProperties('AWS::IAM::Policy', Match.objectLike({
+      PolicyDocument: Match.objectLike({
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Action: Match.arrayWith(['imagebuilder:ListImages']),
+          }),
+          Match.objectLike({
+            Action: Match.arrayWith(['ec2:DescribeLaunchTemplateVersions']),
+          }),
+        ]),
+      }),
+    }));
+  });
+
+  test('overriding the stack AMI tag warns about cleanup', () => {
+    const vpc = new ec2.Vpc(stack, 'vpc');
+
+    const builder = Ec2RunnerProvider.imageBuilder(stack, 'builder', {
+      vpc,
+      awsImageBuilderOptions: {
+        amiTags: {
+          'GitHubRunners:Stack': 'overridden',
+        },
+      },
+    });
+    builder.bindAmi();
+
+    Annotations.fromStack(stack).hasWarning('/test/builder', Match.stringLikeRegexp('can prevent old AMIs from being deleted'));
   });
 });


### PR DESCRIPTION
A stack update that fails *after* EC2 Image Builder finished building a new runner image leaves the runner provider broken. No runner can start until the next scheduled build, which is up to seven days away with default settings (`rebuildInterval`). Applying the stack update again successfully can also resolve the issue.

```
{
  "resourceType": "aws-sdk:ec2",
  "resource": "runInstances.waitForTaskToken",
  "error": "Ec2.Ec2Exception",
  "cause": "The image id '[ami-080b30a8007b83806]' does not exist (Service: Ec2, Status Code: 400, Request ID: a60bccde-20ee-4ad0-b003-a574f769f42c) (SDK Attempt Count: 1)"
}
```

Our `DeleteResourcesFunction` custom resource used the recipe version as its physical resource id, so a successful update replaced it and CloudFormation deleted the old version's resources. On an update rollback the same mechanism works in reverse: CloudFormation deletes the *new* physical resource, so the cleaner deregisters the AMI that was just built. EC2 Image Builder had already pointed the launch template's `$Default` version at it, and CloudFormation cannot roll that back because it never made the change. The launch template is left pointing at a deregistered AMI.

Docker images were spared only because the `latest` tag is skipped and still resolves.

## Why the lifecycle policies didn't cover it

The `CfnLifecyclePolicy` resources were supposed to collect what the custom resource missed, but they cannot express "don't delete what's in use", and they cannot even be relied on to collect old images. Retention is calculated independently per recipe version: `1.x.x` with a count of two keeps the two newest of `1.0.0`, two of `1.0.1`, and so on. Recipe versions change with every component change, so an image left behind by an interrupted deployment is usually the only one of its version and is retained forever. Tag based resource selection is per recipe version too. An `AGE` filter could span versions, but it is unsafe for anyone who disabled `rebuildInterval`, as nothing would replace the image that aged out.

## What replaces them

One Lambda with two entry points, and no lifecycle policies.

On a schedule, an EventBridge rule per builder has it delete old images for that builder. It keeps the newest two, anything that has not finished building, the AMI the launch template's `$Default` version points at, and the Docker image tagged `latest`. The launch template is the only reliable answer to which AMI is in use, since EC2 Image Builder sets it outside of CloudFormation and `RunInstances` reads that same version. If the launch template cannot be read, nothing is deleted at all: not knowing which AMI is in use is not the same as knowing no AMI is in use. Only `InvalidLaunchTemplateId.NotFound` and `.Malformed` count as genuinely gone.

Unfinished builds are never touched. Distribution is one of the build steps, so an image that has not finished may still be on its way to the launch template.

Every version of the recipe is listed, not just the current one. That is what collects the leftovers the lifecycle policies could never reach. The Image Builder image resources go too, which is why `createImage()` keeps `RETAIN_ON_UPDATE_OR_DELETE`.

On removal of the builder, or deletion of the stack, a custom resource has the same Lambda delete everything it finds, including the AMI of the launch template. Nothing it built is in use any more.

## The physical resource id

The custom resource echoes back whatever physical resource id it was given, so the id never changes. CloudFormation therefore never sees a replacement, and the only thing that can produce a `Delete` is the builder leaving the template or the stack being deleted. Updates, and rollbacks of updates, leave it alone entirely. Everything above depends on that: it is what makes deleting everything on `Delete` safe.

Returning a constant of our own instead would have been enough in steady state, but not on the one deployment that upgrades. The id would change once, from the image version ARN to that constant, and a failed upgrade would then have CloudFormation delete the new physical resource and take every image of a builder still in use with it. Even without a failure, the clean-up phase would delete the old version of the resource since we supplied a new physical id. That will take out all images with it.

## Upgrading

Nothing is deleted by the upgrade itself. Stacks deployed by older versions keep their image version ARN as the physical resource id, forever, and that is fine. What tells a real removal from a leftover of the old behavior is the properties: a recipe name only appears in templates written by this version, and CloudFormation hands a `Delete` the properties of the last template that deployed successfully.

The one case that needs help is a builder removed by the very deployment that upgrades. Its properties are still the old ones, so there is no recipe name, so nothing would ever come back for its images. The recipe is looked up from the image version ARN in that case, by reading the name off one of its builds. An image is named after the recipe that built it, and unlike the name inside the ARN that one keeps the casing the `ListImages` filter needs.

`ImageVersionArn` is still written to the custom resource, unchanged from what 0.16.0 emitted. It is the only property older versions read, and leaving it out would mean their code calls `ListImageBuildVersions` with no image version, which lists every image build version in the account (not just for the one specific recipe). This is important for rollbacks of initial upgrades or future downgrades.

## Downgrading

Downgrading below this version deletes the AMIs of an AWS Image Builder based builder, and is documented as a known issue. Older versions clean up by deleting the images of the recipe version they replace, and on the way down that is the version still in use. Roll forward rather than back where you can.

## Docker images

The repository EC2 Image Builder pushes to never had a lifecycle rule. The rules were dropped when the job moved to an Image Builder lifecycle policy. The cleaner finds Docker images through the output resources of an Image Builder image, so an image that lost its tags is invisible to it. A new lifecycle rule now expires untagged images after a day. It is scoped to untagged images alone, so `latest` and the version tags are never at risk.

## Testing

`test/default.integ.ts` has a `testDeploymentFailureAfterImageBuilt` flag that fails a deployment after every image is built.

Other tests I ran and could be useful in the future (upgrading means to a version with this fix):

* Upgrading and changing every recipe in one deployment. Nothing deleted, physical resource ids unchanged, no launch template left pointing at a deregistered AMI.
* Removing a builder from a stack. Only that builder's AMIs and build versions deleted.
* Removing a builder by the same deployment that upgrades. Recipe resolved from the image version ARN, images deleted.
* The schedule. Deleted across recipe versions, kept the newest two by date and the AMI in use.
* `waitOnDeploy: false`. The build already in use and the build in progress were both left alone.

Replaces #991